### PR TITLE
Upgraded tomcat in response to CVE-2019-0232, CVE-2019-0199

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -193,6 +193,17 @@ repositories {
     jcenter()
 }
 
+dependencyManagement {
+    dependencies {
+        // CVE-2019-0232, CVE-2019-0199 - command line injections on windows
+        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.19') {
+            entry 'tomcat-embed-core'
+            entry 'tomcat-embed-el'
+            entry 'tomcat-embed-websocket'
+        }
+    }
+}
+
 dependencies {
 
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.springBoot

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,6 +1,6 @@
 # Temporary fix for template API version error on deployment
 provider "azurerm" {
-  version = "1.19.0"
+  version = "1.21.0"
 }
 
 locals {


### PR DESCRIPTION
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
