### PR TITLE
Fix for 'document_hash' for new Document Access Management solution

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-2783-edit-documents-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-2783-edit-documents-before-listing.json
@@ -28,7 +28,8 @@
                 "document": {
                   "document_url": "http://document-store/d209e64c-b8fe-4ffa-8f8b-c7ae922c6b65",
                   "document_binary_url": "http://document-store/d209e64c-b8fe-4ffa-8f8b-c7ae922c6b65/binary",
-                  "document_filename": "new evidence.pdf"
+                  "document_filename": "new evidence.pdf",
+                  "document_hash": "0239230ab2039cd234234324ee1234324234324ffff"
                 },
                 "description": "some updated description",
                 "dateUploaded": "2018-12-25",
@@ -48,7 +49,8 @@
                 "document": {
                   "document_url": "http://document-store/d209e64c-b8fe-4ffa-8f8b-c7ae922c6b65",
                   "document_binary_url": "http://document-store/d209e64c-b8fe-4ffa-8f8b-c7ae922c6b65/binary",
-                  "document_filename": "new evidence.pdf"
+                  "document_filename": "new evidence.pdf",
+                  "document_hash": "0239230ab2039cd234234324ee1234324234324ffff"
                 },
                 "description": "some original description",
                 "dateUploaded": "2018-12-25",
@@ -61,7 +63,8 @@
                 "document": {
                   "document_url": "http://document-store/e1c202b3-099c-452b-a7f0-b1ad7a231a36",
                   "document_binary_url": "http://document-store/e1c202b3-099c-452b-a7f0-b1ad7a231a36/binary",
-                  "document_filename": "new other evidence.pdf"
+                  "document_filename": "new other evidence.pdf",
+                  "document_hash": "0239230ab2039cd234234321122334ee1234324234324ffff"
                 },
                 "description": "some other original description",
                 "dateUploaded": "2018-12-26",

--- a/src/functionalTest/resources/scenarios/RIA-3366-notification-of-admin-officer-uploaded-addendum-evidence.json
+++ b/src/functionalTest/resources/scenarios/RIA-3366-notification-of-admin-officer-uploaded-addendum-evidence.json
@@ -19,7 +19,8 @@
                 "document": {
                   "document_url": "http://document-store/AAA",
                   "document_binary_url": "http://document-store/AAA/binary",
-                  "document_filename": "existing-evidence.pdf"
+                  "document_filename": "existing-evidence.pdf",
+                  "document_hash": "0239230ab2039cd234234324ee1234324234324ffff"
                 },
                 "description": "Existing evidence",
                 "dateUploaded": "2018-12-25",

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/field/Document.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/field/Document.java
@@ -15,6 +15,7 @@ public class Document {
     private String documentUrl;
     private String documentBinaryUrl;
     private String documentFilename;
+    private String documentHash;
 
     private Document() {
         // noop -- for deserializer
@@ -23,15 +24,18 @@ public class Document {
     public Document(
         String documentUrl,
         String documentBinaryUrl,
-        String documentFilename
+        String documentFilename,
+        String documentHash
     ) {
         requireNonNull(documentUrl);
         requireNonNull(documentBinaryUrl);
         requireNonNull(documentFilename);
+        requireNonNull(documentHash);
 
         this.documentUrl = documentUrl;
         this.documentBinaryUrl = documentBinaryUrl;
         this.documentFilename = documentFilename;
+        this.documentHash = documentHash;
     }
 
     public String getDocumentUrl() {
@@ -44,5 +48,9 @@ public class Document {
 
     public String getDocumentFilename() {
         return documentFilename;
+    }
+
+    public String getDocumentHash() {
+        return documentHash;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/field/DocumentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/field/DocumentTest.java
@@ -4,23 +4,26 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-public class DocumentTest {
+class DocumentTest {
 
     private final String documentUrl = "http://doc-store/A";
     private final String documentBinaryUrl = "http://doc-store/A/binary";
     private final String documentFilename = "evidence.pdf";
+    private final String documentHash = "document-hash";
 
-    private Document document = new Document(
+    private final Document document = new Document(
         documentUrl,
         documentBinaryUrl,
-        documentFilename
+        documentFilename,
+        documentHash
     );
 
     @Test
-    public void should_hold_onto_values() {
+    void should_hold_onto_values() {
 
         assertEquals(documentUrl, document.getDocumentUrl());
         assertEquals(documentBinaryUrl, document.getDocumentBinaryUrl());
         assertEquals(documentFilename, document.getDocumentFilename());
+        assertEquals(documentHash, document.getDocumentHash());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/editdocument/EditDocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/editdocument/EditDocumentServiceTest.java
@@ -122,7 +122,7 @@ public class EditDocumentServiceTest {
 
     private static Document buildDocument(String docId, String filename) {
         String documentUrl = "http://dm-store/" + docId;
-        return new Document(documentUrl, documentUrl + "/binary", filename);
+        return new Document(documentUrl, documentUrl + "/binary", filename,"document-hash");
     }
 
     @ParameterizedTest


### PR DESCRIPTION

### https://tools.hmcts.net/jira/browse/RIA-4869 ###


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
