### PR TITLE
RIA-1287 Allow respondent evidence to be added multiple times

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/Event.java
@@ -20,6 +20,7 @@ public enum Event {
     UPLOAD_ADDITIONAL_EVIDENCE("uploadAdditionalEvidence"),
     LIST_CASE("listCase"),
     CREATE_CASE_SUMMARY("createCaseSummary"),
+    REVERT_STATE_TO_AWAITING_RESPONDENT_EVIDENCE("revertStateToAwaitingRespondentEvidence"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/presubmit/BuildCaseDirectionNotifier.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/presubmit/BuildCaseDirectionNotifier.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdVa
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.handlers.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.LegalRepresentativePersonalisationFactory;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DirectionFinder;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.NotificationIdAppender;
 
 @Component
 public class BuildCaseDirectionNotifier implements PreSubmitCallbackHandler<AsylumCase> {
@@ -27,12 +28,14 @@ public class BuildCaseDirectionNotifier implements PreSubmitCallbackHandler<Asyl
     private final LegalRepresentativePersonalisationFactory legalRepresentativePersonalisationFactory;
     private final DirectionFinder directionFinder;
     private final NotificationSender notificationSender;
+    private final NotificationIdAppender notificationIdAppender;
 
     public BuildCaseDirectionNotifier(
         @Value("${govnotify.template.buildCaseDirection}") String buildCaseDirectionTemplateId,
         LegalRepresentativePersonalisationFactory legalRepresentativePersonalisationFactory,
         DirectionFinder directionFinder,
-        NotificationSender notificationSender
+        NotificationSender notificationSender,
+        NotificationIdAppender notificationIdAppender
     ) {
         requireNonNull(buildCaseDirectionTemplateId, "buildCaseDirectionTemplateId must not be null");
 
@@ -40,6 +43,7 @@ public class BuildCaseDirectionNotifier implements PreSubmitCallbackHandler<Asyl
         this.legalRepresentativePersonalisationFactory = legalRepresentativePersonalisationFactory;
         this.directionFinder = directionFinder;
         this.notificationSender = notificationSender;
+        this.notificationIdAppender = notificationIdAppender;
     }
 
     public boolean canHandle(
@@ -97,9 +101,13 @@ public class BuildCaseDirectionNotifier implements PreSubmitCallbackHandler<Asyl
                 .getNotificationsSent()
                 .orElseGet(ArrayList::new);
 
-        notificationsSent.add(new IdValue<>(reference, notificationId));
-
-        asylumCase.setNotificationsSent(notificationsSent);
+        asylumCase.setNotificationsSent(
+            notificationIdAppender.append(
+                notificationsSent,
+                reference,
+                notificationId
+            )
+        );
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/NotificationIdAppender.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/NotificationIdAppender.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
+
+@Component
+public class NotificationIdAppender {
+
+    public List<IdValue<String>> append(
+        List<IdValue<String>> existingNotificationsSent,
+        String notificationReference,
+        String notificationId
+    ) {
+        long numberOfExistingNotificationsOfSameKind =
+            existingNotificationsSent
+                .stream()
+                .map(IdValue::getId)
+                .filter(existingNotificationReference -> existingNotificationReference.startsWith(notificationReference))
+                .count();
+
+        String qualifiedNotificationReference;
+
+        if (numberOfExistingNotificationsOfSameKind > 0) {
+            qualifiedNotificationReference = notificationReference + "_" + (numberOfExistingNotificationsOfSameKind + 1);
+        } else {
+            qualifiedNotificationReference = notificationReference;
+        }
+
+        final List<IdValue<String>> newNotificationsSent = new ArrayList<>(existingNotificationsSent);
+
+        newNotificationsSent.add(new IdValue<>(qualifiedNotificationReference, notificationId));
+
+        return newNotificationsSent;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/EventTest.java
@@ -24,11 +24,12 @@ public class EventTest {
         assertEquals("uploadAdditionalEvidence", Event.UPLOAD_ADDITIONAL_EVIDENCE.toString());
         assertEquals("listCase", Event.LIST_CASE.toString());
         assertEquals("createCaseSummary", Event.CREATE_CASE_SUMMARY.toString());
+        assertEquals("revertStateToAwaitingRespondentEvidence", Event.REVERT_STATE_TO_AWAITING_RESPONDENT_EVIDENCE.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(17, Event.values().length);
+        assertEquals(18, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/NotificationIdAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/NotificationIdAppenderTest.java
@@ -1,0 +1,72 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.service;
+
+import static junit.framework.TestCase.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
+
+@RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("unchecked")
+public class NotificationIdAppenderTest {
+
+    private final NotificationIdAppender notificationIdAppender = new NotificationIdAppender();
+
+    private final IdValue<String> existingNotification1 = new IdValue<>("foo", "111-222");
+    private final IdValue<String> existingNotification2 = new IdValue<>("bar", "333-444");
+
+    private final List<IdValue<String>> existingNotificationsSent =
+        Arrays.asList(
+            existingNotification1,
+            existingNotification2
+        );
+
+    @Test
+    public void should_append_first_notification_without_qualifier() {
+
+        List<IdValue<String>> actualNotificationsSent =
+            notificationIdAppender.append(
+                existingNotificationsSent,
+                "something",
+                "555-666"
+            );
+
+        assertEquals(3, actualNotificationsSent.size());
+        assertEquals(existingNotification1, actualNotificationsSent.get(0));
+        assertEquals(existingNotification2, actualNotificationsSent.get(1));
+
+        assertEquals("something", actualNotificationsSent.get(2).getId());
+        assertEquals("555-666", actualNotificationsSent.get(2).getValue());
+    }
+
+    @Test
+    public void should_append_subsequent_notifications_with_qualifiers() {
+
+        List<IdValue<String>> actualNotificationsSent1 =
+            notificationIdAppender.append(
+                existingNotificationsSent,
+                "foo",
+                "555-666"
+            );
+
+        List<IdValue<String>> actualNotificationsSent2 =
+            notificationIdAppender.append(
+                actualNotificationsSent1,
+                "foo",
+                "777-888"
+            );
+
+        assertEquals(4, actualNotificationsSent2.size());
+        assertEquals(existingNotification1, actualNotificationsSent2.get(0));
+        assertEquals(existingNotification2, actualNotificationsSent2.get(1));
+
+        assertEquals("foo_2", actualNotificationsSent2.get(2).getId());
+        assertEquals("555-666", actualNotificationsSent2.get(2).getValue());
+
+        assertEquals("foo_3", actualNotificationsSent2.get(3).getId());
+        assertEquals("777-888", actualNotificationsSent2.get(3).getValue());
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-1287

### Change description ###

Support for replaying the "Upload additional evidence" more than once

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
