### PR TITLE
email vault test -- do not merge

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-1463-send-appeal-allowed-decision-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-1463-send-appeal-allowed-decision-notification.json
@@ -38,7 +38,7 @@
     "notifications": [
       {
         "reference": "1001_APPEAL_OUTCOME_HOME_OFFICE",
-        "recipient": "{$allowedAppealHomeOfficeEmailAddress}",
+        "recipient": "HOAllowedDeterminations.ccd@gmail.com",
         "subject": "Immigration and Asylum appeal: decision and reasons",
         "body": [
           "Appeal reference number: PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-1463-send-appeal-dismissed-decision-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-1463-send-appeal-dismissed-decision-notification.json
@@ -38,7 +38,7 @@
     "notifications": [
       {
         "reference": "1003_APPEAL_OUTCOME_HOME_OFFICE",
-        "recipient": "{$dismissedAppealHomeOfficeEmailAddress}",
+        "recipient": "HODismissedDeterminations.ccd@gmail.com",
         "subject": "Immigration and Asylum appeal: decision and reasons",
         "body": [
           "Appeal reference number: PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-1976-appeal-submitted-notification-hatton-cross-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-1976-appeal-submitted-notification-hatton-cross-hearing-centre.json
@@ -33,7 +33,7 @@
     "notifications": [
       {
         "reference": "1007_APPEAL_SUBMITTED_CASE_OFFICER",
-        "recipient": "{$hearingCentreEmailAddresses.hattonCross}",
+        "recipient": "hatton-cross@example.com",
         "subject": "Asylum appeal: new appeal submitted",
         "body": [
           "Appeal reference number: PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-1976-case-submitted-notification-to-case-officer-hatton-cross.json
+++ b/src/functionalTest/resources/scenarios/RIA-1976-case-submitted-notification-to-case-officer-hatton-cross.json
@@ -33,7 +33,7 @@
     "notifications": [
       {
         "reference": "1005_CASE_SUBMITTED_CASE_OFFICER",
-        "recipient": "{$hearingCentreEmailAddresses.hattonCross}",
+        "recipient": "hatton-cross@example.com",
         "subject": "Immigration and Asylum appeal: Appeal Skeleton Argument submitted",
         "body": [
           "Appeal reference number: PA/12345/2019",

--- a/src/main/resources/application-email-addresses.yaml
+++ b/src/main/resources/application-email-addresses.yaml
@@ -5,7 +5,7 @@ hearingCentreEmailAddresses:
   taylorHouse: ${IA_HEARING_CENTRE_TAYLOR_HOUSE_EMAIL:tcw.taylorhouse@example.com}
   northShields: ${IA_HEARING_CENTRE_NORTH_SHIELDS_EMAIL:TCWNorthShieldsIA@example.com}
   birmingham: ${IA_HEARING_CENTRE_BIRMINGHAM_EMAIL:IACBirminghamTCW@example.com}
-  hattonCross: ${IA_HEARING_CENTRE_HATTON_CROSS_EMAIL:TBD_HC_HattonCross@example.com}
+  hattonCross: ${IA_HEARING_CENTRE_HATTON_CROSS_EMAIL:junk@test.com}
   glasgow: ${IA_HEARING_CENTRE_GLASGOW_EMAIL:TBD_HC_Glasgow@example.com}
 
 homeOfficeEmailAddresses:
@@ -29,8 +29,8 @@ hearingCentreTelephoneNumber:
   glasgow: ${IA_HEARING_CENTRE_GLASGOW_TELEPHONE:0300 123 1711}
 
 endAppealHomeOfficeEmailAddress: ${IA_HOME_OFFICE_END_APPEAL_EMAIL:ReformpbAPC@example.com}
-allowedAppealHomeOfficeEmailAddress: ${IA_HOME_OFFICE_ALLOWED_APPEAL_EMAIL:HOAllowedDeterminations@example.com}
-dismissedAppealHomeOfficeEmailAddress: ${IA_HOME_OFFICE_DISMISSED_APPEAL_EMAIL:HODismissedDeterminations@example.com}
+allowedAppealHomeOfficeEmailAddress: ${IA_HOME_OFFICE_ALLOWED_APPEAL_EMAIL:junk@test.com}
+dismissedAppealHomeOfficeEmailAddress: ${IA_HOME_OFFICE_DISMISSED_APPEAL_EMAIL:junk@test.com}
 
 reviewHearingRequirementsAdminOfficerEmailAddress: ${IA_ADMIN_OFFICER_REVIEW_HEARING_REQUIREMENTS_EMAIL:IACReformlisting@example.com}
 


### PR DESCRIPTION
This is a test to see if the the code is in fact pulling correct values from the vault, rather than using the default values set in the _application-email-address.yaml_ file. 

Email addresses currently affected include:

- hearing-centre-hatton-cross-email
- home-office-allowed-appeal-email
- home-office-dismissed-appeal-email

Functional tests should pass if all in order.