### PR TITLE
RIA-6121 Change HO permission roles for bail notification events v2

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -42,4 +42,10 @@
         <cve>CVE-2022-34305</cve>
         <cve>CVE-2022-25857</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[file name: snakeyaml-1.26.jar]]></notes>
+        <cve>CVE-2022-38749</cve>
+        <cve>CVE-2022-38750</cve>
+        <cve>CVE-2022-38751</cve>
+    </suppress>
 </suppressions>

--- a/src/functionalTest/resources/scenarios/RIA-1647-RIA-1276-RIA-2936-end-appeal-home-office-notification-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-1647-RIA-1276-RIA-2936-end-appeal-home-office-notification-after-listing.json
@@ -49,7 +49,7 @@
       {
         "reference": "162762936_END_APPEAL_HOME_OFFICE",
         "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
-        "subject": "Immigration and Asylum appeal: Your appeal has ended – Withdrawn",
+        "subject": "Immigration and Asylum appeal: appeal ended – Withdrawn",
         "body": [
           "PA/12345/2019",
           "LP/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2239-RIA-2936-end-appeal-home-office-notification-judge-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-2239-RIA-2936-end-appeal-home-office-notification-judge-after-listing.json
@@ -49,7 +49,7 @@
       {
         "reference": "22392936_END_APPEAL_HOME_OFFICE",
         "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
-        "subject": "Immigration and Asylum appeal: Your appeal has ended – Withdrawn",
+        "subject": "Immigration and Asylum appeal: appeal ended – Withdrawn",
         "body": [
           "PA/12345/2019",
           "LP/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-4321-end-appeal-aip-notification-after-listing-CO.json
+++ b/src/functionalTest/resources/scenarios/RIA-4321-end-appeal-aip-notification-after-listing-CO.json
@@ -76,7 +76,7 @@
       {
         "reference": "34889657_END_APPEAL_HOME_OFFICE",
         "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
-        "subject": "Immigration and Asylum appeal: Your appeal has ended – Withdrawn",
+        "subject": "Immigration and Asylum appeal: appeal ended – Withdrawn",
         "body": [
           "PA/12345/2019",
           "A1234567",

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1011,10 +1011,6 @@ security:
       - "uploadAddendumEvidenceHomeOffice"
       - "applyForFTPARespondent"
       - "makeAnApplication"
-      - "submitApplication"
-      - "uploadBailSummary"
-      - "uploadDocuments"
-      - "makeNewApplication"
     caseworker-ia-iacjudge:
       - "endAppeal"
       - "sendDecisionAndReasons"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1038,6 +1038,11 @@ security:
       - "changeBailDirectionDueDate"
     caseworker-ia-system:
       - "requestHearingRequirementsFeature"
+    caseworker-ia-homeofficebail:
+      - "submitApplication"
+      - "uploadBailSummary"
+      - "uploadDocuments"
+      - "makeNewApplication"
 
 ### dependency configuration
 core_case_data_api_url: ${CCD_URL:http://127.0.0.1:4452}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6121


### Change description ###
This is to allow any home office user with home office bails to process bails notification events


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
