### PR TITLE
RIA-5599 Update BailDirection to match the version from ia-bal-case-api

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/BailDirection.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/BailDirection.java
@@ -2,8 +2,10 @@ package uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
 
 @EqualsAndHashCode
 @ToString
@@ -15,6 +17,7 @@ public class BailDirection {
     private String dateSent;
     private String dateTimeDirectionCreated;
     private String dateTimeDirectionModified;
+    private List<IdValue<PreviousDates>> previousDates;
 
 
     private BailDirection() {
@@ -26,7 +29,8 @@ public class BailDirection {
         String dateOfCompliance,
         String dateSent,
         String dateTimeDirectionCreated,
-        String dateTimeDirectionModified
+        String dateTimeDirectionModified,
+        List<IdValue<PreviousDates>> previousDates
     ) {
         this.sendDirectionDescription = requireNonNull(sendDirectionDescription);
         this.sendDirectionList = requireNonNull(sendDirectionList);
@@ -34,6 +38,7 @@ public class BailDirection {
         this.dateSent = requireNonNull(dateSent);
         this.dateTimeDirectionCreated = requireNonNull(dateTimeDirectionCreated);
         this.dateTimeDirectionModified = dateTimeDirectionModified;
+        this.previousDates = previousDates;
     }
 
 
@@ -59,5 +64,9 @@ public class BailDirection {
 
     public String getDateTimeDirectionModified() {
         return dateTimeDirectionModified;
+    }
+
+    public List<IdValue<PreviousDates>> getPreviousDates() {
+        return previousDates;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/BailDirectionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/BailDirectionTest.java
@@ -3,11 +3,15 @@ package uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
 
 public class BailDirectionTest {
 
     private static String TEST_VALUE = "some-value";
+    private static List<IdValue<PreviousDates>> TEST_VALUE_PD = Collections.emptyList();
 
     private BailDirection bailDirection = new BailDirection(
         TEST_VALUE,
@@ -15,7 +19,8 @@ public class BailDirectionTest {
         TEST_VALUE,
         TEST_VALUE,
         TEST_VALUE,
-        TEST_VALUE
+        TEST_VALUE,
+        TEST_VALUE_PD
     );
 
     @Test
@@ -27,12 +32,14 @@ public class BailDirectionTest {
         assertEquals(TEST_VALUE, bailDirection.getDateSent());
         assertEquals(TEST_VALUE, bailDirection.getDateTimeDirectionCreated());
         assertEquals(TEST_VALUE, bailDirection.getDateTimeDirectionModified());
+        assertEquals(TEST_VALUE_PD, bailDirection.getPreviousDates());
+
     }
 
     @Test
     public void should_not_allow_null_arguments() {
 
-        assertThatThrownBy(() -> new BailDirection(null, null, null, null, null, null))
+        assertThatThrownBy(() -> new BailDirection(null, null, null, null, null, null, null))
             .isExactlyInstanceOf(NullPointerException.class);
 
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-5599](https://tools.hmcts.net/jira/browse/RIA-5599)


### Change description ###
- BailDirection needs to mirror the Direction class in ia-bail-case-api, which has been expanded to include a new field (`PreviousDates`)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
