### PR TITLE
RIA-5308 | stop the attempt of non-standard direction to LR in AIP jo…

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-5308-send-respondent-non-standard-direction-aip-awaiting-respondent-evidence.json
+++ b/src/functionalTest/resources/scenarios/RIA-5308-send-respondent-non-standard-direction-aip-awaiting-respondent-evidence.json
@@ -1,0 +1,78 @@
+{
+  "description": "RIA-5308 Send respondent non-standard direction for AIP journey in awaitingRespondentEvidence state",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 1022,
+      "eventId": "sendDirection",
+      "state": "awaitingRespondentEvidence",
+      "caseData": {
+        "template": "aip-minimal-appeal-submitted.json",
+        "replacements": {
+          "currentCaseStateVisibleToLegalRepresentative": "awaitingRespondentEvidence",
+          "currentCaseStateVisibleToHomeOfficeAll": "awaitingRespondentEvidence",
+          "directions": [
+            {
+              "id": "1",
+              "value": {
+                "explanation": "Do the non standard thing",
+                "parties": "respondent",
+                "dateDue": "{$TODAY+14}",
+                "dateSent": "{$TODAY}",
+                "tag": ""
+              }
+            }
+          ],
+          "notificationsSent": []
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "aip-minimal-appeal-submitted.json",
+      "replacements": {
+        "currentCaseStateVisibleToHomeOfficeAll": "awaitingRespondentEvidence",
+        "directions": [
+          {
+            "id": "1",
+            "value": {
+              "explanation": "Do the non standard thing",
+              "parties": "respondent",
+              "dateDue": "{$TODAY+14}",
+              "dateSent": "{$TODAY}",
+              "tag": ""
+            }
+          }
+        ],
+        "notificationsSent": [
+          {
+            "id": "1022_RESPONDENT_NON_STANDARD_DIRECTION",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "1022_RESPONDENT_NON_STANDARD_DIRECTION",
+        "recipient": "{$apcHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: direction",
+        "body": [
+          "PA/12345/2019",
+          "A1234567",
+          "Pablo Jimenez",
+          "{$iaExUiFrontendUrl}",
+          "Do the non standard thing",
+          "{$TODAY+14|d MMM yyyy}",
+          "{$customerServices.telephoneNumber}",
+          "{$customerServices.emailAddress}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -789,6 +789,25 @@ public class NotificationGeneratorConfiguration {
         );
     }
 
+    @Bean("awaitingRespondentDirectionAipNotificationGenerator")
+    public List<NotificationGenerator> awaitingRespondentDirectionAipNotificationGenerator(
+            RespondentNonStandardDirectionPersonalisation respondentNonStandardDirectionPersonalisation,
+            NotificationSender notificationSender,
+            NotificationIdAppender notificationIdAppender) {
+
+        List<EmailNotificationPersonalisation> personalisations = isHomeOfficeGovNotifyEnabled
+                ?  newArrayList(respondentNonStandardDirectionPersonalisation)
+                : Collections.emptyList();
+
+        return Arrays.asList(
+                new EmailNotificationGenerator(
+                        personalisations,
+                        notificationSender,
+                        notificationIdAppender
+                )
+        );
+    }
+
     @Bean("legalRepDirectionNotificationGenerator")
     public List<NotificationGenerator> legalRepDirectionNotificationGenerator(
         RespondentNonStandardDirectionPersonalisation respondentNonStandardDirectionPersonalisation,

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -892,9 +892,33 @@ public class NotificationHandlerConfiguration {
                 return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                        && callback.getEvent() == Event.SEND_DIRECTION
                        && isValidUserDirection(directionFinder, asylumCase, DirectionTag.NONE, Parties.RESPONDENT)
-                       && callback.getCaseDetails().getState() == State.AWAITING_RESPONDENT_EVIDENCE;
+                       && callback.getCaseDetails().getState() == State.AWAITING_RESPONDENT_EVIDENCE
+                       && isRepJourney(asylumCase);
             },
             notificationGenerators
+        );
+    }
+
+    @Bean
+    public PreSubmitCallbackHandler<AsylumCase> awaitingRespondentDirectionAipNotificationHandler(
+            @Qualifier("awaitingRespondentDirectionAipNotificationGenerator") List<NotificationGenerator> notificationGenerators,
+            DirectionFinder directionFinder) {
+
+        return new NotificationHandler(
+                (callbackStage, callback) -> {
+                    AsylumCase asylumCase =
+                            callback
+                                    .getCaseDetails()
+                                    .getCaseData();
+
+                    return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                            && callback.getEvent() == Event.SEND_DIRECTION
+                            && isValidUserDirection(directionFinder, asylumCase, DirectionTag.NONE, Parties.RESPONDENT)
+                            && callback.getCaseDetails().getState() == State.AWAITING_RESPONDENT_EVIDENCE
+                            && isAipJourney(asylumCase)
+                            && !notificationGenerators.isEmpty();
+                },
+                notificationGenerators
         );
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-5308


### Change description ###
When sending a non standard direction to respondent, an attempt would be made to send to the legal representative as well.
For an AIP journey, there is no legal representative so would cause an error, throwing exceptions
This change stops this by adding another notification handler and generator which is exclusively for the AIP journey, to stop this error from happening


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
