### PR TITLE
RIA-2866 TCW review reasons for appeal

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DirectionTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DirectionTag.java
@@ -14,6 +14,7 @@ public enum DirectionTag {
     REQUEST_CASE_BUILDING("requestCaseBuilding"),
     REQUEST_RESPONSE_REVIEW("requestResponseReview"),
     REQUEST_RESPONSE_AMEND("requestResponseAmend"),
+    REQUEST_REASONS_FOR_APPEAL("requestReasonsForAppeal"),
 
     @JsonEnumDefaultValue
     NONE("");

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/Parties.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/Parties.java
@@ -6,7 +6,8 @@ public enum Parties {
 
     LEGAL_REPRESENTATIVE("legalRepresentative"),
     RESPONDENT("respondent"),
-    BOTH("both");
+    BOTH("both"),
+    APPELLANT("appellant");
 
     @JsonValue
     private final String id;

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DirectionTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DirectionTagTest.java
@@ -17,11 +17,12 @@ public class DirectionTagTest {
         assertEquals("requestCaseBuilding", DirectionTag.REQUEST_CASE_BUILDING.toString());
         assertEquals("requestResponseReview", DirectionTag.REQUEST_RESPONSE_REVIEW.toString());
         assertEquals("requestResponseAmend", DirectionTag.REQUEST_RESPONSE_AMEND.toString());
+        assertEquals("requestReasonsForAppeal", DirectionTag.REQUEST_REASONS_FOR_APPEAL.toString());
         assertEquals("", DirectionTag.NONE.toString());
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(10, DirectionTag.values().length);
+        assertEquals(11, DirectionTag.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/PartiesTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/PartiesTest.java
@@ -11,10 +11,11 @@ public class PartiesTest {
         assertEquals("legalRepresentative", Parties.LEGAL_REPRESENTATIVE.toString());
         assertEquals("respondent", Parties.RESPONDENT.toString());
         assertEquals("both", Parties.BOTH.toString());
+        assertEquals("appellant", Parties.APPELLANT.toString());
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(3, Parties.values().length);
+        assertEquals(4, Parties.values().length);
     }
 }


### PR DESCRIPTION
Added appellant to the Parties enum and requestReasonsForAppeal to
DirectionTag enum as we are now sending a direction the respondent when
an aip case is sent to the respondent to review.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-2866

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
