### PR TITLE
Change default value for tcw-notifications feature flag

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerClarifyingQuestionsAnswersSubmittedPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerClarifyingQuestionsAnswersSubmittedPersonalisation.java
@@ -41,7 +41,7 @@ public class CaseOfficerClarifyingQuestionsAnswersSubmittedPersonalisation imple
 
     @Override
     public Set<String> getRecipientsList(AsylumCase asylumCase) {
-        return featureToggler.getValue("tcw-notifications-feature", false)
+        return featureToggler.getValue("tcw-notifications-feature", true)
                 ? Collections.singleton(emailAddressFinder.getHearingCentreEmailAddress(asylumCase))
                 : Collections.emptySet();
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerFtpaDecisionHomeOfficeNotificationFailedPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerFtpaDecisionHomeOfficeNotificationFailedPersonalisation.java
@@ -40,7 +40,7 @@ public class CaseOfficerFtpaDecisionHomeOfficeNotificationFailedPersonalisation 
 
     @Override
     public Set<String> getRecipientsList(AsylumCase asylumCase) {
-        return featureToggler.getValue("tcw-notifications-feature", false)
+        return featureToggler.getValue("tcw-notifications-feature", true)
                 ? Collections.singleton(emailAddressFinder.getListCaseHearingCentreEmailAddress(asylumCase))
                 : Collections.emptySet();
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerHomeOfficeResponseUploadedPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerHomeOfficeResponseUploadedPersonalisation.java
@@ -42,7 +42,7 @@ public class CaseOfficerHomeOfficeResponseUploadedPersonalisation implements Ema
 
     @Override
     public Set<String> getRecipientsList(AsylumCase asylumCase) {
-        return featureToggler.getValue("tcw-notifications-feature", false)
+        return featureToggler.getValue("tcw-notifications-feature", true)
                 ? Collections.singleton(asylumCase
                     .read(HEARING_CENTRE, HearingCentre.class)
                     .map(centre -> Optional.ofNullable(hearingCentreEmailAddresses.get(centre))

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerListCmaPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerListCmaPersonalisation.java
@@ -53,7 +53,7 @@ public class CaseOfficerListCmaPersonalisation implements EmailNotificationPerso
 
     @Override
     public Set<String> getRecipientsList(AsylumCase asylumCase) {
-        return featureToggler.getValue("tcw-notifications-feature", false)
+        return featureToggler.getValue("tcw-notifications-feature", true)
                 ? Collections.singleton(emailAddressFinder.getHearingCentreEmailAddress(asylumCase))
                 : Collections.emptySet();
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerMakeAnApplicationPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerMakeAnApplicationPersonalisation.java
@@ -70,7 +70,7 @@ public class CaseOfficerMakeAnApplicationPersonalisation implements EmailNotific
 
     @Override
     public Set<String> getRecipientsList(AsylumCase asylumCase) {
-        return featureToggler.getValue("tcw-notifications-feature", false)
+        return featureToggler.getValue("tcw-notifications-feature", true)
                 ? Collections.singleton(emailAddressFinder.getHearingCentreEmailAddress(asylumCase))
                 : Collections.emptySet();
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerManageFeeUpdatePersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerManageFeeUpdatePersonalisation.java
@@ -48,7 +48,7 @@ public class CaseOfficerManageFeeUpdatePersonalisation implements EmailNotificat
 
     @Override
     public Set<String> getRecipientsList(AsylumCase asylumCase) {
-        if (featureToggler.getValue("tcw-notifications-feature", false)) {
+        if (featureToggler.getValue("tcw-notifications-feature", true)) {
             if (isPaymentByPBa(asylumCase)) {
                 return Collections.singleton(ctscEmailAddress);
             } else if (isPaymentByCard(asylumCase)) {

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerReasonForAppealSubmittedPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerReasonForAppealSubmittedPersonalisation.java
@@ -44,7 +44,7 @@ public class CaseOfficerReasonForAppealSubmittedPersonalisation implements Email
 
     @Override
     public Set<String> getRecipientsList(AsylumCase asylumCase) {
-        return featureToggler.getValue("tcw-notifications-feature", false)
+        return featureToggler.getValue("tcw-notifications-feature", true)
                 ? Collections.singleton(emailAddressFinder.getHearingCentreEmailAddress(asylumCase))
                 : Collections.emptySet();
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerRequestHearingRequirementsPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerRequestHearingRequirementsPersonalisation.java
@@ -45,7 +45,7 @@ public class CaseOfficerRequestHearingRequirementsPersonalisation implements Ema
 
     @Override
     public Set<String> getRecipientsList(AsylumCase asylumCase) {
-        return featureToggler.getValue("tcw-notifications-feature", false)
+        return featureToggler.getValue("tcw-notifications-feature", true)
                 ? Collections.singleton(asylumCase
                     .read(HEARING_CENTRE, HearingCentre.class)
                     .map(centre -> Optional.ofNullable(hearingCentreEmailAddresses.get(centre))

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerRespondentEvidenceSubmittedPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerRespondentEvidenceSubmittedPersonalisation.java
@@ -45,7 +45,7 @@ public class CaseOfficerRespondentEvidenceSubmittedPersonalisation implements Em
 
     @Override
     public Set<String> getRecipientsList(AsylumCase asylumCase) {
-        return featureToggler.getValue("tcw-notifications-feature", false)
+        return featureToggler.getValue("tcw-notifications-feature", true)
                 ? Collections.singleton(emailAddressFinder.getHearingCentreEmailAddress(asylumCase))
                 : Collections.emptySet();
 

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerSubmitAppealPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerSubmitAppealPersonalisation.java
@@ -44,7 +44,7 @@ public class CaseOfficerSubmitAppealPersonalisation implements EmailNotification
 
     @Override
     public Set<String> getRecipientsList(AsylumCase asylumCase) {
-        return featureToggler.getValue("tcw-notifications-feature", false)
+        return featureToggler.getValue("tcw-notifications-feature", true)
                 ?  Collections.singleton(emailAddressFinder.getHearingCentreEmailAddress(asylumCase))
                 : Collections.emptySet();
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerSubmitCasePersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerSubmitCasePersonalisation.java
@@ -43,7 +43,7 @@ public class CaseOfficerSubmitCasePersonalisation implements EmailNotificationPe
 
     @Override
     public Set<String> getRecipientsList(AsylumCase asylumCase) {
-        return featureToggler.getValue("tcw-notifications-feature", false)
+        return featureToggler.getValue("tcw-notifications-feature", true)
                 ? Collections.singleton(emailAddressFinder.getHearingCentreEmailAddress(asylumCase))
                 : Collections.emptySet();
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerSubmittedHearingRequirementsPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerSubmittedHearingRequirementsPersonalisation.java
@@ -44,7 +44,7 @@ public class CaseOfficerSubmittedHearingRequirementsPersonalisation implements E
 
     @Override
     public Set<String> getRecipientsList(AsylumCase asylumCase) {
-        return featureToggler.getValue("tcw-notifications-feature", false)
+        return featureToggler.getValue("tcw-notifications-feature", true)
                 ? Collections.singleton(emailAddressFinder.getHearingCentreEmailAddress(asylumCase))
                 : Collections.emptySet();
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerUploadAddendumEvidencePersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerUploadAddendumEvidencePersonalisation.java
@@ -39,7 +39,7 @@ public class CaseOfficerUploadAddendumEvidencePersonalisation implements EmailNo
 
     @Override
     public Set<String> getRecipientsList(AsylumCase asylumCase) {
-        return featureToggler.getValue("tcw-notifications-feature", false)
+        return featureToggler.getValue("tcw-notifications-feature", true)
                 ? Collections.singleton(emailAddressFinder.getHearingCentreEmailAddress(asylumCase))
                 : Collections.emptySet();
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerClarifyingQuestionsAnswersSubmittedPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerClarifyingQuestionsAnswersSubmittedPersonalisationTest.java
@@ -84,7 +84,7 @@ public class CaseOfficerClarifyingQuestionsAnswersSubmittedPersonalisationTest {
 
     @Test
     public void should_return_given_email_address_from_asylum_case_when_feature_flag_is_On() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         assertTrue(caseOfficerClarifyingQuestionsAnswersSubmittedPersonalisation.getRecipientsList(asylumCase)
                 .contains(hearingCentreEmailAddress), hearingCentreEmailAddress);
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerFtpaDecisionHomeOfficeNotificationFailedPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerFtpaDecisionHomeOfficeNotificationFailedPersonalisationTest.java
@@ -72,7 +72,7 @@ class CaseOfficerFtpaDecisionHomeOfficeNotificationFailedPersonalisationTest {
 
     @Test
     void should_return_given_email_address_from_lookup_map_when_feature_flag_is_On() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         when(emailAddressFinder.getListCaseHearingCentreEmailAddress(asylumCase)).thenReturn(caseOfficerEmailAddress);
         assertTrue(
                 homeOfficeNotificationFailedPersonalisation.getRecipientsList(asylumCase).contains(caseOfficerEmailAddress));

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerHomeOfficeResponseUploadedPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerHomeOfficeResponseUploadedPersonalisationTest.java
@@ -79,14 +79,14 @@ public class CaseOfficerHomeOfficeResponseUploadedPersonalisationTest {
 
     @Test
     public void should_return_given_email_address_from_lookup_map_when_feature_flag_is_On() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         assertTrue(caseOfficerHomeOfficeResponseUploadedPersonalisation.getRecipientsList(asylumCase)
                 .contains(hearingCentreEmailAddress));
     }
 
     @Test
     public void should_throw_exception_on_email_address_when_hearing_centre_is_empty() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         when(asylumCase.read(HEARING_CENTRE, HearingCentre.class)).thenReturn(Optional.empty());
         assertThatThrownBy(() -> caseOfficerHomeOfficeResponseUploadedPersonalisation.getRecipientsList(asylumCase))
             .isExactlyInstanceOf(IllegalStateException.class)
@@ -95,7 +95,7 @@ public class CaseOfficerHomeOfficeResponseUploadedPersonalisationTest {
 
     @Test
     public void should_throw_exception_when_cannot_find_email_address_for_hearing_centre() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         when(hearingCentreEmailAddressMap.get(hearingCentre)).thenReturn(null);
         assertThatThrownBy(() -> caseOfficerHomeOfficeResponseUploadedPersonalisation.getRecipientsList(asylumCase))
             .isExactlyInstanceOf(IllegalStateException.class)

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerListCmaPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerListCmaPersonalisationTest.java
@@ -105,7 +105,7 @@ public class CaseOfficerListCmaPersonalisationTest {
 
     @Test
     public void should_return_given_email_address_from_lookup_map_when_feature_flag_is_On() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         assertTrue(caseOfficerListCmaPersonalisation.getRecipientsList(asylumCase).contains(homeOfficeEmailAddress));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerMakeAnApplicationPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerMakeAnApplicationPersonalisationTest.java
@@ -111,7 +111,7 @@ public class CaseOfficerMakeAnApplicationPersonalisationTest {
 
     @Test
     public void should_return_given_email_address_from_lookup_map_when_feature_flag_is_On() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         assertTrue(caseOfficerMakeAnApplicationPersonalisation.getRecipientsList(asylumCase)
                 .contains(hearingCentreEmailAddress));
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerManageFeeUpdatePersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerManageFeeUpdatePersonalisationTest.java
@@ -173,7 +173,7 @@ class CaseOfficerManageFeeUpdatePersonalisationTest {
 
     @Test
     void should_return_given_nbc_email_address_hu_pay_by_card_when_feature_flag_is_On() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         when(asylumCase.read(EA_HU_APPEAL_TYPE_PAYMENT_OPTION,String.class)).thenReturn(Optional.of("payOffline"));
         when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.HU));
         assertTrue(caseOfficerManageFeeUpdatePersonalisation.getRecipientsList(asylumCase)
@@ -182,7 +182,7 @@ class CaseOfficerManageFeeUpdatePersonalisationTest {
 
     @Test
     void should_return_given_nbc_email_address_ea_pay_by_card_when_feature_flag_is_On() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         when(asylumCase.read(EA_HU_APPEAL_TYPE_PAYMENT_OPTION,String.class)).thenReturn(Optional.of("payOffline"));
         when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.EA));
         assertTrue(caseOfficerManageFeeUpdatePersonalisation.getRecipientsList(asylumCase)
@@ -191,7 +191,7 @@ class CaseOfficerManageFeeUpdatePersonalisationTest {
 
     @Test
     void should_return_given_nbc_email_address_pa_pay_by_card_when_feature_flag_is_On() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         when(asylumCase.read(PA_APPEAL_TYPE_PAYMENT_OPTION,String.class)).thenReturn(Optional.of("payOffline"));
         when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.PA));
         assertTrue(caseOfficerManageFeeUpdatePersonalisation.getRecipientsList(asylumCase)
@@ -200,7 +200,7 @@ class CaseOfficerManageFeeUpdatePersonalisationTest {
 
     @Test
     void should_return_given_ctsc_email_address_hu_pay_by_PBa_when_feature_flag_is_On() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         when(asylumCase.read(EA_HU_APPEAL_TYPE_PAYMENT_OPTION,String.class)).thenReturn(Optional.of("payNow"));
         when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.HU));
         assertTrue(caseOfficerManageFeeUpdatePersonalisation.getRecipientsList(asylumCase)
@@ -209,7 +209,7 @@ class CaseOfficerManageFeeUpdatePersonalisationTest {
 
     @Test
     void should_return_given_ctsc_email_address_ea_pay_by_PBa_when_feature_flag_is_On() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         when(asylumCase.read(EA_HU_APPEAL_TYPE_PAYMENT_OPTION,String.class)).thenReturn(Optional.of("payNow"));
         when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.EA));
         assertTrue(caseOfficerManageFeeUpdatePersonalisation.getRecipientsList(asylumCase)
@@ -218,7 +218,7 @@ class CaseOfficerManageFeeUpdatePersonalisationTest {
 
     @Test
     void should_return_given_ctsc_email_address_pa_pay_by_PBa_now_when_feature_flag_is_On() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         when(asylumCase.read(PA_APPEAL_TYPE_PAYMENT_OPTION,String.class)).thenReturn(Optional.of("payNow"));
         when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.PA));
         assertTrue(caseOfficerManageFeeUpdatePersonalisation.getRecipientsList(asylumCase)
@@ -227,7 +227,7 @@ class CaseOfficerManageFeeUpdatePersonalisationTest {
 
     @Test
     void should_return_given_ctsc_email_address_pa_pay_by_PBa_when_feature_flag_is_On() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         when(asylumCase.read(PA_APPEAL_TYPE_PAYMENT_OPTION,String.class)).thenReturn(Optional.of("payLater"));
         when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.PA));
         assertTrue(caseOfficerManageFeeUpdatePersonalisation.getRecipientsList(asylumCase)
@@ -256,7 +256,7 @@ class CaseOfficerManageFeeUpdatePersonalisationTest {
 
     @Test
     void should_throw_exception_on_email_when_case_is_null() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         when(asylumCase.read(PA_APPEAL_TYPE_PAYMENT_OPTION,String.class)).thenReturn(Optional.empty());
         when(asylumCase.read(EA_HU_APPEAL_TYPE_PAYMENT_OPTION,String.class)).thenReturn(Optional.empty());
         when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.empty());

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerReasonForAppealSubmittedPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerReasonForAppealSubmittedPersonalisationTest.java
@@ -83,7 +83,7 @@ public class CaseOfficerReasonForAppealSubmittedPersonalisationTest {
 
     @Test
     public void should_return_given_email_address_from_asylum_case_when_feature_flag_is_On() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         assertTrue(caseOfficerReasonForAppealSubmittedPersonalisation.getRecipientsList(asylumCase)
                 .contains(hearingCentreEmailAddress), hearingCentreEmailAddress);
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerRespondentEvidenceSubmittedPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerRespondentEvidenceSubmittedPersonalisationTest.java
@@ -81,7 +81,7 @@ public class CaseOfficerRespondentEvidenceSubmittedPersonalisationTest {
 
     @Test
     public void should_return_given_email_address_from_asylum_case_when_feature_flag_is_On() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         assertTrue(caseOfficerRespondentEvidenceSubmittedPersonalisation.getRecipientsList(asylumCase)
                 .contains(hearingCentreEmailAddress), hearingCentreEmailAddress);
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerResponseRequestHearingRequestPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerResponseRequestHearingRequestPersonalisationTest.java
@@ -81,7 +81,7 @@ public class CaseOfficerResponseRequestHearingRequestPersonalisationTest {
 
     @Test
     public void should_return_given_email_address_from_lookup_map_when_feature_flag_is_On() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         assertTrue(caseOfficerRequestHearingRequirementsPersonalisation.getRecipientsList(asylumCase)
                 .contains(hearingCentreEmailAddress));
     }
@@ -89,7 +89,7 @@ public class CaseOfficerResponseRequestHearingRequestPersonalisationTest {
 
     @Test
     public void should_throw_exception_on_email_address_when_hearing_centre_is_empty() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         when(asylumCase.read(HEARING_CENTRE, HearingCentre.class)).thenReturn(Optional.empty());
         assertThatThrownBy(() -> caseOfficerRequestHearingRequirementsPersonalisation.getRecipientsList(asylumCase))
             .isExactlyInstanceOf(IllegalStateException.class)
@@ -98,7 +98,7 @@ public class CaseOfficerResponseRequestHearingRequestPersonalisationTest {
 
     @Test
     public void should_throw_exception_when_cannot_find_email_address_for_hearing_centre() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         when(hearingCentreEmailAddressMap.get(hearingCentre)).thenReturn(null);
         assertThatThrownBy(() -> caseOfficerRequestHearingRequirementsPersonalisation.getRecipientsList(asylumCase))
             .isExactlyInstanceOf(IllegalStateException.class)

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerSubmitAppealPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerSubmitAppealPersonalisationTest.java
@@ -71,7 +71,7 @@ public class CaseOfficerSubmitAppealPersonalisationTest {
 
     @Test
     public void should_return_given_email_address_from_lookup_map_when_feature_flag_is_On() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         assertTrue(caseOfficerSubmitAppealPersonalisation.getRecipientsList(asylumCase).contains(hearingCentreEmailAddress));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerSubmitCasePersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerSubmitCasePersonalisationTest.java
@@ -72,7 +72,7 @@ public class CaseOfficerSubmitCasePersonalisationTest {
 
     @Test
     public void should_return_given_email_address_from_lookup_map_when_feature_flag_is_On() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         assertTrue(
             caseOfficerSubmitCasePersonalisation.getRecipientsList(asylumCase).contains(hearingCentreEmailAddress));
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerSubmittedHearingRequirementsPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerSubmittedHearingRequirementsPersonalisationTest.java
@@ -76,7 +76,7 @@ public class CaseOfficerSubmittedHearingRequirementsPersonalisationTest {
 
     @Test
     public void should_return_given_email_address_from_asylum_case_when_feature_flag_is_On() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         assertEquals(Collections.singleton(hearingCentreEmailAddress),
                 caseOfficerSubmittedHearingRequirementsPersonalisation.getRecipientsList(asylumCase));
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerUploadAddendumEvidencePersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerUploadAddendumEvidencePersonalisationTest.java
@@ -73,7 +73,7 @@ public class CaseOfficerUploadAddendumEvidencePersonalisationTest {
 
     @Test
     public void should_return_given_email_address_from_asylum_case_when_feature_flag_is_On() {
-        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        when(featureToggler.getValue("tcw-notifications-feature", true)).thenReturn(true);
         assertEquals(Collections.singleton(hearingCentreEmailAddress),
                 caseOfficerUploadAddendumEvidencePersonalisation.getRecipientsList(asylumCase));
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[RIA-4748](https://tools.hmcts.net/jira/browse/RIA-4748)


### Change description ###

Change the default value to true for the **tcw-notifications** LD feature flag. This will ensure that the notifications continue to go our in the event the flag is unavailable. This will also address the Nightly Build issue.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
