### PR TITLE
RIA-5586 Added New AppealType

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AppealType.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AppealType.java
@@ -11,7 +11,8 @@ public enum AppealType {
     PA("protection"),
     EA("refusalOfEu"),
     HU("refusalOfHumanRights"),
-    DC("deprivation");
+    DC("deprivation"),
+    EU("euSettlementScheme");
 
     @JsonValue
     private String value;
@@ -21,11 +22,11 @@ public enum AppealType {
     }
 
     public static Optional<AppealType> from(
-        String value
+            String value
     ) {
         return stream(values())
-            .filter(v -> v.getValue().equals(value))
-            .findFirst();
+                .filter(v -> v.getValue().equals(value))
+                .findFirst();
     }
 
     public String getValue() {

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AppealTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AppealTypeTest.java
@@ -14,6 +14,7 @@ public class AppealTypeTest {
         assertEquals(AppealType.from("refusalOfEu").get(), AppealType.EA);
         assertEquals(AppealType.from("refusalOfHumanRights").get(), AppealType.HU);
         assertEquals(AppealType.from("deprivation").get(), AppealType.DC);
+        assertEquals(AppealType.from("euSettlementScheme").get(), AppealType.EU);
     }
 
     @Test
@@ -23,6 +24,6 @@ public class AppealTypeTest {
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(5, AppealType.values().length);
+        assertEquals(6, AppealType.values().length);
     }
 }


### PR DESCRIPTION
JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/RIA-5586

Change description
Remove "My client is not appealing an EU Settlement Scheme decision" from "Tell us about your client" page.
Add "EU Settlement Scheme" to appeal options in Type of appeals page.
Ensure that Type of appeal should appear as EU Settlement Scheme in the CYA page.

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[ x] No