### PR TITLE
RIA-6609 Added ADA suitability notifications for suitable and unsuitable

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-6608-ada-suitability-suitable.json
+++ b/src/functionalTest/resources/scenarios/RIA-6608-ada-suitability-suitable.json
@@ -1,11 +1,11 @@
 {
-  "description": "RIA-6609 Send ada suitability notification to legal rep and home office for ADA appeal (Suitable)",
+  "description": "RIA-6608 Send ada suitability notification to legal rep and home office for ADA appeal (Suitable)",
   "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "Judge",
     "input": {
-      "id": 6609,
+      "id": 6608,
       "eventId": "adaSuitabilityReview",
       "state": "respondentReview",
       "caseData": {
@@ -34,11 +34,11 @@
         "suitabilityReviewDecision": "suitable",
         "notificationsSent": [
           {
-            "id": "6609_ADA_SUITABILITY_DETERMINED_LEGAL_REP",
+            "id": "6608_ADA_SUITABILITY_DETERMINED_LEGAL_REP",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {
-            "id": "6609_ADA_SUITABILITY_DETERMINED_HOME_OFFICE",
+            "id": "6608_ADA_SUITABILITY_DETERMINED_HOME_OFFICE",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
         ]

--- a/src/functionalTest/resources/scenarios/RIA-6609-ada-suitability-suitable.json
+++ b/src/functionalTest/resources/scenarios/RIA-6609-ada-suitability-suitable.json
@@ -1,0 +1,48 @@
+{
+  "description": "RIA-6609 Send ada suitability notification to legal rep and home office for ADA appeal (Suitable)",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 6609,
+      "eventId": "adaSuitabilityReview",
+      "state": "respondentReview",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "isAcceleratedDetainedAppeal": "Yes",
+          "ariaListingReference": "LP/12345/2019",
+          "listCaseHearingCentre": "harmondsworth",
+          "listCaseHearingDate": "2019-05-03T14:25:15.000",
+          "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
+          "suitabilityReviewDecision": "suitable"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "isAcceleratedDetainedAppeal": "Yes",
+        "listCaseHearingCentre": "harmondsworth",
+        "listCaseHearingDate": "2019-05-03T14:25:15.000",
+        "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
+        "suitabilityReviewDecision": "suitable",
+        "notificationsSent": [
+          {
+            "id": "6609_ADA_SUITABILITY_DETERMINED_LEGAL_REP",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "6609_ADA_SUITABILITY_DETERMINED_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-6609-ada-suitability-unsuitable.json
+++ b/src/functionalTest/resources/scenarios/RIA-6609-ada-suitability-unsuitable.json
@@ -1,0 +1,48 @@
+{
+  "description": "RIA-6609 Send ada suitability notification to legal rep and home office for ADA appeal (Unsuitable)",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 6609,
+      "eventId": "adaSuitabilityReview",
+      "state": "respondentReview",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "isAcceleratedDetainedAppeal": "Yes",
+          "ariaListingReference": "LP/12345/2019",
+          "listCaseHearingCentre": "harmondsworth",
+          "listCaseHearingDate": "2019-05-03T14:25:15.000",
+          "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
+          "suitabilityReviewDecision": "unsuitable"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "isAcceleratedDetainedAppeal": "Yes",
+        "listCaseHearingCentre": "harmondsworth",
+        "listCaseHearingDate": "2019-05-03T14:25:15.000",
+        "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
+        "suitabilityReviewDecision": "unsuitable",
+        "notificationsSent": [
+          {
+            "id": "6609_ADA_SUITABILITY_DETERMINED_LEGAL_REP",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "6609_ADA_SUITABILITY_DETERMINED_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AdaSuitabilityReviewDecision.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AdaSuitabilityReviewDecision.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum AdaSuitabilityReviewDecision {
+
+    SUITABLE("suitable"),
+    UNSUITABLE("unsuitable");
+
+    @JsonValue
+    private final String value;
+
+    AdaSuitabilityReviewDecision(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AsylumCaseDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AsylumCaseDefinition.java
@@ -367,7 +367,9 @@ public enum AsylumCaseDefinition {
 
     IS_ACCELERATED_DETAINED_APPEAL(
         "isAcceleratedDetainedAppeal", new TypeReference<YesOrNo>(){}),
-    ;
+
+    SUITABILITY_REVIEW_DECISION(
+        "suitabilityReviewDecision", new TypeReference<AdaSuitabilityReviewDecision>(){});
 
     private final String value;
     private final TypeReference typeReference;

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/Event.java
@@ -97,6 +97,7 @@ public enum Event {
     NOC_REQUEST_BAIL("nocRequestBail"),
     END_APPEAL_AUTOMATICALLY("endAppealAutomatically"),
     UPDATE_PAYMENT_STATUS("updatePaymentStatus"),
+    ADA_SUITABILITY_REVIEW("adaSuitabilityReview"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeAdaSuitabilityPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeAdaSuitabilityPersonalisation.java
@@ -1,0 +1,83 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.homeoffice;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import javax.validation.constraints.NotNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AdaSuitabilityReviewDecision;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.CustomerServicesProvider;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
+
+@Service
+public class HomeOfficeAdaSuitabilityPersonalisation implements EmailNotificationPersonalisation {
+
+    private final String adaSuitabilityUnsuitableHomeOfficeTemplateId;
+    private final String adaSuitabilitySuitableHomeOfficeTemplateId;
+    private final EmailAddressFinder emailAddressFinder;
+    private final CustomerServicesProvider customerServicesProvider;
+    private final String iaExUiFrontendUrl;
+
+    public HomeOfficeAdaSuitabilityPersonalisation(
+            @NotNull(message = "adaSuitabilityUnsuitableHomeOfficeTemplateId cannot be null")
+            @Value("${govnotify.template.adaSuitabilityReview.homeOffice.unsuitable.email}") String adaSuitabilityUnsuitableHomeOfficeTemplateId,
+            @Value("${govnotify.template.adaSuitabilityReview.homeOffice.suitable.email}") String adaSuitabilitySuitableHomeOfficeTemplateId,
+            @Value("${iaExUiFrontendUrl}") String iaExUiFrontendUrl,
+            EmailAddressFinder emailAddressFinder,
+            CustomerServicesProvider customerServicesProvider
+    ) {
+        this.adaSuitabilityUnsuitableHomeOfficeTemplateId = adaSuitabilityUnsuitableHomeOfficeTemplateId;
+        this.adaSuitabilitySuitableHomeOfficeTemplateId = adaSuitabilitySuitableHomeOfficeTemplateId;
+        this.iaExUiFrontendUrl = iaExUiFrontendUrl;
+        this.emailAddressFinder = emailAddressFinder;
+        this.customerServicesProvider = customerServicesProvider;
+    }
+
+    @Override
+    public String getTemplateId(AsylumCase asylumCase) {
+        AdaSuitabilityReviewDecision decision =
+                asylumCase.read(SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class)
+                        .orElseThrow(() -> new IllegalStateException("suitabilityReviewDecision is not present"));
+
+        if (decision.toString().equals(AdaSuitabilityReviewDecision.UNSUITABLE.toString())) {
+            return adaSuitabilityUnsuitableHomeOfficeTemplateId;
+        } else {
+            return adaSuitabilitySuitableHomeOfficeTemplateId;
+        }
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        return Collections.singleton(emailAddressFinder.getListCaseHomeOfficeEmailAddress(asylumCase));
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_ADA_SUITABILITY_DETERMINED_HOME_OFFICE";
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        return ImmutableMap
+                .<String, String>builder()
+                .putAll(customerServicesProvider.getCustomerServicesPersonalisation())
+                .put("appealReferenceNumber", asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+                .put("ariaListingReference", asylumCase.read(ARIA_LISTING_REFERENCE, String.class).orElse(""))
+                .put("homeOfficeReferenceNumber", asylumCase.read(AsylumCaseDefinition.HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""))
+                .put("appellantGivenNames", asylumCase.read(AsylumCaseDefinition.APPELLANT_GIVEN_NAMES, String.class).orElse(""))
+                .put("appellantFamilyName", asylumCase.read(AsylumCaseDefinition.APPELLANT_FAMILY_NAME, String.class).orElse(""))
+                .put("linkToOnlineService", iaExUiFrontendUrl)
+                .build();
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeAdaSuitabilityPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeAdaSuitabilityPersonalisation.java
@@ -1,0 +1,72 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.legalrepresentative;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.ARIA_LISTING_REFERENCE;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.SUITABILITY_REVIEW_DECISION;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import javax.validation.constraints.NotNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AdaSuitabilityReviewDecision;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.CustomerServicesProvider;
+
+@Service
+public class LegalRepresentativeAdaSuitabilityPersonalisation implements LegalRepresentativeEmailNotificationPersonalisation {
+
+    private final String adaSuitabilityUnsuitableLegalRepresentativeTemplateId;
+    private final String adaSuitabilitySuitableLegalRepresentativeTemplateId;
+    private final String iaExUiFrontendUrl;
+    private final CustomerServicesProvider customerServicesProvider;
+
+
+    public LegalRepresentativeAdaSuitabilityPersonalisation(
+            @NotNull(message = "adaSuitabilityUnsuitableLegalRepresentativeTemplateId cannot be null")
+            @Value("${govnotify.template.adaSuitabilityReview.legalRep.unsuitable.email}") String adaSuitabilityUnsuitableLegalRepresentativeTemplateId,
+            @Value("${govnotify.template.adaSuitabilityReview.legalRep.suitable.email}") String adaSuitabilitySuitableLegalRepresentativeTemplateId,
+            @Value("${iaExUiFrontendUrl}") String iaExUiFrontendUrl,
+            CustomerServicesProvider customerServicesProvider
+    ) {
+        this.adaSuitabilityUnsuitableLegalRepresentativeTemplateId = adaSuitabilityUnsuitableLegalRepresentativeTemplateId;
+        this.adaSuitabilitySuitableLegalRepresentativeTemplateId = adaSuitabilitySuitableLegalRepresentativeTemplateId;
+        this.iaExUiFrontendUrl = iaExUiFrontendUrl;
+        this.customerServicesProvider = customerServicesProvider;
+    }
+
+    @Override
+    public String getTemplateId(AsylumCase asylumCase) {
+        AdaSuitabilityReviewDecision decision =
+                asylumCase.read(SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class)
+                        .orElseThrow(() -> new IllegalStateException("suitabilityReviewDecision is not present"));
+
+        if (decision.toString().equals(AdaSuitabilityReviewDecision.UNSUITABLE.toString())) {
+            return adaSuitabilityUnsuitableLegalRepresentativeTemplateId;
+        } else {
+            return adaSuitabilitySuitableLegalRepresentativeTemplateId;
+        }
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_ADA_SUITABILITY_DETERMINED_LEGAL_REP";
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        return ImmutableMap
+                .<String, String>builder()
+                .putAll(customerServicesProvider.getCustomerServicesPersonalisation())
+                .put("appealReferenceNumber", asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+                .put("ariaListingReference", asylumCase.read(ARIA_LISTING_REFERENCE, String.class).orElse(""))
+                .put("legalRepReferenceNumber", asylumCase.read(AsylumCaseDefinition.LEGAL_REP_REFERENCE_NUMBER, String.class).orElse(""))
+                .put("appellantGivenNames", asylumCase.read(AsylumCaseDefinition.APPELLANT_GIVEN_NAMES, String.class).orElse(""))
+                .put("appellantFamilyName", asylumCase.read(AsylumCaseDefinition.APPELLANT_FAMILY_NAME, String.class).orElse(""))
+                .put("linkToOnlineService", iaExUiFrontendUrl)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -3045,4 +3045,24 @@ public class NotificationGeneratorConfiguration {
                 )
         );
     }
+
+    @Bean("adaSuitabilityNotificationGenerator")
+    public List<NotificationGenerator> adaSuitabilityNotificationGenerator(
+            LegalRepresentativeAdaSuitabilityPersonalisation legalRepresentativeAdaSuitabilityPersonalisation,
+            HomeOfficeAdaSuitabilityPersonalisation homeOfficeAdaSuitabilityPersonalisation,
+            GovNotifyNotificationSender notificationSender,
+            NotificationIdAppender notificationIdAppender
+    ) {
+
+        return Collections.singletonList(
+                new EmailNotificationGenerator(
+                        newArrayList(
+                            legalRepresentativeAdaSuitabilityPersonalisation,
+                            homeOfficeAdaSuitabilityPersonalisation
+                        ),
+                        notificationSender,
+                        notificationIdAppender
+                )
+        );
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -3428,6 +3428,18 @@ public class NotificationHandlerConfiguration {
         );
     }
 
+    @Bean
+    public PreSubmitCallbackHandler<AsylumCase> adaSuitabilityNotificationHandler(
+            @Qualifier("adaSuitabilityNotificationGenerator") List<NotificationGenerator> notificationGenerators) {
+
+        return new NotificationHandler(
+                (callbackStage, callback) ->
+                    callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                    && callback.getEvent() == Event.ADA_SUITABILITY_REVIEW,
+                notificationGenerators
+        );
+    }
+
 }
 
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -827,6 +827,17 @@ govnotify:
         email: 200ea13a-b583-4471-8d08-650f77eabd8c
       homeOffice:
         email: f90edfba-ac37-47fa-ab55-e429ffa9f372
+    adaSuitabilityReview:
+      legalRep:
+        unsuitable:
+          email: 6734ec0f-1818-4f2d-88da-8ac89fc4dfff
+        suitable:
+          email: 45efcaae-72b0-49e0-9b07-802d1a65bd6e
+      homeOffice:
+        unsuitable:
+          email: 0c8d72c1-7c63-4426-8d73-f178a540e1ff
+        suitable:
+          email: 1adfdfcf-1eac-44aa-8c2f-90dffd956796
   bail:
     key: ${IA_BAIL_GOV_NOTIFY_KEY}
     timeout: 5000
@@ -1078,6 +1089,7 @@ security:
       - "sendBailDirection"
       - "editBailDocuments"
       - "changeBailDirectionDueDate"
+      - "adaSuitabilityReview"
     caseworker-ia-system:
       - "requestHearingRequirementsFeature"
       - "endAppealAutomatically"

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/EventTest.java
@@ -101,11 +101,12 @@ public class EventTest {
         assertEquals("nocRequestBail", NOC_REQUEST_BAIL.toString());
         assertEquals("endAppealAutomatically", END_APPEAL_AUTOMATICALLY.toString());
         assertEquals("updatePaymentStatus", UPDATE_PAYMENT_STATUS.toString());
+        assertEquals("adaSuitabilityReview", ADA_SUITABILITY_REVIEW.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(94, Event.values().length);
+        assertEquals(95, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeAdaSuitabilityPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeAdaSuitabilityPersonalisationTest.java
@@ -1,0 +1,150 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.homeoffice;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AdaSuitabilityReviewDecision;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.HearingCentre;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.CustomerServicesProvider;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class HomeOfficeAdaSuitabilityPersonalisationTest {
+
+    @Mock
+    AsylumCase asylumCase;
+    @Mock
+    EmailAddressFinder emailAddressFinder;
+    @Mock
+    CustomerServicesProvider customerServicesProvider;
+
+    private Long caseId = 12345L;
+    private String adaUnsuitableTemplateId = "adaUnsuitableTemplateId";
+    private String adaSuitableTemplateId = "adaSuitableTemplateId";
+    private String iaExUiFrontendUrl = "http://localhost";
+    private HearingCentre hearingCentre = HearingCentre.TAYLOR_HOUSE;
+    private String hearingEmailAddress = "hearinge@example.com";
+    private String appealReferenceNumber = "someReferenceNumber";
+    private String ariaListingReference = "someAriaListingReference";
+    private String homeOfficeRefNumber = "someHomeOfficeRefNumber";
+    private String appellantGivenNames = "someAppellantGivenNames";
+    private String appellantFamilyName = "someAppellantFamilyName";
+
+    private String customerServicesTelephone = "555 555 555";
+    private String customerServicesEmail = "cust.services@example.com";
+
+    private HomeOfficeAdaSuitabilityPersonalisation homeOfficeAdaSuitabilityPersonalisation;
+
+    @BeforeEach
+    public void setup() {
+
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(ARIA_LISTING_REFERENCE, String.class)).thenReturn(Optional.of(ariaListingReference));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeRefNumber));
+        when((customerServicesProvider.getCustomerServicesTelephone())).thenReturn(customerServicesTelephone);
+        when((customerServicesProvider.getCustomerServicesEmail())).thenReturn(customerServicesEmail);
+
+        homeOfficeAdaSuitabilityPersonalisation = new HomeOfficeAdaSuitabilityPersonalisation(
+            adaUnsuitableTemplateId,
+            adaSuitableTemplateId,
+            iaExUiFrontendUrl,
+            emailAddressFinder,
+            customerServicesProvider
+        );
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        when(asylumCase.read(SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class))
+                .thenReturn(Optional.of(AdaSuitabilityReviewDecision.UNSUITABLE));
+        assertEquals(adaUnsuitableTemplateId, homeOfficeAdaSuitabilityPersonalisation.getTemplateId(asylumCase));
+
+        when(asylumCase.read(SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class))
+                .thenReturn(Optional.of(AdaSuitabilityReviewDecision.SUITABLE));
+        assertEquals(adaSuitableTemplateId, homeOfficeAdaSuitabilityPersonalisation.getTemplateId(asylumCase));
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        assertEquals(caseId + "_ADA_SUITABILITY_DETERMINED_HOME_OFFICE",
+            homeOfficeAdaSuitabilityPersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address() {
+        when(asylumCase.read(LIST_CASE_HEARING_CENTRE, HearingCentre.class)).thenReturn(Optional.of(hearingCentre));
+        when(emailAddressFinder.getListCaseHomeOfficeEmailAddress(asylumCase)).thenReturn(hearingEmailAddress);
+        assertTrue(homeOfficeAdaSuitabilityPersonalisation.getRecipientsList(asylumCase).contains(hearingEmailAddress));
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(() -> homeOfficeAdaSuitabilityPersonalisation.getPersonalisation((AsylumCase) null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    void should_throw_exception_when_cannot_find_suitability_review_decision() {
+        when(asylumCase.read(SUITABILITY_REVIEW_DECISION, String.class)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> homeOfficeAdaSuitabilityPersonalisation.getTemplateId(asylumCase))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("suitabilityReviewDecision is not present");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given() {
+
+        Map<String, String> personalisation =
+            homeOfficeAdaSuitabilityPersonalisation.getPersonalisation(asylumCase);
+
+        assertEquals(appealReferenceNumber, personalisation.get("appealReferenceNumber"));
+        assertEquals(ariaListingReference, personalisation.get("ariaListingReference"));
+        assertEquals(homeOfficeRefNumber, personalisation.get("homeOfficeReferenceNumber"));
+        assertEquals(appellantGivenNames, personalisation.get("appellantGivenNames"));
+        assertEquals(appellantFamilyName, personalisation.get("appellantFamilyName"));
+        assertEquals(iaExUiFrontendUrl, personalisation.get("linkToOnlineService"));
+        assertEquals(customerServicesTelephone, customerServicesProvider.getCustomerServicesTelephone());
+        assertEquals(customerServicesEmail, customerServicesProvider.getCustomerServicesEmail());
+
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_mandatory_information_given() {
+
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(ARIA_LISTING_REFERENCE, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.empty());
+
+        Map<String, String> personalisation =
+            homeOfficeAdaSuitabilityPersonalisation.getPersonalisation(asylumCase);
+
+        assertEquals("", personalisation.get("appealReferenceNumber"));
+        assertEquals("", personalisation.get("ariaListingReference"));
+        assertEquals("", personalisation.get("homeOfficeReferenceNumber"));
+        assertEquals("", personalisation.get("appellantGivenNames"));
+        assertEquals("", personalisation.get("appellantFamilyName"));
+        assertEquals(iaExUiFrontendUrl, personalisation.get("linkToOnlineService"));
+        assertEquals(customerServicesTelephone, customerServicesProvider.getCustomerServicesTelephone());
+        assertEquals(customerServicesEmail, customerServicesProvider.getCustomerServicesEmail());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeAdaSuitabilityPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeAdaSuitabilityPersonalisationTest.java
@@ -1,0 +1,145 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.legalrepresentative;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AdaSuitabilityReviewDecision;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.CustomerServicesProvider;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class LegalRepresentativeAdaSuitabilityPersonalisationTest {
+
+    private final String adaUnsuitableTemplateId = "adaUnsuitableTemplateId";
+    private final String adaSuitableTemplateId = "adaSuitableTemplateId";
+    private final String iaExUiFrontendUrl = "http://localhost";
+    private final String emailAddress = "legal@example.com";
+    private final String appealReferenceNumber = "someReferenceNumber";
+    private final String ariaListingReference = "someAriaListingReference";
+    private final String legalRefNumber = "someLegalRefNumber";
+    private final String appellantGivenNames = "someAppellantGivenNames";
+    private final String appellantFamilyName = "someAppellantFamilyName";
+    private final String customerServicesTelephone = "555 555 555";
+    private final String customerServicesEmail = "cust.services@example.com";
+    @Mock
+    AsylumCase asylumCase;
+    @Mock
+    CustomerServicesProvider customerServicesProvider;
+    private LegalRepresentativeAdaSuitabilityPersonalisation legalRepresentativeAdaSuitabilityPersonalisation;
+
+    @BeforeEach
+    public void setup() {
+
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(ARIA_LISTING_REFERENCE, String.class)).thenReturn(Optional.of(ariaListingReference));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(asylumCase.read(LEGAL_REP_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(legalRefNumber));
+        when(asylumCase.read(LEGAL_REPRESENTATIVE_EMAIL_ADDRESS, String.class)).thenReturn(Optional.of(emailAddress));
+        when((customerServicesProvider.getCustomerServicesTelephone())).thenReturn(customerServicesTelephone);
+        when((customerServicesProvider.getCustomerServicesEmail())).thenReturn(customerServicesEmail);
+
+        legalRepresentativeAdaSuitabilityPersonalisation = new LegalRepresentativeAdaSuitabilityPersonalisation(
+            adaUnsuitableTemplateId,
+            adaSuitableTemplateId,
+            iaExUiFrontendUrl,
+            customerServicesProvider);
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        when(asylumCase.read(SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class))
+                .thenReturn(Optional.of(AdaSuitabilityReviewDecision.UNSUITABLE));
+        assertEquals(adaUnsuitableTemplateId,
+            legalRepresentativeAdaSuitabilityPersonalisation.getTemplateId(asylumCase));
+
+        when(asylumCase.read(SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class))
+                .thenReturn(Optional.of(AdaSuitabilityReviewDecision.SUITABLE));
+        assertEquals(adaSuitableTemplateId,
+            legalRepresentativeAdaSuitabilityPersonalisation.getTemplateId(asylumCase));
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        Long caseId = 12345L;
+        assertEquals(caseId + "_ADA_SUITABILITY_DETERMINED_LEGAL_REP",
+            legalRepresentativeAdaSuitabilityPersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address() {
+        assertTrue(
+            legalRepresentativeAdaSuitabilityPersonalisation.getRecipientsList(asylumCase).contains(emailAddress));
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(
+            () -> legalRepresentativeAdaSuitabilityPersonalisation.getPersonalisation((AsylumCase) null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    void should_throw_exception_when_cannot_find_suitability_review_decision() {
+        when(asylumCase.read(SUITABILITY_REVIEW_DECISION, String.class)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> legalRepresentativeAdaSuitabilityPersonalisation.getTemplateId(asylumCase))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("suitabilityReviewDecision is not present");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given() {
+
+        Map<String, String> personalisation =
+            legalRepresentativeAdaSuitabilityPersonalisation.getPersonalisation(asylumCase);
+
+        assertEquals(appealReferenceNumber, personalisation.get("appealReferenceNumber"));
+        assertEquals(ariaListingReference, personalisation.get("ariaListingReference"));
+        assertEquals(legalRefNumber, personalisation.get("legalRepReferenceNumber"));
+        assertEquals(appellantGivenNames, personalisation.get("appellantGivenNames"));
+        assertEquals(appellantFamilyName, personalisation.get("appellantFamilyName"));
+        assertEquals(iaExUiFrontendUrl, personalisation.get("linkToOnlineService"));
+        assertEquals(customerServicesTelephone, customerServicesProvider.getCustomerServicesTelephone());
+        assertEquals(customerServicesEmail, customerServicesProvider.getCustomerServicesEmail());
+
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_mandatory_information_given() {
+
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(ARIA_LISTING_REFERENCE, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(LEGAL_REP_REFERENCE_NUMBER, String.class)).thenReturn(Optional.empty());
+
+        Map<String, String> personalisation =
+            legalRepresentativeAdaSuitabilityPersonalisation.getPersonalisation(asylumCase);
+
+        assertEquals("", personalisation.get("appealReferenceNumber"));
+        assertEquals("", personalisation.get("ariaListingReference"));
+        assertEquals("", personalisation.get("legalRepReferenceNumber"));
+        assertEquals("", personalisation.get("appellantGivenNames"));
+        assertEquals("", personalisation.get("appellantFamilyName"));
+        assertEquals(iaExUiFrontendUrl, personalisation.get("linkToOnlineService"));
+        assertEquals(customerServicesTelephone, customerServicesProvider.getCustomerServicesTelephone());
+        assertEquals(customerServicesEmail, customerServicesProvider.getCustomerServicesEmail());
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6609
https://tools.hmcts.net/jira/browse/RIA-6608


### Change description ###
Added ADA suitability notifications for suitable and unsuitable emails

TESTED output:
Unsuitable
(LR)
https://www.notifications.service.gov.uk/services/7f72d0fb-2bc4-421b-bceb-1bf5bf350ff9/notification/bdaee905-54f0-4df7-956c-721be2dae0c6
(HO)
https://www.notifications.service.gov.uk/services/7f72d0fb-2bc4-421b-bceb-1bf5bf350ff9/notification/dfdb04d4-c524-415d-b00e-c6d379f974b9


Suitable
(LR)
https://www.notifications.service.gov.uk/services/7f72d0fb-2bc4-421b-bceb-1bf5bf350ff9/notification/083a1f02-3739-435e-849b-135a9c8047a4
(HO)
https://www.notifications.service.gov.uk/services/7f72d0fb-2bc4-421b-bceb-1bf5bf350ff9/notification/3604a625-2eb1-4fe8-a026-1d86103ee809


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
