### PR TITLE
RIA-6121 Change HO permission roles for bail notification events

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -987,10 +987,6 @@ security:
       - "uploadAddendumEvidenceHomeOffice"
       - "applyForFTPARespondent"
       - "makeAnApplication"
-      - "submitApplication"
-      - "uploadBailSummary"
-      - "uploadDocuments"
-      - "makeNewApplication"
     caseworker-ia-iacjudge:
       - "endAppeal"
       - "sendDecisionAndReasons"
@@ -1014,6 +1010,12 @@ security:
       - "changeBailDirectionDueDate"
     caseworker-ia-system:
       - "requestHearingRequirementsFeature"
+    caseworker-ia-homeofficebail:
+      - "submitApplication"
+      - "uploadBailSummary"
+      - "uploadDocuments"
+      - "makeNewApplication"
+
 
 ### dependency configuration
 core_case_data_api_url: ${CCD_URL:http://127.0.0.1:4452}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6121


### Change description ###
This is to allow any home office user with home office bails to process bails notification events


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
