### PR TITLE
RIA-6733: Make 'Mark appeal as paid' event available for internal cases

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -2191,7 +2191,8 @@ public class NotificationHandlerConfiguration {
                        && callback.getEvent() == Event.MARK_APPEAL_PAID
                        && (isCorrectAppealTypePA || isCorrectAppealTypeAndStateHUorEA)
                        && !paymentStatus.equals(Optional.empty())
-                       && paymentStatus.get().equals(PaymentStatus.PAID);
+                       && paymentStatus.get().equals(PaymentStatus.PAID)
+                       && !AsylumCaseUtils.isInternalCase(asylumCase);
             }, notificationGenerators
         );
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6733


### Change description ###
* A notification is currently being sent to Legal rep on 'markAppealPaid' event. 
* Since Internal cases have no legal representative, attempt to send notifications fail. 
* This ensures that such notification is sent only if the appeal is not internal case.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
