### PR TITLE
RIA-5747 Use a different template for remission rejected LR notification

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -95,7 +95,7 @@ govnotify:
         partiallyApproved:
           email: 717b0290-36eb-4adf-a4c5-baacf59d379d
         rejected:
-          email: 8a48b422-c6ed-448d-aec0-a5b43bd2b472
+          email: bd1bc55d-cece-4aff-b38a-a72e506f662a
       adminOfficer:
         approved:
           email: e819fd09-b350-41b3-a211-18d58936b65d


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-5747](https://tools.hmcts.net/jira/browse/RIA-5747)


### Change description ###
- When admin triggers the RECORD_REMISSION_DECISION event && remission is REJECTED, an email notification is being sent to LR. It's now pointing to the [new template](https://www.notifications.service.gov.uk/services/7f72d0fb-2bc4-421b-bceb-1bf5bf350ff9/templates/bd1bc55d-cece-4aff-b38a-a72e506f662a) rather than the[ old template](https://www.notifications.service.gov.uk/services/7f72d0fb-2bc4-421b-bceb-1bf5bf350ff9/templates/8a48b422-c6ed-448d-aec0-a5b43bd2b472), instead of changing the old template directly. So that the new template will only be used by whatever environment the dev branch (ia-case-notifications-card-payments) is being promoted to.
- The old template can be archived when there'll no environment left using it
- AIP does not seem to be using this template


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
