### PR TITLE
RIA-2959: Notifications sent during adjourn hearing without date event.

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-2959-adjourn-hearing-without-date.json
+++ b/src/functionalTest/resources/scenarios/RIA-2959-adjourn-hearing-without-date.json
@@ -1,0 +1,88 @@
+{
+  "description": "RIA-2959 Adjourn hearing without date",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 1001,
+      "eventId": "adjournHearingWithoutDate",
+      "state": "preHearing",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "adjournHearingWithoutDateReasons": "some reason",
+          "listCaseHearingCentre": "taylorHouse"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "listCaseHearingCentre": "taylorHouse",
+        "notificationsSent": [
+          {
+            "id": "1001_LEGAL_REPRESENTATIVE_ADJOURN_HEARING_WITHOUT_DATE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1001_RESPONDENT_ADJOURN_HEARING_WITHOUT_DATE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1001_CASE_OFFICER_ADJOURN_HEARING_WITHOUT_DATE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1001_ADJOURN_HEARING_WITHOUT_DATE_ADMIN_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "1001_LEGAL_REPRESENTATIVE_ADJOURN_HEARING_WITHOUT_DATE",
+        "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
+        "subject": "Immigration and Asylum appeal: Hearing adjourned",
+        "body": [
+          "PA/12345/2019",
+          "CASE001",
+          "Talha Awan",
+          "some reason"
+        ]
+      },
+      {
+        "reference": "1001_RESPONDENT_ADJOURN_HEARING_WITHOUT_DATE",
+        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: Hearing adjourned",
+        "body": [
+          "PA/12345/2019",
+          "A1234567",
+          "Talha Awan"
+        ]
+      },
+      {
+        "reference": "1001_CASE_OFFICER_ADJOURN_HEARING_WITHOUT_DATE",
+        "recipient": "{$hearingCentreEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: Hearing adjourned",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan"
+        ]
+      },
+      {
+        "reference": "1001_ADJOURN_HEARING_WITHOUT_DATE_ADMIN_OFFICER",
+        "recipient": "{$reviewHearingRequirementsAdminOfficerEmailAddress}",
+        "subject": "Immigration and Asylum appeal: Hearing adjourned",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-2959-adjourn-hearing-without-date.json
+++ b/src/functionalTest/resources/scenarios/RIA-2959-adjourn-hearing-without-date.json
@@ -11,7 +11,8 @@
         "template": "minimal-appeal-submitted.json",
         "replacements": {
           "adjournHearingWithoutDateReasons": "some reason",
-          "listCaseHearingCentre": "taylorHouse"
+          "listCaseHearingCentre": "taylorHouse",
+          "ariaListingReference": "LP/12345/2019"
         }
       }
     }
@@ -50,6 +51,7 @@
         "subject": "Immigration and Asylum appeal: Hearing adjourned",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "some reason"
@@ -61,6 +63,7 @@
         "subject": "Immigration and Asylum appeal: Hearing adjourned",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan"
         ]
@@ -71,6 +74,7 @@
         "subject": "Immigration and Asylum appeal: Hearing adjourned",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan"
         ]
       },
@@ -80,6 +84,7 @@
         "subject": "Immigration and Asylum appeal: Hearing adjourned",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan"
         ]
       }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AsylumCaseDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AsylumCaseDefinition.java
@@ -142,6 +142,10 @@ public enum AsylumCaseDefinition {
         "reviewTimeExtensionDecisionReason", new TypeReference<String>(){}),
     TIME_EXTENSIONS(
         "timeExtensions", new TypeReference<List<IdValue<TimeExtension>>>(){}),
+
+    ADJOURN_HEARING_WITHOUT_DATE_REASONS(
+        "adjournHearingWithoutDateReasons", new TypeReference<String>() {}),
+
     ;
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/Event.java
@@ -51,6 +51,7 @@ public enum Event {
     SUBMIT_CLARIFYING_QUESTION_ANSWERS("submitClarifyingQuestionAnswers"),
     FORCE_CASE_TO_CASE_UNDER_REVIEW("forceCaseToCaseUnderReview"),
     FORCE_CASE_TO_SUBMIT_HEARING_REQUIREMENTS("forceCaseToSubmitHearingRequirements"),
+    ADJOURN_HEARING_WITHOUT_DATE("adjournHearingWithoutDate"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/State.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/State.java
@@ -23,6 +23,7 @@ public enum State {
     FTPA_SUBMITTED("ftpaSubmitted"),
     AWAITING_CLARIFYING_QUESTIONS_ANSWERS("awaitingClarifyingQuestionsAnswers"),
     AWAITING_CMA_REQUIREMENTS("awaitingCmaRequirements"),
+    ADJOURNED("adjourned"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerAdjournHearingWithoutDatePersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerAdjournHearingWithoutDatePersonalisation.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import javax.validation.constraints.NotNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
+
+@Service
+public class AdminOfficerAdjournHearingWithoutDatePersonalisation implements EmailNotificationPersonalisation {
+
+    private final String adjournHearingWithoutDateAdminOfficerTemplateId;
+    private final String reviewHearingRequirementsAdminOfficerEmailAddress;
+    private final AdminOfficerPersonalisationProvider adminOfficerPersonalisationProvider;
+
+    public AdminOfficerAdjournHearingWithoutDatePersonalisation(
+        @NotNull(message = "adjournHearingWithoutDateAdminOfficerTemplateId cannot be null") @Value("${govnotify.template.adjournHearingWithoutDate.adminOfficer.email}") String adjournHearingWithoutDateAdminOfficerTemplateId,
+        @Value("${reviewHearingRequirementsAdminOfficerEmailAddress}") String reviewHearingRequirementsAdminOfficerEmailAddress,
+        AdminOfficerPersonalisationProvider adminOfficerPersonalisationProvider
+    ) {
+        this.adjournHearingWithoutDateAdminOfficerTemplateId = adjournHearingWithoutDateAdminOfficerTemplateId;
+        this.reviewHearingRequirementsAdminOfficerEmailAddress = reviewHearingRequirementsAdminOfficerEmailAddress;
+        this.adminOfficerPersonalisationProvider = adminOfficerPersonalisationProvider;
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_ADJOURN_HEARING_WITHOUT_DATE_ADMIN_OFFICER";
+    }
+
+    @Override
+    public String getTemplateId() {
+        return adjournHearingWithoutDateAdminOfficerTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        return Collections.singleton(reviewHearingRequirementsAdminOfficerEmailAddress);
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+        return adminOfficerPersonalisationProvider.getDefaultPersonlisation(asylumCase);
+
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerAdjournHearingWithoutDatePersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerAdjournHearingWithoutDatePersonalisation.java
@@ -46,7 +46,7 @@ public class AdminOfficerAdjournHearingWithoutDatePersonalisation implements Ema
     @Override
     public Map<String, String> getPersonalisation(AsylumCase asylumCase) {
         requireNonNull(asylumCase, "asylumCase must not be null");
-        return adminOfficerPersonalisationProvider.getDefaultPersonlisation(asylumCase);
+        return adminOfficerPersonalisationProvider.getChangeToHearingRequirementsPersonalisation(asylumCase);
 
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerAdjournHearingWithoutDatePersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerAdjournHearingWithoutDatePersonalisation.java
@@ -1,0 +1,57 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.caseofficer;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
+
+@Service
+public class CaseOfficerAdjournHearingWithoutDatePersonalisation implements EmailNotificationPersonalisation {
+
+    private final String caseOfficerAdjournHearingWithoutDateTemplateId;
+    private EmailAddressFinder emailAddressFinder;
+
+    public CaseOfficerAdjournHearingWithoutDatePersonalisation(
+        @Value("${govnotify.template.adjournHearingWithoutDate.caseOfficer.email}") String caseOfficerAdjournHearingWithoutDateTemplateId,
+        EmailAddressFinder emailAddressFinder
+    ) {
+        this.caseOfficerAdjournHearingWithoutDateTemplateId = caseOfficerAdjournHearingWithoutDateTemplateId;
+        this.emailAddressFinder = emailAddressFinder;
+    }
+
+    @Override
+    public String getTemplateId() {
+        return caseOfficerAdjournHearingWithoutDateTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        return Collections.singleton(emailAddressFinder.getEmailAddress(asylumCase));
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_CASE_OFFICER_ADJOURN_HEARING_WITHOUT_DATE";
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        return
+            ImmutableMap
+                .<String, String>builder()
+                .put("appealReferenceNumber", asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+                .put("appellantGivenNames", asylumCase.read(APPELLANT_GIVEN_NAMES, String.class).orElse(""))
+                .put("appellantFamilyName", asylumCase.read(APPELLANT_FAMILY_NAME, String.class).orElse(""))
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerAdjournHearingWithoutDatePersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerAdjournHearingWithoutDatePersonalisation.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
 
@@ -52,6 +53,8 @@ public class CaseOfficerAdjournHearingWithoutDatePersonalisation implements Emai
                 .put("appealReferenceNumber", asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
                 .put("appellantGivenNames", asylumCase.read(APPELLANT_GIVEN_NAMES, String.class).orElse(""))
                 .put("appellantFamilyName", asylumCase.read(APPELLANT_FAMILY_NAME, String.class).orElse(""))
+                .put("ariaListingReference",
+                    asylumCase.read(AsylumCaseDefinition.ARIA_LISTING_REFERENCE, String.class).orElse(""))
                 .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeAdjournHearingWithoutDatePersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeAdjournHearingWithoutDatePersonalisation.java
@@ -1,0 +1,57 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.legalrepresentative;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
+
+@Service
+public class LegalRepresentativeAdjournHearingWithoutDatePersonalisation implements EmailNotificationPersonalisation {
+
+    private final String legalRepresentativeAdjournHearingWithoutDateTemplateId;
+
+    public LegalRepresentativeAdjournHearingWithoutDatePersonalisation(
+        @Value("${govnotify.template.adjournHearingWithoutDate.legalRep.email}") String legalRepresentativeAdjournHearingWithoutDateTemplateId
+    ) {
+        this.legalRepresentativeAdjournHearingWithoutDateTemplateId = legalRepresentativeAdjournHearingWithoutDateTemplateId;
+    }
+
+    @Override
+    public String getTemplateId() {
+        return legalRepresentativeAdjournHearingWithoutDateTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        return Collections.singleton(asylumCase
+            .read(LEGAL_REPRESENTATIVE_EMAIL_ADDRESS, String.class)
+            .orElseThrow(() -> new IllegalStateException("legalRepresentativeEmailAddress is not present")));
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_LEGAL_REPRESENTATIVE_ADJOURN_HEARING_WITHOUT_DATE";
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        return
+            ImmutableMap
+                .<String, String>builder()
+                .put("appealReferenceNumber", asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+                .put("legalRepReferenceNumber", asylumCase.read(LEGAL_REP_REFERENCE_NUMBER, String.class).orElse(""))
+                .put("appellantGivenNames", asylumCase.read(APPELLANT_GIVEN_NAMES, String.class).orElse(""))
+                .put("appellantFamilyName", asylumCase.read(APPELLANT_FAMILY_NAME, String.class).orElse(""))
+                .put("insertAdjournmentReason", asylumCase.read(ADJOURN_HEARING_WITHOUT_DATE_REASONS, String.class).orElse(""))
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeAdjournHearingWithoutDatePersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeAdjournHearingWithoutDatePersonalisation.java
@@ -52,6 +52,7 @@ public class LegalRepresentativeAdjournHearingWithoutDatePersonalisation impleme
                 .put("appellantGivenNames", asylumCase.read(APPELLANT_GIVEN_NAMES, String.class).orElse(""))
                 .put("appellantFamilyName", asylumCase.read(APPELLANT_FAMILY_NAME, String.class).orElse(""))
                 .put("insertAdjournmentReason", asylumCase.read(ADJOURN_HEARING_WITHOUT_DATE_REASONS, String.class).orElse(""))
+                .put("ariaListingReference", asylumCase.read(ARIA_LISTING_REFERENCE, String.class).orElse(""))
                 .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/respondent/RespondentAdjournHearingWithoutDatePersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/respondent/RespondentAdjournHearingWithoutDatePersonalisation.java
@@ -1,0 +1,64 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
+
+@Service
+public class RespondentAdjournHearingWithoutDatePersonalisation implements EmailNotificationPersonalisation {
+
+    private final String respondentAdjournHearingWithoutDateTemplateId;
+    private final EmailAddressFinder respondentEmailAddressAfterRespondentReview;
+
+    public RespondentAdjournHearingWithoutDatePersonalisation(
+        @Value("${govnotify.template.adjournHearingWithoutDate.respondent.email}") String respondentAdjournHearingWithoutDateTemplateId,
+        EmailAddressFinder respondentEmailAddressAfterRespondentReview
+    ) {
+
+        this.respondentAdjournHearingWithoutDateTemplateId = respondentAdjournHearingWithoutDateTemplateId;
+        this.respondentEmailAddressAfterRespondentReview = respondentEmailAddressAfterRespondentReview;
+    }
+
+    @Override
+    public String getTemplateId() {
+        return respondentAdjournHearingWithoutDateTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        return Collections.singleton(getRespondentEmailAddress(asylumCase));
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_RESPONDENT_ADJOURN_HEARING_WITHOUT_DATE";
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        return ImmutableMap
+            .<String, String>builder()
+            .put("appealReferenceNumber", asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+            .put("homeOfficeReferenceNumber", asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""))
+            .put("appellantGivenNames", asylumCase.read(APPELLANT_GIVEN_NAMES, String.class).orElse(""))
+            .put("appellantFamilyName", asylumCase.read(APPELLANT_FAMILY_NAME, String.class).orElse(""))
+            .build();
+    }
+
+    private String getRespondentEmailAddress(AsylumCase asylumCase) {
+
+        return respondentEmailAddressAfterRespondentReview.getHomeOfficeEmailAddress(asylumCase);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/respondent/RespondentAdjournHearingWithoutDatePersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/respondent/RespondentAdjournHearingWithoutDatePersonalisation.java
@@ -54,6 +54,7 @@ public class RespondentAdjournHearingWithoutDatePersonalisation implements Email
             .put("homeOfficeReferenceNumber", asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""))
             .put("appellantGivenNames", asylumCase.read(APPELLANT_GIVEN_NAMES, String.class).orElse(""))
             .put("appellantFamilyName", asylumCase.read(APPELLANT_FAMILY_NAME, String.class).orElse(""))
+            .put("ariaListingReference", asylumCase.read(ARIA_LISTING_REFERENCE, String.class).orElse(""))
             .build();
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -8,10 +8,7 @@ import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.NotificationSender;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerChangeToHearingRequirementsPersonalisation;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerFtpaSubmittedPersonalisation;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerReviewHearingRequirementsPersonalisation;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerWithoutHearingRequirementsPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.*;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appellant.email.*;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appellant.sms.*;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.caseofficer.*;
@@ -893,6 +890,30 @@ public class NotificationGeneratorConfiguration {
             new EmailNotificationGenerator(
                 newArrayList(
                     respondentForceCaseToSubmitHearingRequirementsPersonalisation
+                ),
+                notificationSender,
+                notificationIdAppender
+            )
+        );
+    }
+
+    @Bean("adjournHearingWithoutDateNotificationGenerator")
+    public List<NotificationGenerator> adjournHearingWithoutDateNotificationGenerator(
+        LegalRepresentativeAdjournHearingWithoutDatePersonalisation legalRepresentativeAdjournHearingWithoutDatePersonalisation,
+        RespondentAdjournHearingWithoutDatePersonalisation respondentAdjournHearingWithoutDatePersonalisation,
+        CaseOfficerAdjournHearingWithoutDatePersonalisation caseOfficerAdjournHearingWithoutDatePersonalisation,
+        AdminOfficerAdjournHearingWithoutDatePersonalisation adminOfficerAdjournHearingWithoutDatePersonalisation,
+        NotificationSender notificationSender,
+        NotificationIdAppender notificationIdAppender
+    ) {
+
+        return Collections.singletonList(
+            new EmailNotificationGenerator(
+                newArrayList(
+                    legalRepresentativeAdjournHearingWithoutDatePersonalisation,
+                    respondentAdjournHearingWithoutDatePersonalisation,
+                    caseOfficerAdjournHearingWithoutDatePersonalisation,
+                    adminOfficerAdjournHearingWithoutDatePersonalisation
                 ),
                 notificationSender,
                 notificationIdAppender

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -656,8 +656,8 @@ public class NotificationHandlerConfiguration {
                     .map(type -> type == AIP).orElse(false);
 
                 return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-                       && callback.getEvent() == Event.SUBMIT_TIME_EXTENSION
-                       && isAipJourney;
+                    && callback.getEvent() == Event.SUBMIT_TIME_EXTENSION
+                    && isAipJourney;
             }, notificationGenerators
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -789,4 +789,16 @@ public class NotificationHandlerConfiguration {
             notificationGenerator
         );
     }
+
+    @Bean
+    public PreSubmitCallbackHandler<AsylumCase> adjournHearingWithoutDateHandler(
+        @Qualifier("adjournHearingWithoutDateNotificationGenerator") List<NotificationGenerator> notificationGenerator) {
+
+        return new NotificationHandler(
+            (callbackStage, callback) ->
+                callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                    && callback.getEvent() == Event.ADJOURN_HEARING_WITHOUT_DATE,
+            notificationGenerator
+        );
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -244,7 +244,6 @@ govnotify:
         sms: 9f0dce67-f8ef-46aa-a2a5-edb7fb19b6fd
       caseOfficer:
         email: 89540f93-a31b-4803-a83e-35cacd0c2415
-<<<<<<< HEAD
     reviewTimeExtensionGranted:
       appellant:
         email: c445e51c-c41b-4bac-ba54-2fc576e5a100

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -244,6 +244,7 @@ govnotify:
         sms: 9f0dce67-f8ef-46aa-a2a5-edb7fb19b6fd
       caseOfficer:
         email: 89540f93-a31b-4803-a83e-35cacd0c2415
+<<<<<<< HEAD
     reviewTimeExtensionGranted:
       appellant:
         email: c445e51c-c41b-4bac-ba54-2fc576e5a100
@@ -265,6 +266,15 @@ govnotify:
     requestCaseEdit:
       legalRep:
         email: 194e0a44-4fab-4e75-94a9-6d910dc4879a
+    adjournHearingWithoutDate:
+      respondent:
+        email: 080b563c-7311-4082-bed9-de67bbca14ee
+      caseOfficer:
+        email: eba2cb81-042c-4af6-90ea-5391a382177c
+      legalRep:
+        email: f5e4cbca-4fc8-4e39-bb92-9fe915aa8c61
+      adminOfficer:
+        email: 5469078a-4ccf-4579-b72b-37900e091455
 
 notificationSender.deduplicateSendsWithinSeconds: 60
 
@@ -345,10 +355,12 @@ security:
       - "sendDirectionWithQuestions"
       - "forceCaseToCaseUnderReview"
       - "forceCaseToSubmitHearingRequirements"
+      - "adjournHearingWithoutDate"
     caseworker-ia-admofficer:
       - "listCase"
       - "editCaseListing"
       - "sendDecisionAndReasons"
+      - "adjournHearingWithoutDate"
     caseworker-ia-homeofficeapc:
       - "uploadHomeOfficeBundle"
       - "uploadAdditionalEvidenceHomeOffice"

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/EventTest.java
@@ -54,6 +54,7 @@ public class EventTest {
         assertEquals("submitClarifyingQuestionAnswers", Event.SUBMIT_CLARIFYING_QUESTION_ANSWERS.toString());
         assertEquals("forceCaseToCaseUnderReview", Event.FORCE_CASE_TO_CASE_UNDER_REVIEW.toString());
         assertEquals("forceCaseToSubmitHearingRequirements", Event.FORCE_CASE_TO_SUBMIT_HEARING_REQUIREMENTS.toString());
+        assertEquals("adjournHearingWithoutDate", Event.ADJOURN_HEARING_WITHOUT_DATE.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/EventTest.java
@@ -60,6 +60,6 @@ public class EventTest {
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(48, Event.values().length);
+        assertEquals(49, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/StateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/StateTest.java
@@ -26,6 +26,7 @@ public class StateTest {
         assertEquals("awaitingReasonsForAppeal", State.AWAITING_REASONS_FOR_APPEAL.toString());
         assertEquals("awaitingClarifyingQuestionsAnswers", State.AWAITING_CLARIFYING_QUESTIONS_ANSWERS.toString());
         assertEquals("awaitingCmaRequirements", State.AWAITING_CMA_REQUIREMENTS.toString());
+        assertEquals("adjourned", State.ADJOURNED.toString());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/StateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/StateTest.java
@@ -31,6 +31,6 @@ public class StateTest {
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(19, State.values().length);
+        assertEquals(20, State.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerAdjournHearingWithoutDatePersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerAdjournHearingWithoutDatePersonalisationTest.java
@@ -1,0 +1,77 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AdminOfficerAdjournHearingWithoutDatePersonalisationTest {
+
+    @Mock AsylumCase asylumCase;
+    @Mock AdminOfficerPersonalisationProvider adminOfficerPersonalisationProvider;
+
+    private Long caseId = 12345L;
+    private String templateId = "someTemplateId";
+
+    private String adminOfficerEmailAddress = "adminOfficer@example.com";
+
+    private String appealReferenceNumber = "someReferenceNumber";
+    private String appellantGivenNames = "someAppellantGivenNames";
+    private String appellantFamilyName = "someAppellantFamilyName";
+
+    private AdminOfficerAdjournHearingWithoutDatePersonalisation adminOfficerdjournHearingWithoutDatePersonalisation;
+
+    @Before
+    public void setup() {
+        when(adminOfficerPersonalisationProvider.getDefaultPersonlisation(asylumCase)).thenReturn(ImmutableMap
+            .<String, String>builder()
+            .put("appealReferenceNumber", appealReferenceNumber)
+            .put("appellantGivenNames", appellantGivenNames)
+            .put("appellantFamilyName", appellantFamilyName)
+            .build());
+
+        adminOfficerdjournHearingWithoutDatePersonalisation = new AdminOfficerAdjournHearingWithoutDatePersonalisation(templateId, adminOfficerEmailAddress, adminOfficerPersonalisationProvider);
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        assertEquals(templateId, adminOfficerdjournHearingWithoutDatePersonalisation.getTemplateId());
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        assertEquals(caseId + "_ADJOURN_HEARING_WITHOUT_DATE_ADMIN_OFFICER", adminOfficerdjournHearingWithoutDatePersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address_from_asylum_case() {
+        assertTrue(adminOfficerdjournHearingWithoutDatePersonalisation.getRecipientsList(asylumCase).contains(adminOfficerEmailAddress));
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(() -> adminOfficerdjournHearingWithoutDatePersonalisation.getPersonalisation((AsylumCase) null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given() {
+
+        Map<String, String> personalisation = adminOfficerdjournHearingWithoutDatePersonalisation.getPersonalisation(asylumCase);
+
+        assertThat(personalisation).isEqualToComparingOnlyGivenFields(asylumCase);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerAdjournHearingWithoutDatePersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerAdjournHearingWithoutDatePersonalisationTest.java
@@ -18,27 +18,29 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 @RunWith(MockitoJUnitRunner.class)
 public class AdminOfficerAdjournHearingWithoutDatePersonalisationTest {
 
-    @Mock AsylumCase asylumCase;
-    @Mock AdminOfficerPersonalisationProvider adminOfficerPersonalisationProvider;
+    @Mock
+    AsylumCase asylumCase;
+    @Mock
+    AdminOfficerPersonalisationProvider adminOfficerPersonalisationProvider;
 
-    private Long caseId = 12345L;
     private String templateId = "someTemplateId";
 
     private String adminOfficerEmailAddress = "adminOfficer@example.com";
-
-    private String appealReferenceNumber = "someReferenceNumber";
-    private String appellantGivenNames = "someAppellantGivenNames";
-    private String appellantFamilyName = "someAppellantFamilyName";
 
     private AdminOfficerAdjournHearingWithoutDatePersonalisation adminOfficerdjournHearingWithoutDatePersonalisation;
 
     @Before
     public void setup() {
-        when(adminOfficerPersonalisationProvider.getDefaultPersonlisation(asylumCase)).thenReturn(ImmutableMap
+        String appealReferenceNumber = "someReferenceNumber";
+        String appellantGivenNames = "someAppellantGivenNames";
+        String appellantFamilyName = "someAppellantFamilyName";
+        String listRef = "LP/12345/2019";
+        when(adminOfficerPersonalisationProvider.getChangeToHearingRequirementsPersonalisation(asylumCase)).thenReturn(ImmutableMap
             .<String, String>builder()
             .put("appealReferenceNumber", appealReferenceNumber)
             .put("appellantGivenNames", appellantGivenNames)
             .put("appellantFamilyName", appellantFamilyName)
+            .put("ariaListingReference", listRef)
             .build());
 
         adminOfficerdjournHearingWithoutDatePersonalisation = new AdminOfficerAdjournHearingWithoutDatePersonalisation(templateId, adminOfficerEmailAddress, adminOfficerPersonalisationProvider);
@@ -51,6 +53,7 @@ public class AdminOfficerAdjournHearingWithoutDatePersonalisationTest {
 
     @Test
     public void should_return_given_reference_id() {
+        Long caseId = 12345L;
         assertEquals(caseId + "_ADJOURN_HEARING_WITHOUT_DATE_ADMIN_OFFICER", adminOfficerdjournHearingWithoutDatePersonalisation.getReferenceId(caseId));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerAdjournHearingWithoutDatePersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerAdjournHearingWithoutDatePersonalisationTest.java
@@ -1,0 +1,77 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.caseofficer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CaseOfficerAdjournHearingWithoutDatePersonalisationTest {
+
+    @Mock AsylumCase asylumCase;
+    @Mock EmailAddressFinder emailAddressFinder;
+
+    private Long caseId = 12345L;
+    private String templateId = "someTemplateId";
+
+    private String caseOfficerEmailAddress = "caseOfficer@example.com";
+
+    private String appealReferenceNumber = "someReferenceNumber";
+    private String appellantGivenNames = "someAppellantGivenNames";
+    private String appellantFamilyName = "someAppellantFamilyName";
+
+    private CaseOfficerAdjournHearingWithoutDatePersonalisation caseOfficerAdjournHearingWithoutDatePersonalisation;
+
+    @Before
+    public void setup() {
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(emailAddressFinder.getEmailAddress(asylumCase)).thenReturn(caseOfficerEmailAddress);
+
+        caseOfficerAdjournHearingWithoutDatePersonalisation = new CaseOfficerAdjournHearingWithoutDatePersonalisation(templateId, emailAddressFinder);
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        assertEquals(templateId, caseOfficerAdjournHearingWithoutDatePersonalisation.getTemplateId());
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        assertEquals(caseId + "_CASE_OFFICER_ADJOURN_HEARING_WITHOUT_DATE", caseOfficerAdjournHearingWithoutDatePersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address_from_asylum_case() {
+        assertTrue(caseOfficerAdjournHearingWithoutDatePersonalisation.getRecipientsList(asylumCase).contains(caseOfficerEmailAddress));
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(() -> caseOfficerAdjournHearingWithoutDatePersonalisation.getPersonalisation((AsylumCase) null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given() {
+
+        Map<String, String> personalisation = caseOfficerAdjournHearingWithoutDatePersonalisation.getPersonalisation(asylumCase);
+
+        assertThat(personalisation).isEqualToComparingOnlyGivenFields(asylumCase);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeAdjournHearingWithoutDatePersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeAdjournHearingWithoutDatePersonalisationTest.java
@@ -1,0 +1,88 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.legalrepresentative;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LegalRepresentativeAdjournHearingWithoutDatePersonalisationTest {
+
+    @Mock AsylumCase asylumCase;
+
+    private Long caseId = 12345L;
+    private String templateId = "someTemplateId";
+    private String someReason = "someExplanation";
+
+    private String legalRepEmailAddress = "legalrep@example.com";
+
+    private String appealReferenceNumber = "someReferenceNumber";
+    private String legalRepRefNumber = "somelegalRepRefNumber";
+    private String appellantGivenNames = "someAppellantGivenNames";
+    private String appellantFamilyName = "someAppellantFamilyName";
+
+    private LegalRepresentativeAdjournHearingWithoutDatePersonalisation legalRepresentativeAdjournHearingWithoutDatePersonalisation;
+
+    @Before
+    public void setup() {
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(asylumCase.read(LEGAL_REP_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(legalRepRefNumber));
+        when(asylumCase.read(LEGAL_REPRESENTATIVE_EMAIL_ADDRESS, String.class)).thenReturn(Optional.of(legalRepEmailAddress));
+        when(asylumCase.read(ADJOURN_HEARING_WITHOUT_DATE_REASONS, String.class)).thenReturn(Optional.of(someReason));
+
+        legalRepresentativeAdjournHearingWithoutDatePersonalisation = new LegalRepresentativeAdjournHearingWithoutDatePersonalisation(templateId);
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        assertEquals(templateId, legalRepresentativeAdjournHearingWithoutDatePersonalisation.getTemplateId());
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        assertEquals(caseId + "_LEGAL_REPRESENTATIVE_ADJOURN_HEARING_WITHOUT_DATE", legalRepresentativeAdjournHearingWithoutDatePersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address_from_asylum_case() {
+        assertTrue(legalRepresentativeAdjournHearingWithoutDatePersonalisation.getRecipientsList(asylumCase).contains(legalRepEmailAddress));
+    }
+
+    @Test
+    public void should_throw_exception_when_cannot_find_email_address_for_legal_rep() {
+        when(asylumCase.read(LEGAL_REPRESENTATIVE_EMAIL_ADDRESS, String.class)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> legalRepresentativeAdjournHearingWithoutDatePersonalisation.getRecipientsList(asylumCase))
+            .isExactlyInstanceOf(IllegalStateException.class)
+            .hasMessage("legalRepresentativeEmailAddress is not present");
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(() -> legalRepresentativeAdjournHearingWithoutDatePersonalisation.getPersonalisation((AsylumCase) null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given() {
+
+        Map<String, String> personalisation = legalRepresentativeAdjournHearingWithoutDatePersonalisation.getPersonalisation(asylumCase);
+
+        assertThat(personalisation).isEqualToComparingOnlyGivenFields(asylumCase);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/respondent/RespondentAdjournHearingWithoutDatePersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/respondent/RespondentAdjournHearingWithoutDatePersonalisationTest.java
@@ -1,0 +1,86 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPELLANT_FAMILY_NAME;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPELLANT_GIVEN_NAMES;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.HOME_OFFICE_REFERENCE_NUMBER;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RespondentAdjournHearingWithoutDatePersonalisationTest {
+
+    @Mock AsylumCase asylumCase;
+    @Mock EmailAddressFinder emailAddressFinder;
+
+    private Long caseId = 12345L;
+    private String templateId = "someTemplateId";
+    private String respondentReviewEmailAddress = "respondentReview@example.com";
+    private String appealReferenceNumber = "someReferenceNumber";
+    private String homeOfficeRefNumber = "someHomeOfficeRefNumber";
+    private String appellantGivenNames = "someAppellantGivenNames";
+    private String appellantFamilyName = "someAppellantFamilyName";
+
+    private RespondentAdjournHearingWithoutDatePersonalisation respondentAdjournHearingWithoutDatePersonalisation;
+
+    @Before
+    public void setup() {
+
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeRefNumber));
+        when(emailAddressFinder.getHomeOfficeEmailAddress(asylumCase)).thenReturn(respondentReviewEmailAddress);
+
+        respondentAdjournHearingWithoutDatePersonalisation = new RespondentAdjournHearingWithoutDatePersonalisation(
+            templateId,
+            emailAddressFinder
+        );
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        assertEquals(templateId, respondentAdjournHearingWithoutDatePersonalisation.getTemplateId());
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        assertEquals(caseId + "_RESPONDENT_ADJOURN_HEARING_WITHOUT_DATE", respondentAdjournHearingWithoutDatePersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address_from_asylum_case() {
+        assertTrue(respondentAdjournHearingWithoutDatePersonalisation.getRecipientsList(asylumCase).contains(respondentReviewEmailAddress));
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(() -> respondentAdjournHearingWithoutDatePersonalisation.getPersonalisation((AsylumCase) null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given() {
+
+        Map<String, String> personalisation = respondentAdjournHearingWithoutDatePersonalisation.getPersonalisation(asylumCase);
+
+        assertEquals(appealReferenceNumber, personalisation.get("appealReferenceNumber"));
+        assertEquals(appellantGivenNames, personalisation.get("appellantGivenNames"));
+        assertEquals(appellantFamilyName, personalisation.get("appellantFamilyName"));
+        assertEquals(homeOfficeRefNumber, personalisation.get("homeOfficeReferenceNumber"));
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-2959


### Change description ###
 - Added new personalisation for legal representative.
 - Added new personalisation for case officer.
 - Added new personalisation for admin officer.
 - Added new personalisation for respondent.
 - Added functional test to check that the correct notifications are sent with prepopullated values.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
