### PR TITLE
RIA-1394 sending multiple notifications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
     id 'org.owasp.dependencycheck' version '3.2.1'
     id 'org.sonarqube' version '2.6.2'
-    id 'org.springframework.boot' version '2.0.4.RELEASE'
+    id 'org.springframework.boot' version '2.0.8.RELEASE'
 }
 
 apply plugin: 'java'

--- a/src/integrationTest/java/uk/gov/hmcts/reform/iacasenotificationsapi/MultipleNotificationsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/iacasenotificationsapi/MultipleNotificationsTest.java
@@ -176,6 +176,8 @@ public class MultipleNotificationsTest {
         DirectionTag directionTag = DirectionTag.NONE;
 
         switch (event) {
+            case SUBMIT_APPEAL:
+                break;
             case UPLOAD_RESPONDENT_EVIDENCE:
                 directionTag = DirectionTag.BUILD_CASE;
                 break;
@@ -195,6 +197,8 @@ public class MultipleNotificationsTest {
             case REQUEST_RESPONDENT_REVIEW:
                 directionTag = DirectionTag.RESPONDENT_REVIEW;
                 break;
+            default:
+                throw new IllegalStateException("unexpected event");
         }
 
         return new Direction(

--- a/src/integrationTest/java/uk/gov/hmcts/reform/iacasenotificationsapi/MultipleNotificationsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/iacasenotificationsapi/MultipleNotificationsTest.java
@@ -13,10 +13,7 @@ import com.google.common.collect.Lists;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import javafx.util.Pair;
+import java.util.*;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,15 +57,15 @@ public class MultipleNotificationsTest {
     private static final String ABOUT_TO_START_PATH = "/asylum/ccdAboutToStart";
     private static final String ABOUT_TO_SUBMIT_PATH = "/asylum/ccdAboutToSubmit";
 
-    private List<Pair<Event, String>> eventAndNotificationSuffixPair =
+    private List<Map.Entry<Event, String>> eventAndNotificationSuffixPair =
         Lists.newArrayList(
-            new Pair<>(Event.SUBMIT_APPEAL, "_APPEAL_SUBMITTED_CASE_OFFICER"),
-            new Pair<>(Event.UPLOAD_RESPONDENT_EVIDENCE, "_BUILD_CASE_DIRECTION"),
-            new Pair<>(Event.REQUEST_HEARING_REQUIREMENTS, "_LEGAL_REPRESENTATIVE_HEARING_REQUIREMENTS_DIRECTION"),
-            new Pair<>(Event.ADD_APPEAL_RESPONSE, "_LEGAL_REPRESENTATIVE_REVIEW_DIRECTION"),
-            new Pair<>(Event.REQUEST_RESPONDENT_EVIDENCE, "_RESPONDENT_EVIDENCE_DIRECTION"),
-            new Pair<>(Event.SEND_DIRECTION, "_RESPONDENT_NON_STANDARD_DIRECTION"),
-            new Pair<>(Event.REQUEST_RESPONDENT_REVIEW, "_RESPONDENT_REVIEW_DIRECTION"));
+            new HashMap.SimpleImmutableEntry<>(Event.SUBMIT_APPEAL, "_APPEAL_SUBMITTED_CASE_OFFICER"),
+            new HashMap.SimpleImmutableEntry<>(Event.UPLOAD_RESPONDENT_EVIDENCE, "_BUILD_CASE_DIRECTION"),
+            new HashMap.SimpleImmutableEntry<>(Event.REQUEST_HEARING_REQUIREMENTS, "_LEGAL_REPRESENTATIVE_HEARING_REQUIREMENTS_DIRECTION"),
+            new HashMap.SimpleImmutableEntry<>(Event.ADD_APPEAL_RESPONSE, "_LEGAL_REPRESENTATIVE_REVIEW_DIRECTION"),
+            new HashMap.SimpleImmutableEntry<>(Event.REQUEST_RESPONDENT_EVIDENCE, "_RESPONDENT_EVIDENCE_DIRECTION"),
+            new HashMap.SimpleImmutableEntry<>(Event.SEND_DIRECTION, "_RESPONDENT_NON_STANDARD_DIRECTION"),
+            new HashMap.SimpleImmutableEntry<>(Event.REQUEST_RESPONDENT_REVIEW, "_RESPONDENT_REVIEW_DIRECTION"));
 
     @Autowired
     private WebApplicationContext webApplicationContext;
@@ -97,7 +94,7 @@ public class MultipleNotificationsTest {
         );
     }
 
-    public void runTestScenario(String notificationId, Pair<Event, String> eventWithSuffixPair) throws Exception {
+    public void runTestScenario(String notificationId, Map.Entry<Event, String> eventWithSuffixPair) throws Exception {
 
         log.info("Scenario eventId: {} expecting suffix: {}", eventWithSuffixPair.getKey(), eventWithSuffixPair.getValue());
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/iacasenotificationsapi/MultipleNotificationsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/iacasenotificationsapi/MultipleNotificationsTest.java
@@ -1,0 +1,222 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import javafx.util.Pair;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.context.WebApplicationContext;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.NotificationSender;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.State;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.security.CcdEventAuthorizor;
+
+@Slf4j
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = Application.class, webEnvironment = MOCK)
+@ActiveProfiles("integration")
+public class MultipleNotificationsTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private CcdEventAuthorizor ccdEventAuthorizor;
+    @MockBean
+    private NotificationSender notificationSender;
+
+    private MockMvc mockMvc;
+
+    private static final String ABOUT_TO_START_PATH = "/asylum/ccdAboutToStart";
+    private static final String ABOUT_TO_SUBMIT_PATH = "/asylum/ccdAboutToSubmit";
+
+    private List<Pair<Event, String>> eventAndNotificationSuffixPair =
+        Lists.newArrayList(
+            new Pair<>(Event.SUBMIT_APPEAL, "_APPEAL_SUBMITTED_CASE_OFFICER"),
+            new Pair<>(Event.UPLOAD_RESPONDENT_EVIDENCE, "_BUILD_CASE_DIRECTION"),
+            new Pair<>(Event.REQUEST_HEARING_REQUIREMENTS, "_LEGAL_REPRESENTATIVE_HEARING_REQUIREMENTS_DIRECTION"),
+            new Pair<>(Event.ADD_APPEAL_RESPONSE, "_LEGAL_REPRESENTATIVE_REVIEW_DIRECTION"),
+            new Pair<>(Event.REQUEST_RESPONDENT_EVIDENCE, "_RESPONDENT_EVIDENCE_DIRECTION"),
+            new Pair<>(Event.SEND_DIRECTION, "_RESPONDENT_NON_STANDARD_DIRECTION"),
+            new Pair<>(Event.REQUEST_RESPONDENT_REVIEW, "_RESPONDENT_REVIEW_DIRECTION"));
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Before
+    public void setUp() {
+        this.mockMvc = webAppContextSetup(webApplicationContext).build();
+
+        doNothing().when(ccdEventAuthorizor).throwIfNotAuthorized(any(Event.class));
+
+    }
+
+    @Test
+    public void should_send_multiple_notifications_of_same_type_with_unique_reference_numbers() {
+
+        String notificationId = "test-notification-id";
+
+        eventAndNotificationSuffixPair.forEach(eventPair -> {
+                try {
+                    runTestScenario(notificationId, eventPair);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    assert false;
+                }
+            }
+        );
+    }
+
+    public void runTestScenario(String notificationId, Pair<Event, String> eventWithSuffixPair) throws Exception {
+
+        log.info("Scenario eventId: {} expecting suffix: {}", eventWithSuffixPair.getKey(), eventWithSuffixPair.getValue());
+
+        long caseDetailsId = 1L;
+
+        String existingReference =
+            caseDetailsId
+            + eventWithSuffixPair.getValue();
+
+        List<IdValue<String>> existingNotifications =
+            Lists.newArrayList(new IdValue<>(existingReference, notificationId));
+
+        when(notificationSender.sendEmail(anyString(), anyString(), anyMap(), anyString())).thenReturn(notificationId);
+
+        Direction direction = createExistingDirection(eventWithSuffixPair.getKey());
+
+        AsylumCase caseData = createBasicAsylumCase();
+        caseData.setDirections(Collections.singletonList(new IdValue<>("1", direction)));
+        caseData.setNotificationsSent(existingNotifications);
+        caseData.setLegalRepresentativeEmailAddress("someone@somewhere.com");
+
+        CaseDetails<AsylumCase> caseDetails = new CaseDetails<>(
+            caseDetailsId,
+            "IA",
+            State.APPEAL_SUBMITTED,
+            caseData,
+            LocalDateTime.now()
+        );
+
+        Callback<AsylumCase> callback = new Callback<>(caseDetails,
+            Optional.empty(),
+            eventWithSuffixPair.getKey());
+
+        final String json = objectMapper.writeValueAsString(callback);
+
+        final PreSubmitCallbackResponse<AsylumCase> callbackResponse = doPost(
+            ABOUT_TO_SUBMIT_PATH,
+            MediaType.APPLICATION_JSON,
+            json,
+            HttpStatus.OK.value()
+        );
+
+        AsylumCase asylumCaseResponse = callbackResponse.getData();
+
+        assertThat(asylumCaseResponse).isNotNull();
+        assertThat(asylumCaseResponse.getNotificationsSent().isPresent()).isTrue();
+
+        List<IdValue<String>> allNotifications =
+            asylumCaseResponse.getNotificationsSent().orElseThrow(IllegalStateException::new);
+
+        assertThat(allNotifications.size()).isEqualTo(2);
+        assertThat(allNotifications.get(0).getId()).isNotEqualTo(allNotifications.get(1).getId());
+
+    }
+
+    private PreSubmitCallbackResponse<AsylumCase> doPost(
+        final String path,
+        final MediaType mediaType,
+        final String content,
+        final int expectedHttpStatus
+    ) throws Exception {
+        MvcResult mvcResult = mockMvc.perform(post(path)
+            .contentType(mediaType).content(content))
+            .andExpect(status().is(expectedHttpStatus)).andReturn();
+
+        String jsonResponse = mvcResult.getResponse().getContentAsString();
+
+        return objectMapper.readValue(jsonResponse,
+            new TypeReference<PreSubmitCallbackResponse<AsylumCase>>() {
+            }
+        );
+
+    }
+
+    private Direction createExistingDirection(Event event) {
+
+        String dateFormat = "yyyy-MM-dd";
+        Parties party = Parties.RESPONDENT;
+        DirectionTag directionTag = DirectionTag.NONE;
+
+        switch (event) {
+            case UPLOAD_RESPONDENT_EVIDENCE:
+                directionTag = DirectionTag.BUILD_CASE;
+                break;
+            case REQUEST_HEARING_REQUIREMENTS:
+                directionTag = DirectionTag.LEGAL_REPRESENTATIVE_HEARING_REQUIREMENTS;
+                break;
+            case ADD_APPEAL_RESPONSE:
+                directionTag = DirectionTag.LEGAL_REPRESENTATIVE_REVIEW;
+                break;
+            case REQUEST_RESPONDENT_EVIDENCE:
+                directionTag = DirectionTag.RESPONDENT_EVIDENCE;
+                break;
+            case SEND_DIRECTION:
+                party = Parties.RESPONDENT;
+                directionTag = DirectionTag.NONE;
+                break;
+            case REQUEST_RESPONDENT_REVIEW:
+                directionTag = DirectionTag.RESPONDENT_REVIEW;
+                break;
+        }
+
+        return new Direction(
+            "some-explanation",
+            party,
+            LocalDate.now().plusDays(7L).format(DateTimeFormatter.ofPattern(dateFormat)),
+            LocalDate.now().format(DateTimeFormatter.ofPattern(dateFormat)),
+            directionTag);
+    }
+
+
+    private AsylumCase createBasicAsylumCase() {
+
+        AsylumCaseBuilder asylumCaseBuilder = new AsylumCaseBuilder();
+        asylumCaseBuilder.setHearingCentre(Optional.of(HearingCentre.MANCHESTER));
+
+        return new AsylumCase(asylumCaseBuilder);
+
+    }
+
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/presubmit/LegalRepresentativeHearingRequirementsDirectionNotifier.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/presubmit/LegalRepresentativeHearingRequirementsDirectionNotifier.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdVa
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.handlers.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.LegalRepresentativePersonalisationFactory;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DirectionFinder;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.NotificationIdAppender;
 
 @Component
 public class LegalRepresentativeHearingRequirementsDirectionNotifier implements PreSubmitCallbackHandler<AsylumCase> {
@@ -27,12 +28,14 @@ public class LegalRepresentativeHearingRequirementsDirectionNotifier implements 
     private final LegalRepresentativePersonalisationFactory legalRepresentativePersonalisationFactory;
     private final DirectionFinder directionFinder;
     private final NotificationSender notificationSender;
+    private final NotificationIdAppender notificationIdAppender;
 
     public LegalRepresentativeHearingRequirementsDirectionNotifier(
         @Value("${govnotify.template.legalRepresentativeHearingRequirementsDirection}") String legalRepresentativeHearingRequirementsDirectionTemplateId,
         LegalRepresentativePersonalisationFactory legalRepresentativePersonalisationFactory,
         DirectionFinder directionFinder,
-        NotificationSender notificationSender
+        NotificationSender notificationSender,
+        NotificationIdAppender notificationIdAppender
     ) {
         requireNonNull(legalRepresentativeHearingRequirementsDirectionTemplateId, "legalRepresentativeHearingRequirementsDirectionTemplateId must not be null");
 
@@ -40,6 +43,7 @@ public class LegalRepresentativeHearingRequirementsDirectionNotifier implements 
         this.legalRepresentativePersonalisationFactory = legalRepresentativePersonalisationFactory;
         this.directionFinder = directionFinder;
         this.notificationSender = notificationSender;
+        this.notificationIdAppender = notificationIdAppender;
     }
 
     public boolean canHandle(
@@ -97,9 +101,13 @@ public class LegalRepresentativeHearingRequirementsDirectionNotifier implements 
                 .getNotificationsSent()
                 .orElseGet(ArrayList::new);
 
-        notificationsSent.add(new IdValue<>(reference, notificationId));
-
-        asylumCase.setNotificationsSent(notificationsSent);
+        asylumCase.setNotificationsSent(
+            notificationIdAppender.append(
+                notificationsSent,
+                reference,
+                notificationId
+            )
+        );
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/presubmit/RespondentReviewDirectionNotifier.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/presubmit/RespondentReviewDirectionNotifier.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdVa
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.handlers.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.RespondentDirectionPersonalisationFactory;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DirectionFinder;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.NotificationIdAppender;
 
 @Component
 public class RespondentReviewDirectionNotifier implements PreSubmitCallbackHandler<AsylumCase> {
@@ -28,13 +29,15 @@ public class RespondentReviewDirectionNotifier implements PreSubmitCallbackHandl
     private final RespondentDirectionPersonalisationFactory respondentDirectionPersonalisationFactory;
     private final DirectionFinder directionFinder;
     private final NotificationSender notificationSender;
+    private final NotificationIdAppender notificationIdAppender;
 
     public RespondentReviewDirectionNotifier(
         @Value("${govnotify.template.respondentReviewDirection}") String respondentReviewDirectionTemplateId,
         @Value("${respondentEmailAddresses.respondentReviewDirection}") String respondentReviewDirectionEmailAddress,
         RespondentDirectionPersonalisationFactory respondentDirectionPersonalisationFactory,
         DirectionFinder directionFinder,
-        NotificationSender notificationSender
+        NotificationSender notificationSender,
+        NotificationIdAppender notificationIdAppender
     ) {
         requireNonNull(respondentReviewDirectionTemplateId, "respondentReviewDirectionTemplateId must not be null");
         requireNonNull(respondentReviewDirectionEmailAddress, "respondentReviewDirectionEmailAddress must not be null");
@@ -44,6 +47,7 @@ public class RespondentReviewDirectionNotifier implements PreSubmitCallbackHandl
         this.respondentDirectionPersonalisationFactory = respondentDirectionPersonalisationFactory;
         this.directionFinder = directionFinder;
         this.notificationSender = notificationSender;
+        this.notificationIdAppender = notificationIdAppender;
     }
 
     public boolean canHandle(
@@ -96,9 +100,13 @@ public class RespondentReviewDirectionNotifier implements PreSubmitCallbackHandl
                 .getNotificationsSent()
                 .orElseGet(ArrayList::new);
 
-        notificationsSent.add(new IdValue<>(reference, notificationId));
-
-        asylumCase.setNotificationsSent(notificationsSent);
+        asylumCase.setNotificationsSent(
+            notificationIdAppender.append(
+                notificationsSent,
+                reference,
+                notificationId
+            )
+        );
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/presubmit/BuildCaseDirectionNotifierTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/presubmit/BuildCaseDirectionNotifierTest.java
@@ -41,12 +41,12 @@ public class BuildCaseDirectionNotifierTest {
     @Mock private Direction buildCaseDirection;
     @Mock private Map<String, String> personalisation;
 
-    final long caseId = 123L;
+    private final long caseId = 123L;
 
-    final String legalRepresentativeEmailAddress = "legal-representative@example.com";
+    private final String legalRepresentativeEmailAddress = "legal-representative@example.com";
 
-    final String expectedNotificationId = "ABC-DEF-GHI-JKL";
-    final String expectedNotificationReference = caseId + "_BUILD_CASE_DIRECTION";
+    private final String expectedNotificationId = "ABC-DEF-GHI-JKL";
+    private final String expectedNotificationReference = caseId + "_BUILD_CASE_DIRECTION";
 
     private BuildCaseDirectionNotifier buildCaseDirectionNotifier;
 
@@ -83,13 +83,13 @@ public class BuildCaseDirectionNotifierTest {
     public void should_send_build_case_direction_notification() {
 
         final List<IdValue<String>> existingNotifications =
-            new ArrayList<>(Arrays.asList(
-                new IdValue<>("some-notification-sent", "ZZZ-ZZZ-ZZZ-ZZZ")
+            new ArrayList<>(Collections.singletonList(
+                new IdValue<>("case-direction-notification-sent", "ZZZ-ZZZ-ZZZ-ZZZ")
             ));
 
         final List<IdValue<String>> expectedNotifications =
             new ArrayList<>(Arrays.asList(
-                new IdValue<>("some-notification-sent", "ZZZ-ZZZ-ZZZ-ZZZ"),
+                new IdValue<>("case-direction-notification-sent", "ZZZ-ZZZ-ZZZ-ZZZ"),
                 new IdValue<>(expectedNotificationReference, expectedNotificationId)
             ));
 
@@ -114,6 +114,7 @@ public class BuildCaseDirectionNotifierTest {
             expectedNotificationReference
         );
 
+        verify(notificationIdAppender).append(anyList(), anyString(), anyString());
         verify(asylumCase, times(1)).setNotificationsSent(expectedNotifications);
     }
 
@@ -123,7 +124,7 @@ public class BuildCaseDirectionNotifierTest {
         final List<IdValue<String>> existingNotifications = Collections.emptyList();
 
         final List<IdValue<String>> expectedNotifications =
-            new ArrayList<>(Arrays.asList(
+            new ArrayList<>(Collections.singletonList(
                 new IdValue<>(expectedNotificationReference, expectedNotificationId)
             ));
 

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/presubmit/RespondentEvidenceDirectionNotifierTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/presubmit/RespondentEvidenceDirectionNotifierTest.java
@@ -8,8 +8,6 @@ import java.util.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.NotificationSender;
@@ -24,6 +22,7 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.P
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.RespondentDirectionPersonalisationFactory;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DirectionFinder;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.NotificationIdAppender;
 
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("unchecked")
@@ -40,15 +39,14 @@ public class RespondentEvidenceDirectionNotifierTest {
     @Mock private AsylumCase asylumCase;
     @Mock private Direction respondentEvidenceDirection;
     @Mock private Map<String, String> personalisation;
+    @Mock private NotificationIdAppender notificationIdAppender;
 
-    @Captor private ArgumentCaptor<List<IdValue<String>>> existingNotificationsSentCaptor;
+    private final long caseId = 123L;
 
-    final long caseId = 123L;
+    private final String respondentEmailAddress = "respondent@example.com";
 
-    final String respondentEmailAddress = "respondent@example.com";
-
-    final String expectedNotificationId = "ABC-DEF-GHI-JKL";
-    final String expectedNotificationReference = caseId + "_RESPONDENT_EVIDENCE_DIRECTION";
+    private final String expectedNotificationId = "ABC-DEF-GHI-JKL";
+    private final String expectedNotificationReference = caseId + "_RESPONDENT_EVIDENCE_DIRECTION";
 
     private RespondentEvidenceDirectionNotifier respondentEvidenceDirectionNotifier;
 
@@ -60,7 +58,8 @@ public class RespondentEvidenceDirectionNotifierTest {
                 respondentEmailAddress,
                 respondentDirectionPersonalisationFactory,
                 directionFinder,
-                notificationSender
+                notificationSender,
+                notificationIdAppender
             );
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
@@ -84,11 +83,23 @@ public class RespondentEvidenceDirectionNotifierTest {
     public void should_send_respondent_evidence_direction_notification() {
 
         final List<IdValue<String>> existingNotifications =
-            new ArrayList<>(Arrays.asList(
+            new ArrayList<>(Collections.singletonList(
                 new IdValue<>("some-notification-sent", "ZZZ-ZZZ-ZZZ-ZZZ")
             ));
 
+        final List<IdValue<String>> expectedNotifications =
+            new ArrayList<>(Arrays.asList(
+                new IdValue<>("some-notification-sent", "ZZZ-ZZZ-ZZZ-ZZZ"),
+                new IdValue<>(expectedNotificationReference, expectedNotificationId)
+            ));
+
         when(asylumCase.getNotificationsSent()).thenReturn(Optional.of(existingNotifications));
+        when(notificationIdAppender.append(
+            existingNotifications,
+            expectedNotificationReference,
+            expectedNotificationId
+        )).thenReturn(expectedNotifications);
+
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             respondentEvidenceDirectionNotifier.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
@@ -103,26 +114,26 @@ public class RespondentEvidenceDirectionNotifierTest {
             expectedNotificationReference
         );
 
-        verify(asylumCase, times(1)).setNotificationsSent(existingNotificationsSentCaptor.capture());
+        verify(asylumCase, times(1)).setNotificationsSent(expectedNotifications);
+        verify(notificationIdAppender).append(anyList(), anyString(), anyString());
 
-        List<IdValue<String>> actualExistingNotificationsSent =
-            existingNotificationsSentCaptor
-                .getAllValues()
-                .get(0);
-
-        assertEquals(2, actualExistingNotificationsSent.size());
-
-        assertEquals("some-notification-sent", actualExistingNotificationsSent.get(0).getId());
-        assertEquals("ZZZ-ZZZ-ZZZ-ZZZ", actualExistingNotificationsSent.get(0).getValue());
-
-        assertEquals(caseId + "_RESPONDENT_EVIDENCE_DIRECTION", actualExistingNotificationsSent.get(1).getId());
-        assertEquals(expectedNotificationId, actualExistingNotificationsSent.get(1).getValue());
     }
 
     @Test
     public void should_send_respondent_evidence_direction_notification_when_no_notifications_exist() {
 
+        final List<IdValue<String>> expectedNotifications =
+            new ArrayList<>(Collections.singletonList(
+                new IdValue<>(expectedNotificationReference, expectedNotificationId)
+            ));
+
         when(asylumCase.getNotificationsSent()).thenReturn(Optional.empty());
+
+        when(notificationIdAppender.append(
+            Collections.emptyList(),
+            expectedNotificationReference,
+            expectedNotificationId
+        )).thenReturn(expectedNotifications);
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             respondentEvidenceDirectionNotifier.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
@@ -137,17 +148,9 @@ public class RespondentEvidenceDirectionNotifierTest {
             expectedNotificationReference
         );
 
-        verify(asylumCase, times(1)).setNotificationsSent(existingNotificationsSentCaptor.capture());
+        verify(asylumCase, times(1)).setNotificationsSent(expectedNotifications);
+        verify(notificationIdAppender).append(anyList(), anyString(), anyString());
 
-        List<IdValue<String>> actualExistingNotificationsSent =
-            existingNotificationsSentCaptor
-                .getAllValues()
-                .get(0);
-
-        assertEquals(1, actualExistingNotificationsSent.size());
-
-        assertEquals(caseId + "_RESPONDENT_EVIDENCE_DIRECTION", actualExistingNotificationsSent.get(0).getId());
-        assertEquals(expectedNotificationId, actualExistingNotificationsSent.get(0).getValue());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/presubmit/RespondentReviewDirectionNotifierTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/presubmit/RespondentReviewDirectionNotifierTest.java
@@ -5,11 +5,10 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
+import org.assertj.core.util.Lists;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.NotificationSender;
@@ -24,6 +23,7 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.P
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.RespondentDirectionPersonalisationFactory;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DirectionFinder;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.NotificationIdAppender;
 
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("unchecked")
@@ -34,6 +34,7 @@ public class RespondentReviewDirectionNotifierTest {
     @Mock private RespondentDirectionPersonalisationFactory respondentDirectionPersonalisationFactory;
     @Mock private DirectionFinder directionFinder;
     @Mock private NotificationSender notificationSender;
+    @Mock private NotificationIdAppender notificationIdAppender;
 
     @Mock private Callback<AsylumCase> callback;
     @Mock private CaseDetails<AsylumCase> caseDetails;
@@ -41,14 +42,12 @@ public class RespondentReviewDirectionNotifierTest {
     @Mock private Direction respondentReviewDirection;
     @Mock private Map<String, String> personalisation;
 
-    @Captor private ArgumentCaptor<List<IdValue<String>>> existingNotificationsSentCaptor;
+    private final long caseId = 123L;
 
-    final long caseId = 123L;
+    private final String respondentEmailAddress = "respondent@example.com";
 
-    final String respondentEmailAddress = "respondent@example.com";
-
-    final String expectedNotificationId = "ABC-DEF-GHI-JKL";
-    final String expectedNotificationReference = caseId + "_RESPONDENT_REVIEW_DIRECTION";
+    private final String expectedNotificationId = "ABC-DEF-GHI-JKL";
+    private final String expectedNotificationReference = caseId + "_RESPONDENT_REVIEW_DIRECTION";
 
     private RespondentReviewDirectionNotifier respondentReviewDirectionNotifier;
 
@@ -60,7 +59,8 @@ public class RespondentReviewDirectionNotifierTest {
                 respondentEmailAddress,
                 respondentDirectionPersonalisationFactory,
                 directionFinder,
-                notificationSender
+                notificationSender,
+                notificationIdAppender
             );
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
@@ -84,11 +84,23 @@ public class RespondentReviewDirectionNotifierTest {
     public void should_send_respondent_review_direction_notification() {
 
         final List<IdValue<String>> existingNotifications =
-            new ArrayList<>(Arrays.asList(
+            new ArrayList<>(Collections.singletonList(
                 new IdValue<>("some-notification-sent", "ZZZ-ZZZ-ZZZ-ZZZ")
             ));
 
+        final List<IdValue<String>> expectedNotifications =
+            new ArrayList<>(Lists.newArrayList(
+                new IdValue<>("some-notification-sent", "ZZZ-ZZZ-ZZZ-ZZZ"),
+                new IdValue<>(expectedNotificationReference, expectedNotificationId)
+            ));
+
         when(asylumCase.getNotificationsSent()).thenReturn(Optional.of(existingNotifications));
+
+        when(notificationIdAppender.append(
+            existingNotifications,
+            expectedNotificationReference,
+            expectedNotificationId))
+            .thenReturn(expectedNotifications);
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             respondentReviewDirectionNotifier.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
@@ -103,26 +115,25 @@ public class RespondentReviewDirectionNotifierTest {
             expectedNotificationReference
         );
 
-        verify(asylumCase, times(1)).setNotificationsSent(existingNotificationsSentCaptor.capture());
+        verify(asylumCase, times(1)).setNotificationsSent(expectedNotifications);
+        verify(notificationIdAppender).append(anyList(), anyString(), anyString());
 
-        List<IdValue<String>> actualExistingNotificationsSent =
-            existingNotificationsSentCaptor
-                .getAllValues()
-                .get(0);
-
-        assertEquals(2, actualExistingNotificationsSent.size());
-
-        assertEquals("some-notification-sent", actualExistingNotificationsSent.get(0).getId());
-        assertEquals("ZZZ-ZZZ-ZZZ-ZZZ", actualExistingNotificationsSent.get(0).getValue());
-
-        assertEquals(caseId + "_RESPONDENT_REVIEW_DIRECTION", actualExistingNotificationsSent.get(1).getId());
-        assertEquals(expectedNotificationId, actualExistingNotificationsSent.get(1).getValue());
     }
 
     @Test
     public void should_send_respondent_review_direction_notification_when_no_notifications_exist() {
 
+        final List<IdValue<String>> expectedNotifications =
+            new ArrayList<>(Lists.newArrayList(
+                new IdValue<>(expectedNotificationReference, expectedNotificationId)
+            ));
+
         when(asylumCase.getNotificationsSent()).thenReturn(Optional.empty());
+        when(notificationIdAppender.append(
+            Lists.emptyList(),
+            expectedNotificationReference,
+            expectedNotificationId))
+            .thenReturn(expectedNotifications);
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             respondentReviewDirectionNotifier.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
@@ -137,17 +148,9 @@ public class RespondentReviewDirectionNotifierTest {
             expectedNotificationReference
         );
 
-        verify(asylumCase, times(1)).setNotificationsSent(existingNotificationsSentCaptor.capture());
+        verify(asylumCase, times(1)).setNotificationsSent(expectedNotifications);
+        verify(notificationIdAppender).append(anyList(), anyString(), anyString());
 
-        List<IdValue<String>> actualExistingNotificationsSent =
-            existingNotificationsSentCaptor
-                .getAllValues()
-                .get(0);
-
-        assertEquals(1, actualExistingNotificationsSent.size());
-
-        assertEquals(caseId + "_RESPONDENT_REVIEW_DIRECTION", actualExistingNotificationsSent.get(0).getId());
-        assertEquals(expectedNotificationId, actualExistingNotificationsSent.get(0).getValue());
     }
 
     @Test


### PR DESCRIPTION
All notifications now call NotificationIdAppender to make ids unique

bumping spring version for CVE-2018-15756 and code some code tidy up

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-1394


### Change description ###

see jira

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
