### PR TITLE
RIA-6434 Fixed notification not to send emails to appellant when Age …

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -2743,7 +2743,8 @@ public class NotificationHandlerConfiguration {
                        && asylumCase.read(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.class).isPresent()
                        && !payLater
                        && !payNow
-                       && smsPreferred;
+                       && smsPreferred
+                       && !isAgeAssessmentAppeal(asylumCase);
             },
             notificationGenerators,
             getSmsErrorHandling()
@@ -2817,7 +2818,8 @@ public class NotificationHandlerConfiguration {
                        && emailPreferred
                        && !payLater
                        && !payNow
-                       && asylumCase.read(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.class).isPresent();
+                       && asylumCase.read(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.class).isPresent()
+                       && !isAgeAssessmentAppeal(asylumCase);
             },
             notificationGenerators,
             (callback, e) -> log.error(


### PR DESCRIPTION
RIA-6434 Fixed notification not to send emails to appellant when Age Assessment payment has been done (updatePaymentStatus)

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6434


### Change description ###
Fixed notification not to send emails to appellant when Age Assessment payment has been done (updatePaymentStatus)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
