### PR TITLE
RIA-2265 & RIA-2270: Reason for appeal submitted

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-2265-aip-reason-for-appeal-received-notification-to-case-worker.json
+++ b/src/functionalTest/resources/scenarios/RIA-2265-aip-reason-for-appeal-received-notification-to-case-worker.json
@@ -1,0 +1,74 @@
+{
+  "description": "RIA-2265 Send Reason for appeal received to case worker",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Citizen",
+    "input": {
+      "id": 1010,
+      "eventId": "uploadRespondentEvidence",
+      "state": "awaitingRespondentEvidence",
+      "caseData": {
+        "template": "aip-minimal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "manchester",
+          "subscriptions": [
+            {
+              "id": "1",
+              "value": {
+                "subscriber": "appellant",
+                "email": "{$TEST_CITIZEN_USERNAME}",
+                "wantsEmail": "No",
+                "mobileNumber": "{$TEST_CITIZEN_MOBILE}",
+                "wantsSms": "No"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "aip-minimal-appeal-submitted.json",
+      "replacements": {
+        "hearingCentre": "manchester",
+        "subscriptions": [
+          {
+            "id": "1",
+            "value": {
+              "subscriber": "appellant",
+              "email": "{$TEST_CITIZEN_USERNAME}",
+              "wantsEmail": "No",
+              "mobileNumber": "{$TEST_CITIZEN_MOBILE}",
+              "wantsSms": "No"
+            }
+          }
+        ],
+        "notificationsSent": [
+          {
+            "id": "1010_REASONS_FOR_APPEAL_SUBMITTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "1010_REASONS_FOR_APPEAL_SUBMITTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.manchester}",
+        "subject": "Immigration and Asylum appeal: Reasons for Appeal submitted",
+        "body": [
+          "Appeal reference number: PA/12345/2019",
+          "Appellant name: Pablo Jimenez",
+          "Link to the online service: {$iaCcdFrontendUrl}",
+          "# A Reasons for Appeal has been submitted",
+          "Log in to the service to review the Reasons for Appeal.",
+          "If you believe the case is ready to proceed, you should direct the respondent to review it. If you don’t think it is ready, you should direct the appellant to answer clarifying questions or attend a case management appointment.",
+          "First-tier Tribunal (Immigration and Asylum Chamber)"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-2270-aip-reason-for-appeal submitted.json
+++ b/src/functionalTest/resources/scenarios/RIA-2270-aip-reason-for-appeal submitted.json
@@ -1,0 +1,108 @@
+{
+  "description": "RIA-2270 Send Reason for appeal submitted to appellant and caseworker",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Citizen",
+    "input": {
+      "id": 1011,
+      "eventId": "uploadRespondentEvidence",
+      "state": "awaitingRespondentEvidence",
+      "caseData": {
+        "template": "aip-minimal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "manchester",
+          "subscriptions": [
+            {
+              "id": "1",
+              "value": {
+                "subscriber": "appellant",
+                "email": "{$TEST_CITIZEN_USERNAME}",
+                "wantsEmail": "Yes",
+                "mobileNumber": "{$TEST_CITIZEN_MOBILE}",
+                "wantsSms": "Yes"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "aip-minimal-appeal-submitted.json",
+      "replacements": {
+        "hearingCentre": "manchester",
+        "subscriptions": [
+          {
+            "id": "1",
+            "value": {
+              "subscriber": "appellant",
+              "email": "{$TEST_CITIZEN_USERNAME}",
+              "wantsEmail": "Yes",
+              "mobileNumber": "{$TEST_CITIZEN_MOBILE}",
+              "wantsSms": "Yes"
+            }
+          }
+        ],
+        "notificationsSent": [
+          {
+            "id": "1011_REASONS_FOR_APPEAL_SUBMITTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1011_REASONS_FOR_APPEAL_SUBMITTED_APPELLANT_AIP_EMAIL",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1011_REASONS_FOR_APPEAL_SUBMITTED_APPELLANT_AIP_SMS",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "1011_REASONS_FOR_APPEAL_SUBMITTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.manchester}",
+        "subject": "Immigration and Asylum appeal: Reasons for Appeal submitted",
+        "body": [
+          "Appeal reference number: PA/12345/2019",
+          "Appellant name: Pablo Jimenez",
+          "Link to the online service: {$iaCcdFrontendUrl}",
+          "# A Reasons for Appeal has been submitted",
+          "Log in to the service to review the Reasons for Appeal.",
+          "If you believe the case is ready to proceed, you should direct the respondent to review it. If you don’t think it is ready, you should direct the appellant to answer clarifying questions or attend a case management appointment.",
+          "First-tier Tribunal (Immigration and Asylum Chamber)"
+        ]
+      },
+      {
+        "reference": "1011_REASONS_FOR_APPEAL_SUBMITTED_APPELLANT_AIP_EMAIL",
+        "recipient": "{$TEST_CITIZEN_USERNAME}",
+        "subject": "You told us why you think the Home Office is wrong",
+        "body": [
+          "Appeal reference: PA/12345/2019",
+          "Home Office reference: A1234567",
+          "Dear Pablo Jimenez",
+          "You have told the Tribunal why you think the Home Office was wrong to refuse your claim.",
+          "A case worker will look at your answer and any supporting evidence you provided and will contact you by {$TODAY+14|d MMM yyyy} to tell you what to do next.",
+          "Sign in to your account to see your appeal progress:",
+          "{$iaAipFrontendUrl}",
+          "First-tier Tribunal (Immigration and Asylum Chamber)"
+        ]
+      },
+      {
+        "reference": "1011_REASONS_FOR_APPEAL_SUBMITTED_APPELLANT_AIP_SMS",
+        "recipient": "{$TEST_CITIZEN_MOBILE}",
+        "subject": "",
+        "body": [
+          "Appeal reference: PA/12345/2019",
+          "You have told the Tribunal why you think the Home Office was wrong to refuse your claim.",
+          "A case worker will look at your answer and any supporting evidence you provided and will contact you by {$TODAY+14|d MMM yyyy} to tell you what to do next.",
+          "{$iaAipFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/NotificationType.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/NotificationType.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities;
+
+public enum NotificationType {
+
+    SMS,
+    EMAIL
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/sms/AppellantReasonsForAppealSubmittedPersonalisationSms.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/sms/AppellantReasonsForAppealSubmittedPersonalisationSms.java
@@ -1,0 +1,68 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appellant.sms;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.ImmutableMap;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.NotificationType;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.SmsNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.RecipientsFinder;
+
+@Service
+public class AppellantReasonsForAppealSubmittedPersonalisationSms implements SmsNotificationPersonalisation {
+
+    private final String reasonsForAppealSubmittedAppellantSmsTemplateId;
+    private final String iaAipFrontendUrl;
+    private final RecipientsFinder recipientsFinder;
+
+    public AppellantReasonsForAppealSubmittedPersonalisationSms(
+        @Value("${govnotify.template.reasonsForAppealSubmittedAppellant.sms}") String reasonsForAppealSubmittedAppellantSmsTemplateId,
+        @Value("${iaAipFrontendUrl}") String iaAipFrontendUrl,
+        RecipientsFinder recipientsFinder
+    ) {
+        this.reasonsForAppealSubmittedAppellantSmsTemplateId = reasonsForAppealSubmittedAppellantSmsTemplateId;
+        this.iaAipFrontendUrl = iaAipFrontendUrl;
+        this.recipientsFinder = recipientsFinder;
+    }
+
+
+    @Override
+    public String getTemplateId() {
+        return reasonsForAppealSubmittedAppellantSmsTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        return recipientsFinder.findAll(asylumCase, NotificationType.SMS);
+
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_REASONS_FOR_APPEAL_SUBMITTED_APPELLANT_AIP_SMS";
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+        final String dueDate =
+            LocalDate.now().plusDays(14)
+                .format(DateTimeFormatter.ofPattern("d MMM yyyy"));
+        return
+            ImmutableMap
+                .<String, String>builder()
+                .put("Appeal Ref Number", asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+                .put("due date", dueDate)
+                .put("Hyperlink to service", iaAipFrontendUrl)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerReasonForAppealSubmittedPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerReasonForAppealSubmittedPersonalisation.java
@@ -1,0 +1,65 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.caseofficer;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPELLANT_FAMILY_NAME;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPELLANT_GIVEN_NAMES;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import javax.validation.constraints.NotNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
+
+@Service
+public class CaseOfficerReasonForAppealSubmittedPersonalisation implements EmailNotificationPersonalisation {
+
+    private final String reasonsForAppealSubmittedCaseOfficerTemplateId;
+    private final String iaCcdFrontendUrl;
+    private final EmailAddressFinder emailAddressFinder;
+
+
+    public CaseOfficerReasonForAppealSubmittedPersonalisation(
+        @NotNull(message = "reasonsForAppealSubmittedCaseOfficerTemplateId cannot be null") @Value("${govnotify.template.reasonsForAppealSubmittedCaseOfficer}") String reasonsForAppealSubmittedCaseOfficerTemplateId,
+        @Value("${iaCcdFrontendUrl}") String iaCcdFrontendUrl,
+        EmailAddressFinder emailAddressFinder
+    ) {
+        this.reasonsForAppealSubmittedCaseOfficerTemplateId = reasonsForAppealSubmittedCaseOfficerTemplateId;
+        this.iaCcdFrontendUrl = iaCcdFrontendUrl;
+        this.emailAddressFinder = emailAddressFinder;
+    }
+
+    @Override
+    public String getTemplateId() {
+        return reasonsForAppealSubmittedCaseOfficerTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        return Collections.singleton(emailAddressFinder.getEmailAddress(asylumCase));
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_REASONS_FOR_APPEAL_SUBMITTED_CASE_OFFICER";
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase cannot be null");
+
+        return
+            ImmutableMap
+                .<String, String>builder()
+                .put("Appeal Ref Number", asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+                .put("Appellant Given names", asylumCase.read(APPELLANT_GIVEN_NAMES, String.class).orElse(""))
+                .put("Appellant Family name", asylumCase.read(APPELLANT_FAMILY_NAME, String.class).orElse(""))
+                .put("Hyperlink to service", iaCcdFrontendUrl)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/RecipientsFinder.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/RecipientsFinder.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.service;
+
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.SUBSCRIPTIONS;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo.YES;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.NotificationType;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.Subscriber;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
+
+@Service
+public class RecipientsFinder {
+
+    public Set<String> findAll(
+        AsylumCase asylumCase,
+        NotificationType notificationType) {
+
+        final Optional<List<IdValue<Subscriber>>> maybeSubscribers = asylumCase.read(SUBSCRIPTIONS);
+
+        switch (notificationType) {
+            case SMS:
+                return maybeSubscribers.orElse(Collections.emptyList()).stream()
+                    .filter(subscriber -> YES.equals(subscriber.getValue().getWantsSms()))
+                    .map(subscriber -> subscriber.getValue().getMobileNumber())
+                    .collect(Collectors.toSet());
+
+            case EMAIL:
+                return maybeSubscribers
+                    .orElse(Collections.emptyList()).stream()
+                    .filter(subscriber -> YES.equals(subscriber.getValue().getWantsEmail()))
+                    .map(subscriber -> subscriber.getValue().getEmail()).collect(Collectors.toSet());
+
+            default:
+                throw new IllegalArgumentException("Notification type must be one of 'SMS', 'EMAIL'");
+
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -9,20 +9,13 @@ import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.NotificationSender;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerReviewHearingRequirementsPersonalisation;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appellant.email.AppellantSubmitAppealPersonalisationEmail;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appellant.sms.AppellantSubmitAppealPersonalisationSms;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.*;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appellant.email.*;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appellant.sms.*;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.caseofficer.*;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.homeoffice.HomeOfficeAppealOutcomePersonalisation;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.homeoffice.HomeOfficeEditListingPersonalisation;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.homeoffice.HomeOfficeEndAppealPersonalisation;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.homeoffice.HomeOfficeHearingBundleReadyPersonalisation;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.homeoffice.HomeOfficeListCasePersonalisation;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.homeoffice.HomeOfficeRecordApplicationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.homeoffice.*;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.legalrepresentative.*;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent.RespondentDirectionPersonalisation;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent.RespondentEvidenceDirectionPersonalisation;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent.RespondentNonStandardDirectionPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent.*;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.EmailNotificationGenerator;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.NotificationGenerator;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.NotificationIdAppender;
@@ -132,8 +125,8 @@ public class NotificationGeneratorConfiguration {
         );
     }
 
-    @Bean("uploadRespondentNotificationGenerator")
-    public List<NotificationGenerator> uploadRespondentNotificationGenerator(
+    @Bean("uploadRespondentEvidenceRepNotificationGenerator")
+    public List<NotificationGenerator> uploadRespondentEvidenceRepNotificationGenerator(
         LegalRepresentativeUploadRespondentEvidencePersonalisation legalRepresentativeUploadRespondentEvidencePersonalisation,
         NotificationSender notificationSender,
         NotificationIdAppender notificationIdAppender) {
@@ -141,6 +134,28 @@ public class NotificationGeneratorConfiguration {
         return Arrays.asList(
             new EmailNotificationGenerator(
                 newArrayList(legalRepresentativeUploadRespondentEvidencePersonalisation),
+                notificationSender,
+                notificationIdAppender
+            )
+        );
+    }
+
+    @Bean("uploadRespondentEvidenceAipNotificationGenerator")
+    public List<NotificationGenerator> uploadRespondentEvidenceAipNotificationGenerator(
+        CaseOfficerReasonForAppealSubmittedPersonalisation caseOfficerReasonForAppealSubmittedPersonalisation,
+        AppellantReasonsForAppealSubmittedPersonalisationEmail appellantReasonsForAppealSubmittedPersonalisationEmail,
+        AppellantReasonsForAppealSubmittedPersonalisationSms appellantReasonsForAppealSubmittedPersonalisationSms,
+        NotificationSender notificationSender,
+        NotificationIdAppender notificationIdAppender) {
+
+        return Arrays.asList(
+            new EmailNotificationGenerator(
+                newArrayList(caseOfficerReasonForAppealSubmittedPersonalisation, appellantReasonsForAppealSubmittedPersonalisationEmail),
+                notificationSender,
+                notificationIdAppender
+            ),
+            new SmsNotificationGenerator(
+                newArrayList(appellantReasonsForAppealSubmittedPersonalisationSms),
                 notificationSender,
                 notificationIdAppender
             )

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -166,13 +166,31 @@ public class NotificationHandlerConfiguration {
     }
 
     @Bean
-    public PreSubmitCallbackHandler<AsylumCase> uploadRespondentNotificationHandler(
-        @Qualifier("uploadRespondentNotificationGenerator") List<NotificationGenerator> notificationGenerators) {
+    public PreSubmitCallbackHandler<AsylumCase> uploadRespondentEvidenceRepNotificationHandler(
+        @Qualifier("uploadRespondentEvidenceRepNotificationGenerator") List<NotificationGenerator> notificationGenerators) {
 
         return new NotificationHandler(
             (callbackStage, callback) ->
                 callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-                    && callback.getEvent() == Event.UPLOAD_RESPONDENT_EVIDENCE,
+                    && callback.getEvent() == Event.UPLOAD_RESPONDENT_EVIDENCE
+                    && callback.getCaseDetails().getCaseData()
+                    .read(JOURNEY_TYPE, JourneyType.class)
+                    .map(type -> type == REP).orElse(true),
+            notificationGenerators
+        );
+    }
+
+    @Bean
+    public PreSubmitCallbackHandler<AsylumCase> uploadRespondentEvidenceAipNotificationHandler(
+        @Qualifier("uploadRespondentEvidenceAipNotificationGenerator") List<NotificationGenerator> notificationGenerators) {
+
+        return new NotificationHandler(
+            (callbackStage, callback) ->
+                callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                    && callback.getEvent() == Event.UPLOAD_RESPONDENT_EVIDENCE
+                    && callback.getCaseDetails().getCaseData()
+                    .read(JOURNEY_TYPE, JourneyType.class)
+                    .map(type -> type == AIP).orElse(false),
             notificationGenerators
         );
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -57,6 +57,9 @@ govnotify.template.submittedHearingRequirementsCaseOfficerTemplateId: aa36afd2-2
 
 govnotify.template.appealSubmittedAppellant.email: b53d6e97-b7d9-4112-9669-9db81e563506
 govnotify.template.appealSubmittedAppellant.sms: 2cc4d346-cfb6-4ea9-93b3-c3f1f4f56491
+govnotify.template.reasonsForAppealSubmittedAppellant.email: 91ab0576-f0cc-412f-aadf-ad260fee1428
+govnotify.template.reasonsForAppealSubmittedAppellant.sms: 33758f88-eb3c-469d-8c49-ca3f9fa69a6d
+govnotify.template.reasonsForAppealSubmittedCaseOfficer: 2e3d6dfb-409d-4b45-a50b-0703c47341ea
 
 govnotify.baseUrl: "https://api.notifications.service.gov.uk"
 
@@ -94,6 +97,7 @@ security:
       - "startAppeal"
       - "editAppeal"
       - "submitAppeal"
+      - "uploadRespondentEvidence"
     caseworker-ia-legalrep-solicitor:
       - "startAppeal"
       - "editAppeal"

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantReasonsForAppealSubmittedPersonalisationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantReasonsForAppealSubmittedPersonalisationEmailTest.java
@@ -1,0 +1,123 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appellant.email;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPELLANT_FAMILY_NAME;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPELLANT_GIVEN_NAMES;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.HOME_OFFICE_REFERENCE_NUMBER;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.NotificationType;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.RecipientsFinder;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class AppellantReasonsForAppealSubmittedPersonalisationEmailTest {
+
+    @Mock AsylumCase asylumCase;
+    @Mock RecipientsFinder recipientsFinder;
+
+    private Long caseId = 12345L;
+    private String emailTemplateId = "someEmailTemplateId";
+    private String iaAipFrontendUrl = "http://localhost";
+
+    private String mockedAppealReferenceNumber = "someReferenceNumber";
+    private String mockedAppealHomeOfficeReferenceNumber = "someHomeOfficeReferenceNumber";
+    private String mockedAppellantGivenNames = "someAppellantGivenNames";
+    private String mockedAppellantFamilyName = "someAppellantFamilyName";
+    private String mockedAppellantEmailAddress = "appelant@example.net";
+
+    private AppellantReasonsForAppealSubmittedPersonalisationEmail appellantReasonsForAppealSubmittedPersonalisationEmail;
+
+    @Before
+    public void setup() {
+
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(mockedAppealReferenceNumber));
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(mockedAppealHomeOfficeReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(mockedAppellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(mockedAppellantFamilyName));
+
+        appellantReasonsForAppealSubmittedPersonalisationEmail = new AppellantReasonsForAppealSubmittedPersonalisationEmail(
+            emailTemplateId,
+            iaAipFrontendUrl,
+            recipientsFinder
+        );
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        assertEquals(emailTemplateId, appellantReasonsForAppealSubmittedPersonalisationEmail.getTemplateId());
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        assertEquals(caseId + "_REASONS_FOR_APPEAL_SUBMITTED_APPELLANT_AIP_EMAIL", appellantReasonsForAppealSubmittedPersonalisationEmail.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address_list_from_subscribers_in_asylum_case() {
+
+        when(recipientsFinder.findAll(asylumCase, NotificationType.EMAIL)).thenReturn(Collections.singleton(mockedAppellantEmailAddress));
+
+        assertTrue(appellantReasonsForAppealSubmittedPersonalisationEmail.getRecipientsList(asylumCase).contains(mockedAppellantEmailAddress));
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(() -> appellantReasonsForAppealSubmittedPersonalisationEmail.getRecipientsList(null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given() {
+
+        final String dueDate = LocalDate.now().plusDays(14)
+            .format(DateTimeFormatter.ofPattern("d MMM yyyy"));
+
+        Map<String, String> personalisation = appellantReasonsForAppealSubmittedPersonalisationEmail.getPersonalisation(asylumCase);
+
+        assertEquals(mockedAppealReferenceNumber, personalisation.get("Appeal Ref Number"));
+        assertEquals(mockedAppealHomeOfficeReferenceNumber, personalisation.get("HO Ref Number"));
+        assertEquals(mockedAppellantGivenNames, personalisation.get("Given names"));
+        assertEquals(mockedAppellantFamilyName, personalisation.get("Family name"));
+        assertEquals(dueDate, personalisation.get("due date"));
+        assertEquals(iaAipFrontendUrl, personalisation.get("Hyperlink to service"));
+
+    }
+
+    @Test
+    public void should_return_personalisation_when_only_mandatory_information_given() {
+
+        final String dueDate = LocalDate.now().plusDays(14)
+            .format(DateTimeFormatter.ofPattern("d MMM yyyy"));
+
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.empty());
+
+        Map<String, String> personalisation = appellantReasonsForAppealSubmittedPersonalisationEmail.getPersonalisation(asylumCase);
+
+        assertEquals("", personalisation.get("Appeal Ref Number"));
+        assertEquals("", personalisation.get("HO Ref Number"));
+        assertEquals("", personalisation.get("Given names"));
+        assertEquals("", personalisation.get("Family name"));
+        assertEquals(dueDate, personalisation.get("due date"));
+        assertEquals(iaAipFrontendUrl, personalisation.get("Hyperlink to service"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/sms/AppellantReasonsForAppealSubmittedPersonalisationSmsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/sms/AppellantReasonsForAppealSubmittedPersonalisationSmsTest.java
@@ -1,0 +1,115 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appellant.sms;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.NotificationType;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.RecipientsFinder;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class AppellantReasonsForAppealSubmittedPersonalisationSmsTest {
+
+    @Mock
+    AsylumCase asylumCase;
+    @Mock
+    RecipientsFinder recipientsFinder;
+
+    private Long caseId = 12345L;
+    private String smsTemplateId = "someSmsTemplateId";
+    private String iaAipFrontendUrl = "http://localhost";
+
+    private String mockedAppealReferenceNumber = "someReferenceNumber";
+    private String mockedAppellantMobilePhone = "07123456789";
+
+    private AppellantReasonsForAppealSubmittedPersonalisationSms appellantReasonsForAppealSubmittedPersonalisationSms;
+
+    @Before
+    public void setup() {
+
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(mockedAppealReferenceNumber));
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(mockedAppealReferenceNumber));
+
+        appellantReasonsForAppealSubmittedPersonalisationSms = new AppellantReasonsForAppealSubmittedPersonalisationSms(
+            smsTemplateId,
+            iaAipFrontendUrl,
+            recipientsFinder
+        );
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        Assert.assertEquals(smsTemplateId, appellantReasonsForAppealSubmittedPersonalisationSms.getTemplateId());
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        Assert.assertEquals(caseId + "_REASONS_FOR_APPEAL_SUBMITTED_APPELLANT_AIP_SMS", appellantReasonsForAppealSubmittedPersonalisationSms.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_throw_exception_on_recipients_when_case_is_null() {
+
+        assertThatThrownBy(() -> appellantReasonsForAppealSubmittedPersonalisationSms.getRecipientsList(null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_return_given_mobile_mobile_list_from_subscribers_in_asylum_case() {
+
+        when(recipientsFinder.findAll(asylumCase, NotificationType.SMS)).thenReturn(Collections.singleton(mockedAppellantMobilePhone));
+
+        assertTrue(appellantReasonsForAppealSubmittedPersonalisationSms.getRecipientsList(asylumCase).contains(mockedAppellantMobilePhone));
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(() -> appellantReasonsForAppealSubmittedPersonalisationSms.getPersonalisation((AsylumCase) null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given() {
+        final String dueDate = LocalDate.now().plusDays(14)
+            .format(DateTimeFormatter.ofPattern("d MMM yyyy"));
+
+        Map<String, String> personalisation = appellantReasonsForAppealSubmittedPersonalisationSms.getPersonalisation(asylumCase);
+        assertEquals(mockedAppealReferenceNumber, personalisation.get("Appeal Ref Number"));
+        assertEquals(dueDate, personalisation.get("due date"));
+        assertEquals(iaAipFrontendUrl, personalisation.get("Hyperlink to service"));
+
+    }
+
+    @Test
+    public void should_return_personalisation_when_only_mandatory_information_given() {
+        final String dueDate = LocalDate.now().plusDays(14)
+            .format(DateTimeFormatter.ofPattern("d MMM yyyy"));
+
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.empty());
+
+        Map<String, String> personalisation = appellantReasonsForAppealSubmittedPersonalisationSms.getPersonalisation(asylumCase);
+
+        assertEquals("", personalisation.get("Appeal Ref Number"));
+        assertEquals(dueDate, personalisation.get("due date"));
+        assertEquals(iaAipFrontendUrl, personalisation.get("Hyperlink to service"));
+
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerReasonForAppealSubmittedPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerReasonForAppealSubmittedPersonalisationTest.java
@@ -1,0 +1,119 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.caseofficer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPELLANT_FAMILY_NAME;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPELLANT_GIVEN_NAMES;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CaseOfficerReasonForAppealSubmittedPersonalisationTest {
+
+    @Mock AsylumCase asylumCase;
+    @Mock EmailAddressFinder emailAddressFinder;
+
+    private Long caseId = 12345L;
+    private String templateId = "someTemplateId";
+    private String hearingCentreEmailAddress = "hearingCentre@example.com";
+    private String appealReferenceNumber = "someReferenceNumber";
+    private String appellantGivenName = "Pablo";
+    private String appellantFamilyName = "Jimenez";
+    private String iaCcdFrontendUrl = "http://localhost";
+
+
+    private CaseOfficerReasonForAppealSubmittedPersonalisation caseOfficerReasonForAppealSubmittedPersonalisation;
+
+    @Before
+    public void setUp() {
+        when(emailAddressFinder.getEmailAddress(asylumCase)).thenReturn(hearingCentreEmailAddress);
+
+        when(asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenName));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+
+        caseOfficerReasonForAppealSubmittedPersonalisation =
+            new CaseOfficerReasonForAppealSubmittedPersonalisation(
+                templateId,
+                iaCcdFrontendUrl,
+                emailAddressFinder
+            );
+
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        assertEquals(templateId, caseOfficerReasonForAppealSubmittedPersonalisation.getTemplateId());
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        assertEquals(caseId + "_REASONS_FOR_APPEAL_SUBMITTED_CASE_OFFICER", caseOfficerReasonForAppealSubmittedPersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address_from_asylum_case() {
+        assertTrue(hearingCentreEmailAddress, caseOfficerReasonForAppealSubmittedPersonalisation.getRecipientsList(asylumCase).contains(hearingCentreEmailAddress));
+    }
+
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(() -> caseOfficerReasonForAppealSubmittedPersonalisation.getPersonalisation((AsylumCase) null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("asylumCase cannot be null");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given() {
+
+        final Map<String, String> expectedPersonalisation =
+            ImmutableMap
+                .<String, String>builder()
+                .put("Appeal Ref Number", appealReferenceNumber)
+                .put("Appellant Given names", appellantGivenName)
+                .put("Appellant Family name",appellantFamilyName)
+                .put("Hyperlink to service", iaCcdFrontendUrl)
+                .build();
+
+        Map<String, String> actualPersonalisation = caseOfficerReasonForAppealSubmittedPersonalisation.getPersonalisation(asylumCase);
+
+        assertThat(actualPersonalisation).isEqualTo(expectedPersonalisation);
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_mandatory_information_given() {
+
+        final Map<String, String> expectedPersonalisation =
+            ImmutableMap
+                .<String, String>builder()
+                .put("Appeal Ref Number", "")
+                .put("Appellant Given names", "")
+                .put("Appellant Family name", "")
+                .put("Hyperlink to service", iaCcdFrontendUrl)
+                .build();
+
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.empty());
+
+        Map<String, String> actualPersonalisation = caseOfficerReasonForAppealSubmittedPersonalisation.getPersonalisation(asylumCase);
+
+        assertThat(actualPersonalisation).isEqualTo(expectedPersonalisation);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/RecipientsFinderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/RecipientsFinderTest.java
@@ -1,0 +1,94 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.SUBSCRIPTIONS;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.NotificationType.EMAIL;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.NotificationType.SMS;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.Subscriber;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.SubscriberType;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
+
+@RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("unchecked")
+public class RecipientsFinderTest {
+
+    private final RecipientsFinder recipientsFinder = new RecipientsFinder();
+    @Mock
+    private AsylumCase asylumCase;
+
+    private String mockedAppellantEmailAddress = "appelant@example.net";
+    private String mockedAppellantMobilePhone = "07123456789";
+
+    @Test
+    public void should_find_all_email_recipients() {
+
+        Subscriber subscriber = new Subscriber(
+            SubscriberType.APPELLANT, //subscriberType
+            mockedAppellantEmailAddress, //email
+            YesOrNo.YES, // wants email
+            "", //mobileNumber
+            YesOrNo.NO // wants sms
+        );
+
+        when(asylumCase.read(SUBSCRIPTIONS)).thenReturn(Optional.of(Collections.singletonList(new IdValue<>("foo", subscriber))));
+
+        Set<String> result = recipientsFinder.findAll(asylumCase, EMAIL);
+
+        assertNotNull(result);
+        assertTrue(result.contains(subscriber.getEmail()));
+    }
+
+    @Test
+    public void should_return_empty_set_if_emails_not_found() {
+
+        when(asylumCase.read(SUBSCRIPTIONS)).thenReturn(Optional.of(Collections.emptyList()));
+
+        Set<String> result = recipientsFinder.findAll(asylumCase, EMAIL);
+
+        assertNotNull(result);
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void should_find_all_mobile_phone_recipients() {
+
+        Subscriber subscriber = new Subscriber(
+            SubscriberType.APPELLANT, //subscriberType
+            "", //email
+            YesOrNo.NO, // wants email
+            mockedAppellantMobilePhone, //mobileNumber
+            YesOrNo.YES // wants sms
+        );
+
+        when(asylumCase.read(SUBSCRIPTIONS)).thenReturn(Optional.of(Collections.singletonList(new IdValue<>("foo", subscriber))));
+
+        Set<String> result = recipientsFinder.findAll(asylumCase, SMS);
+
+        assertNotNull(result);
+        assertTrue(result.contains(subscriber.getMobileNumber()));
+    }
+
+    @Test
+    public void should_return_empty_set_if_mobile_phone_not_found() {
+
+        when(asylumCase.read(SUBSCRIPTIONS)).thenReturn(Optional.of(Collections.emptyList()));
+
+        Set<String> result = recipientsFinder.findAll(asylumCase, SMS);
+
+        assertNotNull(result);
+        assertEquals(0, result.size());
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-2265
https://tools.hmcts.net/jira/browse/RIA-2270

### Change description ###

RIA-2265: Adds tcw notification of reason for appeal submission which is triggered on the event uploadRespondentEvidence

RIA-2270: Adds appellant notifications (email and sms) of reason for appeal submission which is triggered on the event uploadRespondentEvidence

Adds functional tests to cover acceptance criteria and unit tests


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
