### PR TITLE
RIA-5965: Send notifications after NoC

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -41,5 +41,8 @@
         <cve>CVE-2022-29885</cve>
         <cve>CVE-2022-34305</cve>
         <cve>CVE-2022-25857</cve>
+        <cve>CVE-2022-38749</cve>
+        <cve>CVE-2022-38750</cve>
+        <cve>CVE-2022-38751</cve>
     </suppress>
 </suppressions>

--- a/src/functionalTest/resources/scenarios/bail/RIA-5965-send-notification-noc-appellant-sms.json
+++ b/src/functionalTest/resources/scenarios/bail/RIA-5965-send-notification-noc-appellant-sms.json
@@ -1,0 +1,32 @@
+{
+  "description": "RIA-5965 send NoC notification to appellant SMS",
+  "request": {
+    "uri": "/bail/ccdSubmitted",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "id": 5965,
+      "eventId": "nocRequestBail",
+      "state": "applicationSubmitted",
+      "caseData": {
+        "template": "minimal-bail-application-submitted.json",
+        "replacements": {
+          "currentCaseStateVisibleToAdminOfficer": "applicationSubmitted",
+          "applicantMobileNumber1": "{$TEST_CITIZEN_MOBILE}",
+          "applicantHasMobile": "Yes",
+          "currentCaseStateVisibleToLegalRepresentative": "applicationSubmitted"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "confirmation": {
+      "header": "success",
+      "body": "contains([_BAIL_NOC_CHANGED_LR_APPLICANT_SMS])",
+      "body": "contains([_BAIL_NOC_CHANGED_LR_ADMIN])",
+      "body": "contains([_BAIL_NOC_CHANGED_LR_LEGAL_REPRESENTATIVE])",
+      "body": "contains([_BAIL_NOC_CHANGED_LR_HOME_OFFICE])"
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/bail/RIA-5965-send-notification-noc.json
+++ b/src/functionalTest/resources/scenarios/bail/RIA-5965-send-notification-noc.json
@@ -1,0 +1,33 @@
+{
+  "description": "RIA-5965 send NoC notification to legal representative",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "request": {
+    "uri": "/bail/ccdSubmitted",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "id": 5965,
+      "eventId": "nocRequestBail",
+      "state": "applicationSubmitted",
+      "caseData": {
+        "template": "minimal-bail-application-submitted.json",
+        "replacements": {
+          "isLegallyRepresentedForFlag": "Yes",
+          "currentCaseStateVisibleToJudge": "applicationSubmitted",
+          "currentCaseStateVisibleToHomeOffice": "applicationSubmitted",
+          "currentCaseStateVisibleToAdminOfficer": "applicationSubmitted",
+          "currentCaseStateVisibleToLegalRepresentative": "applicationSubmitted"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "confirmation": {
+      "header": "success",
+      "body": "contains([_BAIL_NOC_CHANGED_LR_LEGAL_REPRESENTATIVE])",
+      "body": "contains([_BAIL_NOC_CHANGED_LR_ADMIN])",
+      "body": "contains([_BAIL_NOC_CHANGED_LR_HOME_OFFICE])"
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/Event.java
@@ -93,6 +93,7 @@ public enum Event {
     CHANGE_BAIL_DIRECTION_DUE_DATE("changeBailDirectionDueDate"),
     MAKE_NEW_APPLICATION("makeNewApplication"),
     EDIT_BAIL_APPLICATION_AFTER_SUBMIT("editBailApplicationAfterSubmit"),
+    NOC_REQUEST_BAIL("nocRequestBail"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/postsubmit/BailPostSubmitNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/postsubmit/BailPostSubmitNotificationHandler.java
@@ -1,0 +1,87 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.handlers.postsubmit;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiPredicate;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.Message;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.PostSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.handlers.ErrorHandler;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.handlers.PostSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.BailNotificationGenerator;
+
+
+public class BailPostSubmitNotificationHandler implements PostSubmitCallbackHandler<BailCase> {
+
+    private final BiPredicate<PostSubmitCallbackStage, Callback<BailCase>> canHandleFunction;
+    private final List<? extends BailNotificationGenerator> bailNotificationGenerators;
+    private final Optional<ErrorHandler<BailCase>> errorHandling;
+
+    public BailPostSubmitNotificationHandler(BiPredicate<PostSubmitCallbackStage, Callback<BailCase>> canHandleFunction,
+                                             List<? extends BailNotificationGenerator> bailNotificationGenerators
+    ) {
+        this.canHandleFunction = canHandleFunction;
+        this.bailNotificationGenerators = bailNotificationGenerators;
+        this.errorHandling = Optional.empty();
+    }
+
+    public BailPostSubmitNotificationHandler(BiPredicate<PostSubmitCallbackStage, Callback<BailCase>> canHandleFunction,
+                                             List<? extends BailNotificationGenerator> bailNotificationGenerators,
+                                             ErrorHandler<BailCase> errorHandling
+    ) {
+        this.canHandleFunction = canHandleFunction;
+        this.bailNotificationGenerators = bailNotificationGenerators;
+        this.errorHandling = Optional.ofNullable(errorHandling);
+    }
+
+    @Override
+    public boolean canHandle(PostSubmitCallbackStage callbackStage, Callback<BailCase> callback) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return canHandleFunction.test(callbackStage, callback);
+    }
+
+    @Override
+    public PostSubmitCallbackResponse handle(PostSubmitCallbackStage callbackStage, Callback<BailCase> callback) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        PostSubmitCallbackResponse postSubmitCallbackResponse = new PostSubmitCallbackResponse("success", "success");
+
+        try {
+            bailNotificationGenerators.forEach(notificationGenerator -> notificationGenerator.generate(callback));
+
+            if (!bailNotificationGenerators.isEmpty()) {
+
+                int lastNotificationGeneratorIndex = bailNotificationGenerators.size() - 1;
+                Message message = bailNotificationGenerators.get(lastNotificationGeneratorIndex).getSuccessMessage();
+
+                if (message.getMessageHeader() != null) {
+                    postSubmitCallbackResponse.setConfirmationHeader(message.getMessageHeader());
+                }
+                if (message.getMessageBody() != null) {
+
+                    BailCase bailCase =
+                        callback
+                            .getCaseDetails()
+                            .getCaseData();
+
+                    postSubmitCallbackResponse.setConfirmationBody(bailCase.toString());
+                }
+            }
+        } catch (Exception e) {
+            if (errorHandling.isPresent()) {
+                errorHandling.get().accept(callback, e);
+            } else {
+                throw e;
+            }
+        }
+        return postSubmitCallbackResponse;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/postsubmit/PostSubmitNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/postsubmit/PostSubmitNotificationHandler.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.function.BiPredicate;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.Message;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.PostSubmitCallbackStage;
@@ -43,6 +44,9 @@ public class PostSubmitNotificationHandler implements PostSubmitCallbackHandler<
         requireNonNull(callbackStage, "callbackStage must not be null");
         requireNonNull(callback, "callback must not be null");
 
+        if (getEventsToSkip().contains(callback.getEvent())) {
+            return false;
+        }
         return canHandleFunction.test(callbackStage, callback);
     }
 
@@ -56,7 +60,6 @@ public class PostSubmitNotificationHandler implements PostSubmitCallbackHandler<
 
         try {
             notificationGenerators.forEach(notificationGenerator -> notificationGenerator.generate(callback));
-
             if (!notificationGenerators.isEmpty()) {
 
                 int lastNotificationGeneratorIndex = notificationGenerators.size() - 1;
@@ -83,5 +86,11 @@ public class PostSubmitNotificationHandler implements PostSubmitCallbackHandler<
             }
         }
         return postSubmitCallbackResponse;
+    }
+
+    private List<Event> getEventsToSkip() {
+        return List.of(
+            Event.NOC_REQUEST_BAIL
+        );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/bail/adminofficer/email/AdminOfficerBailNocChangedLrPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/bail/adminofficer/email/AdminOfficerBailNocChangedLrPersonalisation.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.adminofficer.email;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import javax.validation.constraints.NotNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.BailEmailNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
+
+@Service
+public class AdminOfficerBailNocChangedLrPersonalisation implements BailEmailNotificationPersonalisation {
+
+    private final String adminOfficeBailNocChangedLrPersonalisationTemplateId;
+    private final EmailAddressFinder emailAddressFinder;
+
+    public AdminOfficerBailNocChangedLrPersonalisation(
+        @NotNull(message = "adminOfficeBailNocChangedLrPersonalisationTemplateId cannot be null")
+        @Value("${govnotify.bail.template.nocChangedLRForAdmin.email}") String adminOfficeBailNocChangedLrPersonalisationTemplateId,
+        EmailAddressFinder emailAddressFinder
+    ) {
+        this.adminOfficeBailNocChangedLrPersonalisationTemplateId = adminOfficeBailNocChangedLrPersonalisationTemplateId;
+        this.emailAddressFinder = emailAddressFinder;
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_BAIL_NOC_CHANGED_LR_ADMIN";
+    }
+
+    @Override
+    public String getTemplateId(BailCase bailCase) {
+        return adminOfficeBailNocChangedLrPersonalisationTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(BailCase bailCase) {
+        return Collections.singleton(emailAddressFinder.getBailHearingCentreEmailAddress(bailCase));
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(BailCase bailCase) {
+        requireNonNull(bailCase, "bailCase must not be null");
+
+        return ImmutableMap
+            .<String, String>builder()
+            .put("bailReferenceNumber", bailCase.read(BailCaseFieldDefinition.BAIL_REFERENCE_NUMBER, String.class).orElse(""))
+            .put("legalRepReference", bailCase.read(BailCaseFieldDefinition.LEGAL_REP_REFERENCE, String.class).orElse(""))
+            .put("applicantGivenNames", bailCase.read(BailCaseFieldDefinition.APPLICANT_GIVEN_NAMES, String.class).orElse(""))
+            .put("applicantFamilyName", bailCase.read(BailCaseFieldDefinition.APPLICANT_FAMILY_NAME, String.class).orElse(""))
+            .put("homeOfficeReferenceNumber", bailCase.read(BailCaseFieldDefinition.HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""))
+            .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/bail/applicant/sms/ApplicantBailNocChangedLrPersonalisationSms.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/bail/applicant/sms/ApplicantBailNocChangedLrPersonalisationSms.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.applicant.sms;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.applicant.ApplicantBailSmsNotificationPersonalisation;
+
+@Service
+public class ApplicantBailNocChangedLrPersonalisationSms implements ApplicantBailSmsNotificationPersonalisation {
+
+    private final String nocChangedLrApplicantSmsTemplateId;
+
+    public ApplicantBailNocChangedLrPersonalisationSms(
+            @Value("${govnotify.bail.template.nocChangedLRForApplicant.sms}") String nocChangedLrApplicantSmsTemplateId) {
+        this.nocChangedLrApplicantSmsTemplateId = nocChangedLrApplicantSmsTemplateId;
+    }
+
+    @Override
+    public String getTemplateId() {
+        return nocChangedLrApplicantSmsTemplateId;
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_BAIL_NOC_CHANGED_LR_APPLICANT_SMS";
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(BailCase bailCase) {
+        requireNonNull(bailCase, "bailCase must not be null");
+
+        return ImmutableMap
+                .<String, String>builder()
+                .put("applicantGivenNames", bailCase.read(BailCaseFieldDefinition.APPLICANT_GIVEN_NAMES, String.class).orElse(""))
+                .put("applicantFamilyName", bailCase.read(BailCaseFieldDefinition.APPLICANT_FAMILY_NAME, String.class).orElse(""))
+                .put("applicantDateOfBirth", bailCase.read(BailCaseFieldDefinition.APPLICANT_DATE_OF_BIRTH, String.class).orElse(""))
+                .put("bailReferenceNumber", bailCase.read(BailCaseFieldDefinition.BAIL_REFERENCE_NUMBER, String.class).orElse(""))
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/bail/homeoffice/email/HomeOfficeBailNocChangedLrPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/bail/homeoffice/email/HomeOfficeBailNocChangedLrPersonalisation.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.homeoffice.email;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import javax.validation.constraints.NotNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.BailEmailNotificationPersonalisation;
+
+@Service
+public class HomeOfficeBailNocChangedLrPersonalisation implements BailEmailNotificationPersonalisation {
+
+    private final String homeOfficeBailNocChangedLrPersonalisationTemplateId;
+    private final String bailHomeOfficeEmailAddress;
+
+
+    public HomeOfficeBailNocChangedLrPersonalisation(
+        @NotNull(message = "homeOfficeBailNocChangedLrPersonalisationTemplateId cannot be null")
+        @Value("${govnotify.bail.template.nocChangedLRForHO.email}") String homeOfficeBailNocChangedLrPersonalisationTemplateId,
+        @Value("${bailHomeOfficeEmailAddress}") String bailHomeOfficeEmailAddress
+    ) {
+        this.homeOfficeBailNocChangedLrPersonalisationTemplateId = homeOfficeBailNocChangedLrPersonalisationTemplateId;
+        this.bailHomeOfficeEmailAddress = bailHomeOfficeEmailAddress;
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_BAIL_NOC_CHANGED_LR_HOME_OFFICE";
+    }
+
+    @Override
+    public String getTemplateId(BailCase bailCase) {
+        return homeOfficeBailNocChangedLrPersonalisationTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(BailCase bailCase) {
+        return Collections.singleton(bailHomeOfficeEmailAddress);
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(BailCase bailCase) {
+        requireNonNull(bailCase, "bailCase must not be null");
+
+        return ImmutableMap
+            .<String, String>builder()
+            .put("bailReferenceNumber", bailCase.read(BailCaseFieldDefinition.BAIL_REFERENCE_NUMBER, String.class).orElse(""))
+            .put("legalRepReference", bailCase.read(BailCaseFieldDefinition.LEGAL_REP_REFERENCE, String.class).orElse(""))
+            .put("applicantGivenNames", bailCase.read(BailCaseFieldDefinition.APPLICANT_GIVEN_NAMES, String.class).orElse(""))
+            .put("applicantFamilyName", bailCase.read(BailCaseFieldDefinition.APPLICANT_FAMILY_NAME, String.class).orElse(""))
+            .put("homeOfficeReferenceNumber", bailCase.read(BailCaseFieldDefinition.HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""))
+            .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/bail/legalrepresentative/email/LegalRepresentativeBailNocChangedLrPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/bail/legalrepresentative/email/LegalRepresentativeBailNocChangedLrPersonalisation.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.legalrepresentative.email;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import javax.validation.constraints.NotNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.legalrepresentative.LegalRepresentativeBailEmailNotificationPersonalisation;
+
+@Service
+public class LegalRepresentativeBailNocChangedLrPersonalisation implements LegalRepresentativeBailEmailNotificationPersonalisation {
+
+    private final String legalRepresentativeBailNocChangedLrPPersonalisationTemplateId;
+
+
+    public LegalRepresentativeBailNocChangedLrPersonalisation(
+        @NotNull(message = "legalRepresentativeBailNocChangedLrPPersonalisationTemplateId cannot be null")
+        @Value("${govnotify.bail.template.nocChangedLRForLR.email}") String legalRepresentativeBailNocChangedLrPPersonalisationTemplateId
+    ) {
+        this.legalRepresentativeBailNocChangedLrPPersonalisationTemplateId = legalRepresentativeBailNocChangedLrPPersonalisationTemplateId;
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_BAIL_NOC_CHANGED_LR_LEGAL_REPRESENTATIVE";
+    }
+
+    @Override
+    public String getTemplateId() {
+        return legalRepresentativeBailNocChangedLrPPersonalisationTemplateId;
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(BailCase bailCase) {
+        requireNonNull(bailCase, "bailCase must not be null");
+
+        return ImmutableMap
+            .<String, String>builder()
+            .put("bailReferenceNumber", bailCase.read(BailCaseFieldDefinition.BAIL_REFERENCE_NUMBER, String.class).orElse(""))
+            .put("legalRepReference", bailCase.read(BailCaseFieldDefinition.LEGAL_REP_REFERENCE, String.class).orElse(""))
+            .put("applicantGivenNames", bailCase.read(BailCaseFieldDefinition.APPLICANT_GIVEN_NAMES, String.class).orElse(""))
+            .put("applicantFamilyName", bailCase.read(BailCaseFieldDefinition.APPLICANT_FAMILY_NAME, String.class).orElse(""))
+            .put("homeOfficeReferenceNumber", bailCase.read(BailCaseFieldDefinition.HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""))
+            .build();
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/BailNotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/BailNotificationGeneratorConfiguration.java
@@ -6,9 +6,11 @@ import java.util.Arrays;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.adminofficer.email.AdminOfficerBailNocChangedLrPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.adminofficer.email.AdminOfficerBailSummaryUploadedPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.applicant.sms.ApplicantBailApplicationEndedPersonalisationSms;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.applicant.sms.ApplicantBailApplicationSubmittedPersonalisationSms;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.applicant.sms.ApplicantBailNocChangedLrPersonalisationSms;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.applicant.sms.ApplicantBailSignedDecisionNoticeUploadedPersonalisationSms;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.hearingcentre.email.HearingCentreSubmitApplicationPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.homeoffice.email.*;
@@ -330,6 +332,32 @@ public class BailNotificationGeneratorConfiguration {
         return List.of(
             new BailEmailNotificationGenerator(
                 newArrayList(homeOfficeBailApplicationEditAfterSubmitPersonalisation),
+                notificationSender,
+                notificationIdAppender
+            )
+        );
+    }
+
+
+    @Bean("nocChangedLegalRepNotificationGenerator")
+    public List<BailNotificationGenerator> nocChangedLegalRepNotificationGenerator(
+        LegalRepresentativeBailNocChangedLrPersonalisation legalRepresentativeBailNocChangedLrPersonalisation,
+        AdminOfficerBailNocChangedLrPersonalisation adminOfficerBailNocChangedLrPersonalisation,
+        HomeOfficeBailNocChangedLrPersonalisation homeOfficeBailNocChangedLrPersonalisation,
+        ApplicantBailNocChangedLrPersonalisationSms applicantBailNocChangedLrPersonalisationSms,
+        BailGovNotifyNotificationSender notificationSender,
+        BailNotificationIdAppender notificationIdAppender) {
+
+        return Arrays.asList(
+            new BailEmailNotificationGenerator(
+                newArrayList(legalRepresentativeBailNocChangedLrPersonalisation,
+                    adminOfficerBailNocChangedLrPersonalisation,
+                    homeOfficeBailNocChangedLrPersonalisation),
+                notificationSender,
+                notificationIdAppender
+            ),
+            new BailSmsNotificationGenerator(
+                newArrayList(applicantBailNocChangedLrPersonalisationSms),
                 notificationSender,
                 notificationIdAppender
             )

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/BailNotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/BailNotificationHandlerConfiguration.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.config;
 
-
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition.IS_LEGALLY_REPRESENTED_FOR_FLAG;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition.SUBMIT_NOTIFICATION_STATUS;
 
@@ -11,10 +10,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.PostSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.handlers.ErrorHandler;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.handlers.PostSubmitCallbackHandler;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.handlers.postsubmit.BailPostSubmitNotificationHandler;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.handlers.presubmit.BailNotificationHandler;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.BailNotificationGenerator;
 
@@ -373,6 +375,19 @@ public class BailNotificationHandlerConfiguration {
             },
             bailNotificationGenerators,
             getErrorHandler()
+        );
+    }
+
+    @Bean
+    public PostSubmitCallbackHandler<BailCase> nocChangedLegalRepNotificationHandler(
+        @Qualifier("nocChangedLegalRepNotificationGenerator") List<BailNotificationGenerator> bailNotificationGenerators
+    ) {
+        return new BailPostSubmitNotificationHandler(
+            (callbackStage, callback) -> {
+                return callbackStage == PostSubmitCallbackStage.CCD_SUBMITTED
+                    && callback.getEvent() == Event.NOC_REQUEST_BAIL;
+            },
+            bailNotificationGenerators
         );
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -884,6 +884,7 @@ security:
   roleEventAccess:
     caseworker-caa:
       - "nocRequest"
+      - "nocRequestBail"
     caseworker-approver:
       - "removeRepresentation"
       - "removeLegalRepresentative"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -846,6 +846,14 @@ govnotify:
         email: 84d48a3f-afd6-4759-9219-22cb37bebabb
       editApplicationAfterSubmitWithoutLr:
         email: 160386c8-7fc5-4359-8d3d-f99765af00d5
+      nocChangedLRForLR:
+        email: 803cc8e0-1b98-4154-9d91-b1f56cbe85d7
+      nocChangedLRForHO:
+        email: a7d6c3bc-2108-4fba-995c-bb8a407ae58f
+      nocChangedLRForAdmin:
+        email: 8a745ed0-63f0-4a35-8cf0-f2ed4f962daf
+      nocChangedLRForApplicant:
+        sms: 8141263c-c1f1-4f86-a164-ab48df561dbe
 
 
 notificationSender.deduplicateSendsWithinSeconds: 60
@@ -915,6 +923,7 @@ security:
       - "submitApplication"
       - "uploadDocuments"
       - "makeNewApplication"
+      - "nocRequestBail"
     caseworker-ia-caseofficer:
       - "sendDirection"
       - "changeDirectionDueDate"

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/EventTest.java
@@ -97,11 +97,12 @@ public class EventTest {
         assertEquals("sendBailDirection", SEND_BAIL_DIRECTION.toString());
         assertEquals("makeNewApplication", MAKE_NEW_APPLICATION.toString());
         assertEquals("editBailApplicationAfterSubmit", EDIT_BAIL_APPLICATION_AFTER_SUBMIT.toString());
+        assertEquals("nocRequestBail", NOC_REQUEST_BAIL.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(90, Event.values().length);
+        assertEquals(91, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/postsubmit/BailPostSubmitNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/postsubmit/BailPostSubmitNotificationHandlerTest.java
@@ -3,7 +3,10 @@ package uk.gov.hmcts.reform.iacasenotificationsapi.domain.handlers.postsubmit;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -13,58 +16,57 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.Message;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.CaseDetails;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.PostSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.handlers.ErrorHandler;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.NotificationGenerator;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.BailNotificationGenerator;
 
 @ExtendWith(MockitoExtension.class)
-class PostSubmitNotificationHandlerTest {
+class BailPostSubmitNotificationHandlerTest {
 
     @Mock
-    Callback<AsylumCase> callback;
+    Callback<BailCase> callback;
     @Mock
-    CaseDetails<AsylumCase> caseDetails;
+    CaseDetails<BailCase> caseDetails;
     @Mock
-    AsylumCase asylumCase;
+    BailCase bailCase;
     @Mock
-    NotificationGenerator notificationGenerator;
+    BailNotificationGenerator notificationGenerator;
     @Mock
-    BiPredicate<PostSubmitCallbackStage, Callback<AsylumCase>> canHandle;
+    BiPredicate<PostSubmitCallbackStage, Callback<BailCase>> canHandle;
     @Mock
-    ErrorHandler<AsylumCase> errorHandler;
+    ErrorHandler<BailCase> errorHandler;
 
     private PostSubmitCallbackStage callbackStage = PostSubmitCallbackStage.CCD_SUBMITTED;
-    private PostSubmitNotificationHandler notificationHandler;
+    private BailPostSubmitNotificationHandler notificationHandler;
     private Message expectedMessage = new Message("success", "success");
 
     @BeforeEach
     void setUp() {
-        notificationHandler = new PostSubmitNotificationHandler(canHandle, Collections.singletonList(notificationGenerator));
+        notificationHandler = new BailPostSubmitNotificationHandler(canHandle, Collections.singletonList(notificationGenerator));
     }
 
     @Test
     void should_generate_notification_when_event_can_be_handled() {
-        when(callback.getEvent()).thenReturn(Event.EDIT_DOCUMENTS);
+
         when(canHandle.test(callbackStage, callback)).thenReturn(true);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
-        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
         when(notificationGenerator.getSuccessMessage()).thenReturn(expectedMessage);
         PostSubmitCallbackResponse response = notificationHandler.handle(callbackStage, callback);
 
         assertEquals("success", response.getConfirmationHeader().get());
-        assertEquals(asylumCase.toString(), response.getConfirmationBody().get());
+        assertEquals(bailCase.toString(), response.getConfirmationBody().get());
         verify(notificationGenerator).generate(callback);
     }
 
     @Test
     void should_return_default_confirmation_when_no_custom_message_is_given() {
-        when(callback.getEvent()).thenReturn(Event.BUILD_CASE);
+
         when(canHandle.test(callbackStage, callback)).thenReturn(true);
         when(notificationGenerator.getSuccessMessage()).thenReturn(new Message());
         PostSubmitCallbackResponse response = notificationHandler.handle(callbackStage, callback);
@@ -78,7 +80,6 @@ class PostSubmitNotificationHandlerTest {
 
     @Test
     void should_not_generate_notification_when_cannot_handle_event() {
-        when(callback.getEvent()).thenReturn(Event.BUILD_CASE);
         when(canHandle.test(callbackStage, callback)).thenReturn(false);
 
         assertThatThrownBy(() -> notificationHandler.handle(callbackStage, callback))
@@ -90,15 +91,8 @@ class PostSubmitNotificationHandlerTest {
 
     @Test
     void should_return_false_when_cannot_handle_event() {
-        when(callback.getEvent()).thenReturn(Event.BUILD_CASE);
         when(canHandle.test(callbackStage, callback)).thenReturn(false);
 
-        assertEquals(false, notificationHandler.canHandle(callbackStage, callback));
-    }
-
-    @Test
-    void should_return_false_when_skip_event() {
-        when(callback.getEvent()).thenReturn(Event.NOC_REQUEST_BAIL);
         assertEquals(false, notificationHandler.canHandle(callbackStage, callback));
     }
 
@@ -118,13 +112,12 @@ class PostSubmitNotificationHandlerTest {
 
     @Test
     void should_catch_exception_and_invoke_error_handler() {
-        when(callback.getEvent()).thenReturn(Event.BUILD_CASE);
         when(canHandle.test(callbackStage, callback)).thenReturn(true);
         String message = "exception happened";
         Throwable exception = new RuntimeException(message);
         doThrow(exception).when(notificationGenerator).generate(callback);
         notificationHandler =
-            new PostSubmitNotificationHandler(canHandle, Collections.singletonList(notificationGenerator), errorHandler);
+            new BailPostSubmitNotificationHandler(canHandle, Collections.singletonList(notificationGenerator), errorHandler);
 
         notificationHandler.handle(callbackStage, callback);
 
@@ -133,11 +126,11 @@ class PostSubmitNotificationHandlerTest {
 
     @Test
     void should_re_throw_exception_from_generator() {
-        when(callback.getEvent()).thenReturn(Event.BUILD_CASE);
+
         when(canHandle.test(callbackStage, callback)).thenReturn(true);
         String message = "exception happened";
         doThrow(new RuntimeException(message)).when(notificationGenerator).generate(callback);
-        notificationHandler = new PostSubmitNotificationHandler(canHandle, Collections.singletonList(notificationGenerator));
+        notificationHandler = new BailPostSubmitNotificationHandler(canHandle, Collections.singletonList(notificationGenerator));
 
         assertThatThrownBy(() -> notificationHandler.handle(callbackStage, callback))
             .isExactlyInstanceOf(RuntimeException.class)

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/bail/adminofficer/AdminOfficerBailNocPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/bail/adminofficer/AdminOfficerBailNocPersonalisationTest.java
@@ -1,0 +1,108 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.adminofficer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.adminofficer.email.AdminOfficerBailNocChangedLrPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class AdminOfficerBailNocPersonalisationTest {
+
+    @Mock
+    BailCase bailCase;
+
+    private final Long caseId = 12345L;
+    private final String templateId = "someTemplateId";
+    private final String bailReferenceNumber = "someReferenceNumber";
+    private final String legalRepReference = "someLegalRepReference";
+    private final String homeOfficeReferenceNumber = "someHomeOfficeReferenceNumber";
+    private final String applicantGivenNames = "someApplicantGivenNames";
+    private final String applicantFamilyName = "someApplicantFamilyName";
+
+    @Mock
+    private EmailAddressFinder emailAddressFinder;
+    private AdminOfficerBailNocChangedLrPersonalisation adminOfficerBailNocPersonalisation;
+
+    @BeforeEach
+    public void setup() {
+
+        when(bailCase.read(BailCaseFieldDefinition.BAIL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(bailReferenceNumber));
+        when(bailCase.read(BailCaseFieldDefinition.APPLICANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(applicantGivenNames));
+        when(bailCase.read(BailCaseFieldDefinition.APPLICANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(applicantFamilyName));
+        when(bailCase.read(BailCaseFieldDefinition.LEGAL_REP_REFERENCE, String.class)).thenReturn(Optional.of(legalRepReference));
+        when(bailCase.read(BailCaseFieldDefinition.HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
+
+        adminOfficerBailNocPersonalisation = new AdminOfficerBailNocChangedLrPersonalisation(
+                templateId,
+                emailAddressFinder
+        );
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        assertEquals(templateId, adminOfficerBailNocPersonalisation.getTemplateId(bailCase));
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        assertEquals(caseId + "_BAIL_NOC_CHANGED_LR_ADMIN",
+            adminOfficerBailNocPersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address_for_hearing_centre() {
+        String hearingCentreEmail = "someHearingCentre@example.com";
+        when(emailAddressFinder.getBailHearingCentreEmailAddress(bailCase)).thenReturn(hearingCentreEmail);
+        assertTrue(adminOfficerBailNocPersonalisation.getRecipientsList(bailCase)
+                .contains(hearingCentreEmail));
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+        assertThatThrownBy(
+                () -> adminOfficerBailNocPersonalisation.getPersonalisation((BailCase) null))
+                .isExactlyInstanceOf(NullPointerException.class)
+                .hasMessage("bailCase must not be null");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given() {
+
+        Map<String, String> personalisation =
+            adminOfficerBailNocPersonalisation.getPersonalisation(bailCase);
+
+        assertThat(personalisation).isEqualToComparingOnlyGivenFields(bailCase);
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_mandatory_information_given() {
+
+        when(bailCase.read(BailCaseFieldDefinition.BAIL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.empty());
+        when(bailCase.read(BailCaseFieldDefinition.APPLICANT_GIVEN_NAMES, String.class)).thenReturn(Optional.empty());
+        when(bailCase.read(BailCaseFieldDefinition.APPLICANT_FAMILY_NAME, String.class)).thenReturn(Optional.empty());
+        when(bailCase.read(BailCaseFieldDefinition.LEGAL_REP_REFERENCE, String.class)).thenReturn(Optional.empty());
+        when(bailCase.read(BailCaseFieldDefinition.HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.empty());
+
+        Map<String, String> personalisation =
+            adminOfficerBailNocPersonalisation.getPersonalisation(bailCase);
+
+        assertThat(personalisation).isEqualToComparingOnlyGivenFields(bailCase);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/bail/applicant/ApplicantBailNocPersonalisationSmsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/bail/applicant/ApplicantBailNocPersonalisationSmsTest.java
@@ -1,0 +1,115 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.applicant;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_DATE_OF_BIRTH;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_FAMILY_NAME;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_GIVEN_NAMES;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_MOBILE_NUMBER_1;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition.BAIL_REFERENCE_NUMBER;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.applicant.sms.ApplicantBailNocChangedLrPersonalisationSms;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class ApplicantBailNocPersonalisationSmsTest {
+
+    private final String smsTemplateId = "someTemplateId";
+    private final String mobileNumber = "111 111 111";
+    private final String bailReferenceNumber = "someReferenceNumber";
+    private final String applicantDoB = "2000-05-13";
+    private final String applicantGivenNames = "someApplicantGivenNames";
+    private final String applicantFamilyName = "someApplicantFamilyName";
+
+    @Mock
+    BailCase bailCase;
+
+    private ApplicantBailNocChangedLrPersonalisationSms applicantBailNocPersonalisationSms;
+
+    @BeforeEach
+    public void setup() {
+
+        when(bailCase.read(APPLICANT_MOBILE_NUMBER_1, String.class)).thenReturn(Optional.of(mobileNumber));
+        when(bailCase.read(BAIL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(bailReferenceNumber));
+        when(bailCase.read(BailCaseFieldDefinition.APPLICANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(applicantGivenNames));
+        when(bailCase.read(BailCaseFieldDefinition.APPLICANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(applicantFamilyName));
+        when(bailCase.read(BailCaseFieldDefinition.APPLICANT_DATE_OF_BIRTH, String.class)).thenReturn(Optional.of(applicantDoB));
+
+        applicantBailNocPersonalisationSms =
+            new ApplicantBailNocChangedLrPersonalisationSms(smsTemplateId);
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        assertEquals(smsTemplateId, applicantBailNocPersonalisationSms.getTemplateId());
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        Long caseId = 12345L;
+        assertEquals(caseId + "_BAIL_NOC_CHANGED_LR_APPLICANT_SMS",
+            applicantBailNocPersonalisationSms.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_mobile_number() {
+        assertTrue(
+            applicantBailNocPersonalisationSms.getRecipientsList(bailCase).contains(mobileNumber));
+
+        when(bailCase.read(APPLICANT_MOBILE_NUMBER_1, String.class)).thenReturn(Optional.empty());
+
+        assertTrue(applicantBailNocPersonalisationSms.getRecipientsList(bailCase).isEmpty());
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(
+            () -> applicantBailNocPersonalisationSms.getPersonalisation((BailCase) null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("bailCase must not be null");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given() {
+
+        Map<String, String> personalisation =
+            applicantBailNocPersonalisationSms.getPersonalisation(bailCase);
+
+        assertEquals(bailReferenceNumber, personalisation.get("bailReferenceNumber"));
+        assertEquals(applicantGivenNames, personalisation.get("applicantGivenNames"));
+        assertEquals(applicantFamilyName, personalisation.get("applicantFamilyName"));
+        assertEquals(applicantDoB, personalisation.get("applicantDateOfBirth"));
+
+    }
+
+    @Test
+    public void should_return_personalisation_when_only_mandatory_information_given() {
+
+        when(bailCase.read(BAIL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.empty());
+        when(bailCase.read(APPLICANT_FAMILY_NAME, String.class)).thenReturn(Optional.empty());
+        when(bailCase.read(APPLICANT_GIVEN_NAMES, String.class)).thenReturn(Optional.empty());
+        when(bailCase.read(APPLICANT_DATE_OF_BIRTH, String.class)).thenReturn(Optional.empty());
+
+        Map<String, String> personalisation =
+            applicantBailNocPersonalisationSms.getPersonalisation(bailCase);
+
+        assertEquals("", personalisation.get("bailReferenceNumber"));
+        assertEquals("", personalisation.get("applicantGivenNames"));
+        assertEquals("", personalisation.get("applicantFamilyName"));
+        assertEquals("", personalisation.get("applicantDateOfBirth"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/bail/homeoffice/email/HomeOfficeBailNocPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/bail/homeoffice/email/HomeOfficeBailNocPersonalisationTest.java
@@ -1,0 +1,106 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.homeoffice.email;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_FAMILY_NAME;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition.APPLICANT_GIVEN_NAMES;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition.BAIL_REFERENCE_NUMBER;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition.HOME_OFFICE_REFERENCE_NUMBER;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition.IS_LEGALLY_REPRESENTED_FOR_FLAG;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_REFERENCE;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class HomeOfficeBailNocPersonalisationTest {
+
+    private final Long caseId = 12345L;
+    private final String templateId = "someTemplateIdWithLegalRep";
+    private final String homeOfficeEmailAddress = "HO_user@example.com";
+    private final String bailReferenceNumber = "someReferenceNumber";
+    private final String legalRepReference = "someLegalRepReference";
+    private final String homeOfficeReferenceNumber = "someHomeOfficeReferenceNumber";
+    private final String applicantGivenNames = "someApplicantGivenNames";
+    private final String applicantFamilyName = "someApplicantFamilyName";
+    @Mock BailCase bailCase;
+    private HomeOfficeBailNocChangedLrPersonalisation homeOfficeBailNocPersonalisation;
+
+    @BeforeEach
+    public void setup() {
+
+        when(bailCase.read(BAIL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(bailReferenceNumber));
+        when(bailCase.read(LEGAL_REP_REFERENCE, String.class)).thenReturn(Optional.of(legalRepReference));
+        when(bailCase.read(APPLICANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(applicantGivenNames));
+        when(bailCase.read(APPLICANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(applicantFamilyName));
+        when(bailCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
+        when(bailCase.read(IS_LEGALLY_REPRESENTED_FOR_FLAG, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        homeOfficeBailNocPersonalisation =
+            new HomeOfficeBailNocChangedLrPersonalisation(templateId, homeOfficeEmailAddress);
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        assertEquals(templateId, homeOfficeBailNocPersonalisation.getTemplateId(bailCase));
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        assertEquals(caseId + "_BAIL_NOC_CHANGED_LR_HOME_OFFICE",
+            homeOfficeBailNocPersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(
+            () -> homeOfficeBailNocPersonalisation.getPersonalisation((BailCase) null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("bailCase must not be null");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given() {
+
+        Map<String, String> personalisation =
+            homeOfficeBailNocPersonalisation.getPersonalisation(bailCase);
+
+        assertEquals(bailReferenceNumber, personalisation.get("bailReferenceNumber"));
+        assertEquals(legalRepReference, personalisation.get("legalRepReference"));
+        assertEquals(applicantGivenNames, personalisation.get("applicantGivenNames"));
+        assertEquals(applicantFamilyName, personalisation.get("applicantFamilyName"));
+        assertEquals(homeOfficeReferenceNumber, personalisation.get("homeOfficeReferenceNumber"));
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_mandatory_information_given() {
+
+        when(bailCase.read(BAIL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.empty());
+        when(bailCase.read(APPLICANT_GIVEN_NAMES, String.class)).thenReturn(Optional.empty());
+        when(bailCase.read(APPLICANT_FAMILY_NAME, String.class)).thenReturn(Optional.empty());
+        when(bailCase.read(LEGAL_REP_REFERENCE, String.class)).thenReturn(Optional.empty());
+        when(bailCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.empty());
+
+        Map<String, String> personalisation =
+            homeOfficeBailNocPersonalisation.getPersonalisation(bailCase);
+
+        assertEquals("", personalisation.get("bailReferenceNumber"));
+        assertEquals("", personalisation.get("legalRepReference"));
+        assertEquals("", personalisation.get("applicantGivenNames"));
+        assertEquals("", personalisation.get("applicantFamilyName"));
+        assertEquals("", personalisation.get("homeOfficeReferenceNumber"));
+    }
+
+}
+

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/bail/legalrepresentative/LegalRepresentativeBailNocPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/bail/legalrepresentative/LegalRepresentativeBailNocPersonalisationTest.java
@@ -1,0 +1,114 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.legalrepresentative;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.bail.legalrepresentative.email.LegalRepresentativeBailNocChangedLrPersonalisation;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LegalRepresentativeBailNocPersonalisationTest {
+
+    @Mock
+    BailCase bailCase;
+
+    private final Long caseId = 12345L;
+    private final String templateId = "someTemplateId";
+    private final String legalRepEmailAddress = "legalRep@example.com";
+    private final String bailReferenceNumber = "someReferenceNumber";
+    private final String legalRepReference = "someLegalRepReference";
+    private final String homeOfficeReferenceNumber = "someHomeOfficeReferenceNumber";
+    private final String applicantGivenNames = "someApplicantGivenNames";
+    private final String applicantFamilyName = "someApplicantFamilyName";
+
+    private LegalRepresentativeBailNocChangedLrPersonalisation legalRepresentativeBailNocPersonalisation;
+
+    @BeforeEach
+    public void setup() {
+
+        when(bailCase.read(BailCaseFieldDefinition.BAIL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(bailReferenceNumber));
+        when(bailCase.read(BailCaseFieldDefinition.APPLICANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(applicantGivenNames));
+        when(bailCase.read(BailCaseFieldDefinition.APPLICANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(applicantFamilyName));
+        when(bailCase.read(BailCaseFieldDefinition.LEGAL_REP_REFERENCE, String.class)).thenReturn(Optional.of(legalRepReference));
+        when(bailCase.read(BailCaseFieldDefinition.HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
+        when(bailCase.read(BailCaseFieldDefinition.LEGAL_REP_EMAIL, String.class))
+                .thenReturn(Optional.of(legalRepEmailAddress));
+
+        legalRepresentativeBailNocPersonalisation = new LegalRepresentativeBailNocChangedLrPersonalisation(
+                templateId
+        );
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        assertEquals(templateId, legalRepresentativeBailNocPersonalisation.getTemplateId());
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        assertEquals(caseId + "_BAIL_NOC_CHANGED_LR_LEGAL_REPRESENTATIVE",
+            legalRepresentativeBailNocPersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address_from_bail_case() {
+        assertTrue(legalRepresentativeBailNocPersonalisation.getRecipientsList(bailCase)
+                .contains(legalRepEmailAddress));
+    }
+
+    @Test
+    public void should_throw_exception_when_cannot_find_email_address_for_legal_rep() {
+        when(bailCase.read(BailCaseFieldDefinition.LEGAL_REP_EMAIL, String.class)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> legalRepresentativeBailNocPersonalisation.getRecipientsList(bailCase))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("legalRepresentativeEmailAddress is not present");
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+        assertThatThrownBy(
+                () -> legalRepresentativeBailNocPersonalisation.getPersonalisation((BailCase) null))
+                .isExactlyInstanceOf(NullPointerException.class)
+                .hasMessage("bailCase must not be null");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given() {
+
+        Map<String, String> personalisation =
+            legalRepresentativeBailNocPersonalisation.getPersonalisation(bailCase);
+
+        assertThat(personalisation).isEqualToComparingOnlyGivenFields(bailCase);
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_mandatory_information_given() {
+
+        when(bailCase.read(BailCaseFieldDefinition.BAIL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.empty());
+        when(bailCase.read(BailCaseFieldDefinition.APPLICANT_GIVEN_NAMES, String.class)).thenReturn(Optional.empty());
+        when(bailCase.read(BailCaseFieldDefinition.APPLICANT_FAMILY_NAME, String.class)).thenReturn(Optional.empty());
+        when(bailCase.read(BailCaseFieldDefinition.LEGAL_REP_REFERENCE, String.class)).thenReturn(Optional.empty());
+        when(bailCase.read(BailCaseFieldDefinition.HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.empty());
+
+        Map<String, String> personalisation =
+            legalRepresentativeBailNocPersonalisation.getPersonalisation(bailCase);
+
+        assertThat(personalisation).isEqualToComparingOnlyGivenFields(bailCase);
+    }
+
+}


### PR DESCRIPTION
- Added new event NOC_REQUEST_BAIL to distinguish from asylum counterpart.
- Added unit and functional tests.
