### PR TITLE
Ria 469 add nightly zap testing with ignore

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -53,6 +53,6 @@ withNightlyPipeline(type, product, component) {
   loadVaultSecrets(secrets)
 
   enableSecurityScan()
-//  enableMutationTest()
-//  enableSlackNotifications('#ia-tech')
+  enableMutationTest()
+  enableSlackNotifications('#ia-tech')
 }

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -2,7 +2,10 @@
 
 properties([
   // H allow predefined but random minute see https://en.wikipedia.org/wiki/Cron#Non-standard_characters
-  pipelineTriggers([cron('H 22 * * *')])
+  pipelineTriggers([cron('H 22 * * *')]),
+  parameters([
+          string(name: 'URL_TO_TEST', defaultValue: 'https://ia-case-documents-api-aat.service.core-compute-aat.internal', description: 'The URL you want to run these tests against'),
+  ])
 ])
 
 @Library("Infrastructure")
@@ -44,10 +47,12 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 }
 
 withNightlyPipeline(type, product, component) {
+  env.TEST_URL = params.URL_TO_TEST
 
   setVaultName('ia')
   loadVaultSecrets(secrets)
 
-  enableMutationTest()
-  enableSlackNotifications('#ia-tech')
+  enableSecurityScan()
+//  enableMutationTest()
+//  enableSlackNotifications('#ia-tech')
 }

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -4,7 +4,7 @@ properties([
   // H allow predefined but random minute see https://en.wikipedia.org/wiki/Cron#Non-standard_characters
   pipelineTriggers([cron('H 22 * * *')]),
   parameters([
-          string(name: 'URL_TO_TEST', defaultValue: 'https://ia-case-documents-api-aat.service.core-compute-aat.internal', description: 'The URL you want to run these tests against'),
+          string(name: 'URL_TO_TEST', defaultValue: 'https://ia-case-notifications-api-aat.service.core-compute-aat.internal', description: 'The URL you want to run these tests against'),
   ])
 ])
 

--- a/security.sh
+++ b/security.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+echo ${TEST_URL}
+zap-api-scan.py -t ${TEST_URL}/v2/api-docs -f openapi -P 1001
+cat zap.out
+zap-cli --zap-url http://0.0.0.0 -p 1001 report -o /zap/api-report.xml -f xml
+zap-cli --zap-url http://0.0.0.0 -p 1001 report -o /zap/api-report.html -f html
+echo "listings of zap folder"
+cat /zap/api-report.xml
+ls -la /zap
+cp /zap/api-report.html functional-output/
+cp /zap/api-report.xml functional-output/
+
+if [ -f zap-known-issues.xml ]; then
+  if diff -q zap-known-issues.xml functional-output/api-report.xml --ignore-all-space --ignore-matching-lines=OWASPZAPReport > /dev/null 2>&1; then
+    echo
+    echo Ignorning known vulnerabilities
+    exit 0
+  fi
+fi
+echo
+echo ZAP Security vulnerabilities were found that were not ignored
+echo
+echo Check to see if these vulnerabilities apply to production
+echo and/or if they have fixes available. If they do not have
+echo fixes and they do not apply to production, you may ignore them
+echo
+echo To ignore these vulnerabilities, add them to:
+echo
+echo "./zap-known-issues.xml"
+echo
+echo and commit the change
+
+zap-cli -p 1001 alerts -l Informational

--- a/zap-known-issues.xml
+++ b/zap-known-issues.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0"?><OWASPZAPReport version="D-2019-03-11" generated="Thu, 14 Mar 2019 16:30:34">
+<site name="https://ia-case-documents-api-aat.service.core-compute-aat.internal" host="ia-case-documents-api-aat.service.core-compute-aat.internal" port="443" ssl="true"><alerts><alertitem>
+  <pluginid>10021</pluginid>
+  <alert>X-Content-Type-Options Header Missing</alert>
+  <name>X-Content-Type-Options Header Missing</name>
+  <riskcode>1</riskcode>
+  <confidence>2</confidence>
+  <riskdesc>Low (Medium)</riskdesc>
+  <desc>&lt;p&gt;The Anti-MIME-Sniffing header X-Content-Type-Options was not set to &apos;nosniff&apos;. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.&lt;/p&gt;</desc>
+  <instances>
+  <instance>
+  <uri>https://ia-case-documents-api-aat.service.core-compute-aat.internal/v2/api-docs</uri>
+  <method>GET</method>
+  <param>X-Content-Type-Options</param>
+  </instance>
+  <instance>
+  <uri>https://ia-case-documents-api-aat.service.core-compute-aat.internal/</uri>
+  <method>GET</method>
+  <param>X-Content-Type-Options</param>
+  </instance>
+  </instances>
+  <count>2</count>
+  <solution>&lt;p&gt;Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to &apos;nosniff&apos; for all web pages.&lt;/p&gt;&lt;p&gt;If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.&lt;/p&gt;</solution>
+  <otherinfo>&lt;p&gt;This issue still applies to error type pages (401, 403, 500, etc) as those pages are often still affected by injection issues, in which case there is still concern for browsers sniffing pages away from their actual content type.&lt;/p&gt;&lt;p&gt;At &quot;High&quot; threshold this scanner will not alert on client or server error responses.&lt;/p&gt;</otherinfo>
+  <reference>&lt;p&gt;http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx&lt;/p&gt;&lt;p&gt;https://www.owasp.org/index.php/List_of_useful_HTTP_headers&lt;/p&gt;</reference>
+  <cweid>16</cweid>
+  <wascid>15</wascid>
+  <sourceid>3</sourceid>
+</alertitem>
+<alertitem>
+  <pluginid>100000</pluginid>
+  <alert>A Client Error response code was returned by the server</alert>
+  <name>A Client Error response code was returned by the server</name>
+  <riskcode>0</riskcode>
+  <confidence>3</confidence>
+  <riskdesc>Informational (High)</riskdesc>
+  <desc>&lt;p&gt;A response code of 403 was returned by the server.&lt;/p&gt;&lt;p&gt;This may indicate that the application is failing to handle unexpected input correctly.&lt;/p&gt;&lt;p&gt;Raised by the &apos;Alert on HTTP Response Code Error&apos; script&lt;/p&gt;</desc>
+  <instances>
+  <instance>
+  <uri>https://ia-case-documents-api-aat.service.core-compute-aat.internal/asylum/ccdAboutToStart</uri>
+  <method>POST</method>
+  <evidence>HTTP/1.1 403</evidence>
+  </instance>
+  <instance>
+  <uri>https://ia-case-documents-api-aat.service.core-compute-aat.internal/asylum/ccdAboutToSubmit</uri>
+  <method>POST</method>
+  <evidence>HTTP/1.1 403</evidence>
+  </instance>
+  </instances>
+  <count>2</count>
+  <solution>&lt;p&gt;&lt;/p&gt;</solution>
+  <reference>&lt;p&gt;&lt;/p&gt;</reference>
+  <cweid>388</cweid>
+  <wascid>20</wascid>
+  <sourceid>4</sourceid>
+</alertitem>
+<alertitem>
+  <pluginid>10023</pluginid>
+  <alert>Information Disclosure - Debug Error Messages</alert>
+  <name>Information Disclosure - Debug Error Messages</name>
+  <riskcode>1</riskcode>
+  <confidence>2</confidence>
+  <riskdesc>Low (Medium)</riskdesc>
+  <desc>&lt;p&gt;The response appeared to contain common error messages returned by platforms such as ASP.NET, and Web-servers such as IIS and Apache. You can configure the list of common debug messages.&lt;/p&gt;</desc>
+  <instances>
+  <instance>
+  <uri>https://ia-case-documents-api-aat.service.core-compute-aat.internal/v2/api-docs</uri>
+  <method>GET</method>
+  <evidence>Internal Server Error</evidence>
+  </instance>
+  </instances>
+  <count>1</count>
+  <solution>&lt;p&gt;Disable debugging messages before pushing to production.&lt;/p&gt;</solution>
+  <reference>&lt;p&gt;&lt;/p&gt;</reference>
+  <cweid>200</cweid>
+  <wascid>13</wascid>
+  <sourceid>3</sourceid>
+</alertitem>
+<alertitem>
+  <pluginid>10015</pluginid>
+  <alert>Incomplete or No Cache-control and Pragma HTTP Header Set</alert>
+  <name>Incomplete or No Cache-control and Pragma HTTP Header Set</name>
+  <riskcode>1</riskcode>
+  <confidence>2</confidence>
+  <riskdesc>Low (Medium)</riskdesc>
+  <desc>&lt;p&gt;The cache-control and pragma HTTP header have not been set properly or are missing allowing the browser and proxies to cache content.&lt;/p&gt;</desc>
+  <instances>
+  <instance>
+  <uri>https://ia-case-documents-api-aat.service.core-compute-aat.internal/v2/api-docs</uri>
+  <method>GET</method>
+  <param>Cache-Control</param>
+  </instance>
+  <instance>
+  <uri>https://ia-case-documents-api-aat.service.core-compute-aat.internal/</uri>
+  <method>GET</method>
+  <param>Cache-Control</param>
+  <evidence>no-cache</evidence>
+  </instance>
+  </instances>
+  <count>2</count>
+  <solution>&lt;p&gt;Whenever possible ensure the cache-control HTTP header is set with no-cache, no-store, must-revalidate; and that the pragma HTTP header is set with no-cache.&lt;/p&gt;</solution>
+  <reference>&lt;p&gt;https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Web_Content_Caching&lt;/p&gt;</reference>
+  <cweid>525</cweid>
+  <wascid>13</wascid>
+  <sourceid>3</sourceid>
+</alertitem>
+<alertitem>
+  <pluginid>90022</pluginid>
+  <alert>Application Error Disclosure</alert>
+  <name>Application Error Disclosure</name>
+  <riskcode>2</riskcode>
+  <confidence>2</confidence>
+  <riskdesc>Medium (Medium)</riskdesc>
+  <desc>&lt;p&gt;This page contains an error/warning message that may disclose sensitive information like the location of the file that produced the unhandled exception. This information can be used to launch further attacks against the web application. The alert could be a false positive if the error message is found inside a documentation page.&lt;/p&gt;</desc>
+  <instances>
+  <instance>
+  <uri>https://ia-case-documents-api-aat.service.core-compute-aat.internal/v2/api-docs</uri>
+  <method>GET</method>
+  <evidence>Internal Server Error</evidence>
+  </instance>
+  </instances>
+  <count>1</count>
+  <solution>&lt;p&gt;Review the source code of this page. Implement custom error pages. Consider implementing a mechanism to provide a unique error reference/identifier to the client (browser) while logging the details on the server side and not exposing them to the user.&lt;/p&gt;</solution>
+  <reference>&lt;p&gt;&lt;/p&gt;</reference>
+  <cweid>200</cweid>
+  <wascid>13</wascid>
+  <sourceid>3</sourceid>
+</alertitem>
+</alerts></site></OWASPZAPReport>

--- a/zap-known-issues.xml
+++ b/zap-known-issues.xml
@@ -1,33 +1,5 @@
-<?xml version="1.0"?><OWASPZAPReport version="D-2019-03-11" generated="Thu, 14 Mar 2019 16:30:34">
-<site name="https://ia-case-documents-api-aat.service.core-compute-aat.internal" host="ia-case-documents-api-aat.service.core-compute-aat.internal" port="443" ssl="true"><alerts><alertitem>
-  <pluginid>10021</pluginid>
-  <alert>X-Content-Type-Options Header Missing</alert>
-  <name>X-Content-Type-Options Header Missing</name>
-  <riskcode>1</riskcode>
-  <confidence>2</confidence>
-  <riskdesc>Low (Medium)</riskdesc>
-  <desc>&lt;p&gt;The Anti-MIME-Sniffing header X-Content-Type-Options was not set to &apos;nosniff&apos;. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.&lt;/p&gt;</desc>
-  <instances>
-  <instance>
-  <uri>https://ia-case-documents-api-aat.service.core-compute-aat.internal/v2/api-docs</uri>
-  <method>GET</method>
-  <param>X-Content-Type-Options</param>
-  </instance>
-  <instance>
-  <uri>https://ia-case-documents-api-aat.service.core-compute-aat.internal/</uri>
-  <method>GET</method>
-  <param>X-Content-Type-Options</param>
-  </instance>
-  </instances>
-  <count>2</count>
-  <solution>&lt;p&gt;Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to &apos;nosniff&apos; for all web pages.&lt;/p&gt;&lt;p&gt;If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.&lt;/p&gt;</solution>
-  <otherinfo>&lt;p&gt;This issue still applies to error type pages (401, 403, 500, etc) as those pages are often still affected by injection issues, in which case there is still concern for browsers sniffing pages away from their actual content type.&lt;/p&gt;&lt;p&gt;At &quot;High&quot; threshold this scanner will not alert on client or server error responses.&lt;/p&gt;</otherinfo>
-  <reference>&lt;p&gt;http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx&lt;/p&gt;&lt;p&gt;https://www.owasp.org/index.php/List_of_useful_HTTP_headers&lt;/p&gt;</reference>
-  <cweid>16</cweid>
-  <wascid>15</wascid>
-  <sourceid>3</sourceid>
-</alertitem>
-<alertitem>
+<?xml version="1.0"?><OWASPZAPReport version="D-2019-03-11" generated="Fri, 15 Mar 2019 10:45:58">
+<site name="https://ia-case-notifications-api-aat.service.core-compute-aat.internal" host="ia-case-notifications-api-aat.service.core-compute-aat.internal" port="443" ssl="true"><alerts><alertitem>
   <pluginid>100000</pluginid>
   <alert>A Client Error response code was returned by the server</alert>
   <name>A Client Error response code was returned by the server</name>
@@ -37,93 +9,16 @@
   <desc>&lt;p&gt;A response code of 403 was returned by the server.&lt;/p&gt;&lt;p&gt;This may indicate that the application is failing to handle unexpected input correctly.&lt;/p&gt;&lt;p&gt;Raised by the &apos;Alert on HTTP Response Code Error&apos; script&lt;/p&gt;</desc>
   <instances>
   <instance>
-  <uri>https://ia-case-documents-api-aat.service.core-compute-aat.internal/asylum/ccdAboutToStart</uri>
-  <method>POST</method>
-  <evidence>HTTP/1.1 403</evidence>
-  </instance>
-  <instance>
-  <uri>https://ia-case-documents-api-aat.service.core-compute-aat.internal/asylum/ccdAboutToSubmit</uri>
-  <method>POST</method>
+  <uri>https://ia-case-notifications-api-aat.service.core-compute-aat.internal/v2/api-docs</uri>
+  <method>GET</method>
   <evidence>HTTP/1.1 403</evidence>
   </instance>
   </instances>
-  <count>2</count>
+  <count>1</count>
   <solution>&lt;p&gt;&lt;/p&gt;</solution>
   <reference>&lt;p&gt;&lt;/p&gt;</reference>
   <cweid>388</cweid>
   <wascid>20</wascid>
   <sourceid>4</sourceid>
-</alertitem>
-<alertitem>
-  <pluginid>10023</pluginid>
-  <alert>Information Disclosure - Debug Error Messages</alert>
-  <name>Information Disclosure - Debug Error Messages</name>
-  <riskcode>1</riskcode>
-  <confidence>2</confidence>
-  <riskdesc>Low (Medium)</riskdesc>
-  <desc>&lt;p&gt;The response appeared to contain common error messages returned by platforms such as ASP.NET, and Web-servers such as IIS and Apache. You can configure the list of common debug messages.&lt;/p&gt;</desc>
-  <instances>
-  <instance>
-  <uri>https://ia-case-documents-api-aat.service.core-compute-aat.internal/v2/api-docs</uri>
-  <method>GET</method>
-  <evidence>Internal Server Error</evidence>
-  </instance>
-  </instances>
-  <count>1</count>
-  <solution>&lt;p&gt;Disable debugging messages before pushing to production.&lt;/p&gt;</solution>
-  <reference>&lt;p&gt;&lt;/p&gt;</reference>
-  <cweid>200</cweid>
-  <wascid>13</wascid>
-  <sourceid>3</sourceid>
-</alertitem>
-<alertitem>
-  <pluginid>10015</pluginid>
-  <alert>Incomplete or No Cache-control and Pragma HTTP Header Set</alert>
-  <name>Incomplete or No Cache-control and Pragma HTTP Header Set</name>
-  <riskcode>1</riskcode>
-  <confidence>2</confidence>
-  <riskdesc>Low (Medium)</riskdesc>
-  <desc>&lt;p&gt;The cache-control and pragma HTTP header have not been set properly or are missing allowing the browser and proxies to cache content.&lt;/p&gt;</desc>
-  <instances>
-  <instance>
-  <uri>https://ia-case-documents-api-aat.service.core-compute-aat.internal/v2/api-docs</uri>
-  <method>GET</method>
-  <param>Cache-Control</param>
-  </instance>
-  <instance>
-  <uri>https://ia-case-documents-api-aat.service.core-compute-aat.internal/</uri>
-  <method>GET</method>
-  <param>Cache-Control</param>
-  <evidence>no-cache</evidence>
-  </instance>
-  </instances>
-  <count>2</count>
-  <solution>&lt;p&gt;Whenever possible ensure the cache-control HTTP header is set with no-cache, no-store, must-revalidate; and that the pragma HTTP header is set with no-cache.&lt;/p&gt;</solution>
-  <reference>&lt;p&gt;https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Web_Content_Caching&lt;/p&gt;</reference>
-  <cweid>525</cweid>
-  <wascid>13</wascid>
-  <sourceid>3</sourceid>
-</alertitem>
-<alertitem>
-  <pluginid>90022</pluginid>
-  <alert>Application Error Disclosure</alert>
-  <name>Application Error Disclosure</name>
-  <riskcode>2</riskcode>
-  <confidence>2</confidence>
-  <riskdesc>Medium (Medium)</riskdesc>
-  <desc>&lt;p&gt;This page contains an error/warning message that may disclose sensitive information like the location of the file that produced the unhandled exception. This information can be used to launch further attacks against the web application. The alert could be a false positive if the error message is found inside a documentation page.&lt;/p&gt;</desc>
-  <instances>
-  <instance>
-  <uri>https://ia-case-documents-api-aat.service.core-compute-aat.internal/v2/api-docs</uri>
-  <method>GET</method>
-  <evidence>Internal Server Error</evidence>
-  </instance>
-  </instances>
-  <count>1</count>
-  <solution>&lt;p&gt;Review the source code of this page. Implement custom error pages. Consider implementing a mechanism to provide a unique error reference/identifier to the client (browser) while logging the details on the server side and not exposing them to the user.&lt;/p&gt;</solution>
-  <reference>&lt;p&gt;&lt;/p&gt;</reference>
-  <cweid>200</cweid>
-  <wascid>13</wascid>
-  <sourceid>3</sourceid>
 </alertitem>
 </alerts></site></OWASPZAPReport>


### PR DESCRIPTION
### WHAT?

This change adds a `security.sh` file to make use of the `Jenkins_nightly` pipeline **enableSecurityScan()** call. This means that each night the Zap security scanner will security test this service's APIs and produce a report that will be published in Jenkins.

It includes a way to ignore known issues / false positives by comparing the contents of a `zap-known-issues.xml` to that of the generated ZAP XLM report.

### WHY?

This gives us an automated way to discover any vulnerabilities that might exist in our code, and even if the repo isn't touched in a while the code is still being security tested with the latests Zap docker image.


### WARNINGS BEING IGNORED
- `A Client Error response code was returned by the server`: Reported as Informational - was not deemed relevant