### PR TITLE
RIA-1897: Sending a notification to legal rep when case officer requests HO evidence

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-893-RIA-1897-send-home-office-evidence-direction.json
+++ b/src/functionalTest/resources/scenarios/RIA-893-RIA-1897-send-home-office-evidence-direction.json
@@ -1,5 +1,5 @@
 {
-  "description": "RIA-893 Send Home Office evidence direction",
+  "description": "RIA-893 RIA-1897 Send Home Office evidence direction",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "CaseOfficer",
@@ -49,6 +49,10 @@
           {
             "id": "1003_RESPONDENT_EVIDENCE_DIRECTION",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1003_EVIDENCE_DIRECTION_LEGAL_REPRESENTATIVE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
         ]
       }
@@ -63,6 +67,17 @@
           "A1234567",
           "Talha Awan",
           "Send your evidence",
+          "{$TODAY+14|d MMM yyyy}"
+        ]
+      },
+      {
+        "reference": "1003_EVIDENCE_DIRECTION_LEGAL_REPRESENTATIVE",
+        "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
+        "subject": "Immigration and Asylum appeal: direction sent to the Home Office",
+        "body": [
+          "PA/12345/2019",
+          "CASE001",
+          "Talha Awan",
           "{$TODAY+14|d MMM yyyy}"
         ]
       }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeRequestHomeOfficeBundlePersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeRequestHomeOfficeBundlePersonalisation.java
@@ -1,0 +1,78 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.legalrepresentative;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPELLANT_FAMILY_NAME;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPELLANT_GIVEN_NAMES;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.LEGAL_REPRESENTATIVE_EMAIL_ADDRESS;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.LEGAL_REP_REFERENCE_NUMBER;
+
+import com.google.common.collect.ImmutableMap;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.Direction;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DirectionTag;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DirectionFinder;
+
+@Service
+public class LegalRepresentativeRequestHomeOfficeBundlePersonalisation implements EmailNotificationPersonalisation {
+
+    private final String legalRepEvidenceDirectionTemplateId;
+    private final DirectionFinder directionFinder;
+
+    public LegalRepresentativeRequestHomeOfficeBundlePersonalisation(
+        @Value("${govnotify.template.requestRespondentEvidenceDirection.legalRep.email}") String legalRepEvidenceDirectionTemplateId,
+        DirectionFinder directionFinder) {
+
+        this.legalRepEvidenceDirectionTemplateId = legalRepEvidenceDirectionTemplateId;
+        this.directionFinder = directionFinder;
+    }
+
+    @Override
+    public String getTemplateId() {
+        return legalRepEvidenceDirectionTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        return Collections.singleton(asylumCase
+            .read(LEGAL_REPRESENTATIVE_EMAIL_ADDRESS, String.class)
+            .orElseThrow(() -> new IllegalStateException("legalRepresentativeEmailAddress is not present")));
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_EVIDENCE_DIRECTION_LEGAL_REPRESENTATIVE";
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        final Direction direction =
+            directionFinder
+                .findFirst(asylumCase, DirectionTag.RESPONDENT_EVIDENCE)
+                .orElseThrow(() -> new IllegalStateException("direction '" + DirectionTag.RESPONDENT_EVIDENCE + "' is not present"));
+
+        final String directionDueDate =
+            LocalDate
+                .parse(direction.getDateDue())
+                .format(DateTimeFormatter.ofPattern("d MMM yyyy"));
+
+        return ImmutableMap
+            .<String, String>builder()
+            .put("appealReferenceNumber", asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+            .put("legalRepReferenceNumber", asylumCase.read(LEGAL_REP_REFERENCE_NUMBER, String.class).orElse(""))
+            .put("appellantGivenNames", asylumCase.read(APPELLANT_GIVEN_NAMES, String.class).orElse(""))
+            .put("appellantFamilyName", asylumCase.read(APPELLANT_FAMILY_NAME, String.class).orElse(""))
+            .put("insertDate", directionDueDate)
+            .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -322,12 +322,16 @@ public class NotificationGeneratorConfiguration {
     @Bean("respondentEvidenceRepNotificationGenerator")
     public List<NotificationGenerator> respondentEvidenceRepNotificationGenerator(
         RespondentEvidenceDirectionPersonalisation respondentEvidenceDirectionPersonalisation,
+        LegalRepresentativeRequestHomeOfficeBundlePersonalisation legalRepresentativeRequestHomeOfficeBundlePersonalisation,
         NotificationSender notificationSender,
         NotificationIdAppender notificationIdAppender) {
 
-        return Arrays.asList(
+        return Collections.singletonList(
             new EmailNotificationGenerator(
-                newArrayList(respondentEvidenceDirectionPersonalisation),
+                newArrayList(
+                    respondentEvidenceDirectionPersonalisation,
+                    legalRepresentativeRequestHomeOfficeBundlePersonalisation
+                ),
                 notificationSender,
                 notificationIdAppender
             )

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,6 +44,8 @@ govnotify:
       appellant:
         email: 9c8ab848-b1f7-4dbe-9854-4922e94ece67
         sms: e805b3c5-b1e2-4ad1-9416-3298ca765738
+      legalRep:
+        email: 33430912-89d5-416d-8d49-52eae9ce82c3
       respondent:
         email: a1fee4a6-6650-4d91-8f9e-cd15944adef4
     respondentEvidenceSubmitted:

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeRequestHomeOfficeBundlePersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeRequestHomeOfficeBundlePersonalisationTest.java
@@ -1,0 +1,125 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.legalrepresentative;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPELLANT_FAMILY_NAME;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPELLANT_GIVEN_NAMES;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.LEGAL_REPRESENTATIVE_EMAIL_ADDRESS;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.LEGAL_REP_REFERENCE_NUMBER;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.Direction;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DirectionTag;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DirectionFinder;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LegalRepresentativeRequestHomeOfficeBundlePersonalisationTest {
+
+    @Mock AsylumCase asylumCase;
+    @Mock DirectionFinder directionFinder;
+    @Mock Direction direction;
+
+    private Long caseId = 12345L;
+    private String templateId = "someTemplateId";
+    private String directionDueDate = "2019-09-10";
+    private String expectedDirectionDueDate = "10 Oct 2019";
+
+    private String legalRepEmailAddress = "legalrep@example.com";
+
+    private String appealReferenceNumber = "someReferenceNumber";
+    private String legalRepRefNumber = "somelegalRepRefNumber";
+    private String appellantGivenNames = "someAppellantGivenNames";
+    private String appellantFamilyName = "someAppellantFamilyName";
+
+    private LegalRepresentativeRequestHomeOfficeBundlePersonalisation legalRepresentativeRequestHomeOfficeBundlePersonalisation;
+
+    @Before
+    public void setUp() {
+
+        when((direction.getDateDue())).thenReturn(directionDueDate);
+        when(directionFinder.findFirst(asylumCase, DirectionTag.RESPONDENT_EVIDENCE)).thenReturn(Optional.of(direction));
+
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(asylumCase.read(LEGAL_REP_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(legalRepRefNumber));
+        when(asylumCase.read(LEGAL_REPRESENTATIVE_EMAIL_ADDRESS, String.class)).thenReturn(Optional.of(legalRepEmailAddress));
+
+        legalRepresentativeRequestHomeOfficeBundlePersonalisation = new LegalRepresentativeRequestHomeOfficeBundlePersonalisation(
+            templateId,
+            directionFinder
+        );
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        assertEquals(templateId, legalRepresentativeRequestHomeOfficeBundlePersonalisation.getTemplateId());
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        assertEquals(caseId + "_EVIDENCE_DIRECTION_LEGAL_REPRESENTATIVE", legalRepresentativeRequestHomeOfficeBundlePersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address_from_asylum_case() {
+        assertTrue(legalRepresentativeRequestHomeOfficeBundlePersonalisation.getRecipientsList(asylumCase).contains(legalRepEmailAddress));
+    }
+
+    @Test
+    public void should_throw_exception_when_cannot_find_email_address_for_legal_rep() {
+        when(asylumCase.read(LEGAL_REPRESENTATIVE_EMAIL_ADDRESS, String.class)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> legalRepresentativeRequestHomeOfficeBundlePersonalisation.getRecipientsList(asylumCase))
+            .isExactlyInstanceOf(IllegalStateException.class)
+            .hasMessage("legalRepresentativeEmailAddress is not present");
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(() -> legalRepresentativeRequestHomeOfficeBundlePersonalisation.getPersonalisation((AsylumCase) null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given() {
+
+        final Map<String, String> expectedPersonalisation =
+            ImmutableMap
+                .<String, String>builder()
+                .put("appealReferenceNumber", appealReferenceNumber)
+                .put("legalRepReferenceNumber", legalRepRefNumber)
+                .put("appellantGivenNames", appellantGivenNames)
+                .put("appellantFamilyName", appellantGivenNames)
+                .put("insertDate", expectedDirectionDueDate)
+                .build();
+
+        Map<String, String> actualPersonalisation = legalRepresentativeRequestHomeOfficeBundlePersonalisation.getPersonalisation(asylumCase);
+
+        assertThat(actualPersonalisation).isEqualToComparingOnlyGivenFields(expectedPersonalisation);
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_direction_is_empty() {
+
+        when(directionFinder.findFirst(asylumCase, DirectionTag.RESPONDENT_EVIDENCE)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> legalRepresentativeRequestHomeOfficeBundlePersonalisation.getPersonalisation(asylumCase))
+            .isExactlyInstanceOf(IllegalStateException.class)
+            .hasMessage("direction 'respondentEvidence' is not present");
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-1897


### Change description ###
 - Added a new personalisation for legal rep which is sent when case officer requests the Home Office bundle from respondent.
 - Updated functional test to reflect the changes.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
