### PR TITLE
Launch Darkly example

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -228,6 +228,8 @@ dependencies {
     compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
     compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
 
+    compile group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '4.12.0'
+
     compile group: 'uk.gov.hmcts.reform', name: 'logging-spring', version: versions.reformLogging
     compile group: 'uk.gov.hmcts.reform', name: 'logging-httpcomponents', version: versions.reformLogging
     compile group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging

--- a/src/integrationTest/java/uk/gov/hmcts/reform/iacasenotificationsapi/LaunchDarklyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/iacasenotificationsapi/LaunchDarklyTest.java
@@ -1,0 +1,67 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi;
+
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.UserDetailsProvider;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.UserDetails;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PreSubmitCallbackDispatcher;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.controllers.PreSubmitCallbackController;
+
+
+/*
+To get this to work you will have to set an env variable called LAUNCH_DARKLY_SDK_KEY in your env
+Also this assumes there is a feature toggle called some-feature-key switched on the IAC Launch Darkly project
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = Application.class, webEnvironment = MOCK)
+public class LaunchDarklyTest {
+
+    @MockBean private UserDetailsProvider userDetailsProvider;
+    @MockBean private PreSubmitCallbackDispatcher<AsylumCase> callbackDispatcher;
+    @Mock private Callback<AsylumCase> callback;
+    @Mock private CaseDetails<AsylumCase> caseDetails;
+    @Mock private AsylumCase asylumCase;
+    @Mock private UserDetails userDetails;
+
+    @Autowired
+    private PreSubmitCallbackController preSubmitCallbackController;
+
+    @Before
+    public void setUp() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getEvent()).thenReturn(Event.END_APPEAL);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(caseDetails.getId()).thenReturn(12345L);
+    }
+
+    @Test
+    public void should_get_real_feature_toggle_value_and_skip_req_to_dispatcher() {
+
+        when(userDetailsProvider.getUserDetails()).thenReturn(userDetails);
+        when(userDetails.getId()).thenReturn("123");
+        when(userDetails.getForename()).thenReturn("forename");
+        when(userDetails.getSurname()).thenReturn("surname");
+        when(userDetails.getEmailAddress()).thenReturn("some-email");
+
+        preSubmitCallbackController.ccdAboutToSubmit(callback);
+
+        //Check no interactions with dispatcher
+        verifyZeroInteractions(callbackDispatcher);
+    }
+
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/Application.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/Application.java
@@ -1,5 +1,8 @@
 package uk.gov.hmcts.reform.iacasenotificationsapi;
 
+import com.launchdarkly.client.LDClient;
+import java.io.IOException;
+import javax.annotation.PreDestroy;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
@@ -16,8 +19,19 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 @SuppressWarnings("HideUtilityClassConstructor") // Spring needs a constructor, its not a utility class
 public class Application {
 
+    private final LDClient ldClient;
+
+    public Application(LDClient ldClient) {
+        this.ldClient = ldClient;
+    }
+
     public static void main(final String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    @PreDestroy
+    public void onShutdown() throws IOException {
+        ldClient.close();
     }
 }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/FeatureToggler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/FeatureToggler.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.service;
+
+public interface FeatureToggler {
+
+    boolean getValue(String key, Boolean defaultValue);
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/clients/LaunchDarklyFeatureToggler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/clients/LaunchDarklyFeatureToggler.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients;
+
+import com.launchdarkly.client.LDClient;
+import com.launchdarkly.client.LDUser;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.UserDetailsProvider;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.UserDetails;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.FeatureToggler;
+
+@Service
+public class LaunchDarklyFeatureToggler implements FeatureToggler {
+
+    private LDClient ldClient;
+    private UserDetailsProvider userDetailsProvider;
+
+    public LaunchDarklyFeatureToggler(LDClient ldClient,
+                                      UserDetailsProvider userDetailsProvider) {
+        this.ldClient = ldClient;
+        this.userDetailsProvider = userDetailsProvider;
+    }
+
+    public boolean getValue(String key, Boolean defaultValue) {
+
+        UserDetails userDetails = userDetailsProvider.getUserDetails();
+
+        return ldClient.boolVariation(
+            key,
+            new LDUser.Builder(userDetails.getId())
+                .firstName(userDetails.getForename())
+                .lastName(userDetails.getSurname())
+                .email(userDetails.getEmailAddress())
+                .build(),
+            defaultValue
+        );
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/FeatureToggleConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/FeatureToggleConfiguration.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.config;
+
+import com.launchdarkly.client.LDClient;
+import com.launchdarkly.client.LDConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeatureToggleConfiguration {
+
+    @Value("${launch-darkly-sdk-key}")
+    private String sdkKey;
+
+    @Bean
+    public LDConfig ldConfig() {
+        return new LDConfig.Builder()
+            .connectTimeout(3)
+            .socketTimeout(3)
+            .build();
+    }
+
+    @Bean
+    public LDClient ldClient(LDConfig ldConfig) {
+        return new LDClient(sdkKey, ldConfig);
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -203,3 +203,6 @@ respondentEmailAddresses:
   nonStandardDirectionUntilListing: ${IA_RESPONDENT_NON_STANDARD_DIRECTION_UNTIL_LISTING_EMAIL:respondent@example.com}
   respondentEvidenceDirection: ${IA_RESPONDENT_EVIDENCE_DIRECTION_EMAIL:respondent@example.com}
   respondentReviewDirection: ${IA_RESPONDENT_REVIEW_DIRECTION_EMAIL:respondent-lart@example.com}
+
+# Launch Darkly config
+launch-darkly-sdk-key: ${LAUNCH_DARKLY_SDK_KEY:sdk-key}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/controllers/PreSubmitCallbackControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/controllers/PreSubmitCallbackControllerTest.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.CaseDetail
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.FeatureToggler;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PreSubmitCallbackDispatcher;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -24,6 +25,8 @@ public class PreSubmitCallbackControllerTest {
     @Mock private PreSubmitCallbackResponse<AsylumCase> callbackResponse;
     @Mock private Callback<AsylumCase> callback;
     @Mock private CaseDetails<AsylumCase> caseDetails;
+    @Mock private AsylumCase asylumCase;
+    @Mock private FeatureToggler featureToggler;
 
     private PreSubmitCallbackController preSubmitCallbackController;
 
@@ -31,7 +34,8 @@ public class PreSubmitCallbackControllerTest {
     public void setUp() {
         preSubmitCallbackController =
             new PreSubmitCallbackController(
-                callbackDispatcher
+                callbackDispatcher,
+                featureToggler
             );
     }
 
@@ -39,6 +43,7 @@ public class PreSubmitCallbackControllerTest {
     public void should_deserialize_about_to_start_callback_then_dispatch_then_return_response() {
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
 
         doReturn(callbackResponse)
             .when(callbackDispatcher)
@@ -59,6 +64,7 @@ public class PreSubmitCallbackControllerTest {
     public void should_deserialize_about_to_submit_callback_then_dispatch_then_return_response() {
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
 
         doReturn(callbackResponse)
             .when(callbackDispatcher)
@@ -78,7 +84,7 @@ public class PreSubmitCallbackControllerTest {
     @Test
     public void should_not_allow_null_constructor_arguments() {
 
-        assertThatThrownBy(() -> new PreSubmitCallbackController(null))
+        assertThatThrownBy(() -> new PreSubmitCallbackController(null, null))
             .hasMessage("callbackDispatcher must not be null")
             .isExactlyInstanceOf(NullPointerException.class);
     }


### PR DESCRIPTION
Example of Launch Darkly usage for a backend app including an integration test calling the IAC Launch Darkly project.

You'll need to set the test environment variable: `LAUNCH_DARKLY_SDK_KEY` in your env.

