### PR TITLE
RIA-6811 Add Det personalisation, MakeAnApplicationType model, beans

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-6811-internal-ada-case-decide-an-application-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-6811-internal-ada-case-decide-an-application-granted.json
@@ -1,5 +1,5 @@
 {
-  "description": "RIA-6811: internal ada case decideAnApplication event",
+  "description": "RIA-6811: internal ada case decideAnApplication event (Granted)",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "CaseOfficer",
@@ -15,32 +15,14 @@
           "appealType": "refusalOfEu",
           "isAdmin": "Yes",
           "isAcceleratedDetainedAppeal": "Yes",
-          "makeAnApplicationDecision": "Granted",
-          "makeAnApplicationDecisionReason": "A reason for the decision",
           "decideAnApplicationId": "1",
-          "makeAnApplicationsList": {
-            "value": {
-              "code": "1",
-              "label": "Admin Officer : Application 1"
-            },
-            "list_items": [
-              {
-                "code": "1",
-                "label": "Admin Officer : Application 1"
-              }
-            ]
-          },
           "makeAnApplications": [
             {
               "id": "1",
               "value": {
-                "date": "2023-03-03",
-                "type": "Time extension",
-                "state": "caseBuilding",
-                "details": "A reason for extending the timeframe",
-                "decisionMaker": "Tribunal Caseworker",
-                "decision": "Pending",
-                "evidence": [
+                "type":"Other",
+                "details":"",
+                "evidence":[
                   {
                     "id": "1",
                     "value": {
@@ -50,12 +32,17 @@
                     }
                   }
                 ],
-                "applicant": "Admin Officer",
-                "applicantRole": "caseworker-ia-admofficer"
+                "applicant":"",
+                "date":"",
+                "decision":"Granted",
+                "state":"caseBuilding",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"A reason for the decision",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Tribunal Caseworker"
               }
             }
-          ],
-          "hasApplicationsToDecide": "Yes"
+          ]
         }
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-6811-internal-ada-case-decide-an-application-refused.json
+++ b/src/functionalTest/resources/scenarios/RIA-6811-internal-ada-case-decide-an-application-refused.json
@@ -1,0 +1,71 @@
+{
+  "description": "RIA-6811: internal ada case decideAnApplication event (Refused)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 68112,
+      "eventId": "decideAnApplication",
+      "state": "caseBuilding",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "appellantGivenNames": "Test",
+          "appellantFamilyName": "User",
+          "appealType": "refusalOfEu",
+          "isAdmin": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Time extension",
+                "details":"",
+                "evidence":[
+                  {
+                    "id": "1",
+                    "value": {
+                      "document_url": "http://document-store/AAA",
+                      "document_filename": "Annexure-E.pdf",
+                      "document_binary_url": "http://document-store/AAA/binary"
+                    }
+                  }
+                ],
+                "applicant":"",
+                "date":"",
+                "decision":"Refused",
+                "state":"caseBuilding",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"A reason for the decision",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Tribunal Caseworker"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "appellantGivenNames": "Test",
+        "appellantFamilyName": "User",
+        "appealType": "refusalOfEu",
+        "isAdmin": "Yes",
+        "isAcceleratedDetainedAppeal": "Yes",
+        "decideAnApplicationId": "1",
+        "notificationsSent":[
+          {
+            "id":"68112_DECIDE_AN_APPLICATION_DET",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }]
+      }
+    }
+  }
+}
+

--- a/src/functionalTest/resources/scenarios/RIA-6811-internal-ada-case-decide-an-application.json
+++ b/src/functionalTest/resources/scenarios/RIA-6811-internal-ada-case-decide-an-application.json
@@ -1,0 +1,84 @@
+{
+  "description": "RIA-6811: internal ada case decideAnApplication event",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 68111,
+      "eventId": "decideAnApplication",
+      "state": "caseBuilding",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "appellantGivenNames": "Test",
+          "appellantFamilyName": "User",
+          "appealType": "refusalOfEu",
+          "isAdmin": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "makeAnApplicationDecision": "Granted",
+          "makeAnApplicationDecisionReason": "A reason for the decision",
+          "decideAnApplicationId": "1",
+          "makeAnApplicationsList": {
+            "value": {
+              "code": "1",
+              "label": "Admin Officer : Application 1"
+            },
+            "list_items": [
+              {
+                "code": "1",
+                "label": "Admin Officer : Application 1"
+              }
+            ]
+          },
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "date": "2023-03-03",
+                "type": "Time extension",
+                "state": "caseBuilding",
+                "details": "A reason for extending the timeframe",
+                "decisionMaker": "Tribunal Caseworker",
+                "decision": "Pending",
+                "evidence": [
+                  {
+                    "id": "1",
+                    "value": {
+                      "document_url": "http://document-store/AAA",
+                      "document_filename": "Annexure-E.pdf",
+                      "document_binary_url": "http://document-store/AAA/binary"
+                    }
+                  }
+                ],
+                "applicant": "Admin Officer",
+                "applicantRole": "caseworker-ia-admofficer"
+              }
+            }
+          ],
+          "hasApplicationsToDecide": "Yes"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "appellantGivenNames": "Test",
+        "appellantFamilyName": "User",
+        "appealType": "refusalOfEu",
+        "isAdmin": "Yes",
+        "isAcceleratedDetainedAppeal": "Yes",
+        "decideAnApplicationId": "1",
+        "notificationsSent":[
+          {
+            "id":"68111_DECIDE_AN_APPLICATION_DET",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }]
+      }
+    }
+  }
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/MakeAnApplicationType.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/MakeAnApplicationType.java
@@ -1,0 +1,48 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities;
+
+import static java.util.Arrays.stream;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Optional;
+
+public enum  MakeAnApplicationType {
+
+    ADJOURN("Adjourn"),
+    EXPEDITE("Expedite"),
+    JUDGE_REVIEW("Judge's review of application decision"),
+    JUDGE_REVIEW_LO("Judge's review of Legal Officer decision"),
+    LINK_OR_UNLINK("Link/unlink appeals"),
+    TIME_EXTENSION("Time extension"),
+    TRANSFER("Transfer"),
+    WITHDRAW("Withdraw"),
+    UPDATE_HEARING_REQUIREMENTS("Update hearing requirements"),
+    UPDATE_APPEAL_DETAILS("Update appeal details"),
+    REINSTATE("Reinstate an ended appeal"),
+    TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS("Transfer out of accelerated detained appeals process"),
+    OTHER("Other");
+
+    MakeAnApplicationType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    private final String value;
+
+    public static Optional<MakeAnApplicationType> from(
+        String value
+    ) {
+        return stream(values())
+            .filter(v -> v.getValue().equals(value))
+            .findFirst();
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamDecideAnApplicationPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamDecideAnApplicationPersonalisation.java
@@ -32,7 +32,7 @@ public class DetentionEngagementTeamDecideAnApplicationPersonalisation implement
     private final CustomerServicesProvider customerServicesProvider;
     private final String detentionEngagementTeamDecideAnApplicationTemplateId;
     private final String makeAnApplicationFormLink;
-    private final String judgesReviewDeadlineDateDelay;
+    private final int judgesReviewDeadlineDateDelay;
     private final String detentionEngagementTeamEmail;
     private final MakeAnApplicationService makeAnApplicationService;
     private final DateProvider dateProvider;
@@ -46,7 +46,7 @@ public class DetentionEngagementTeamDecideAnApplicationPersonalisation implement
         @Value("${govnotify.template.decideAnApplication.det.email}") String detentionEngagementTeamDecideAnApplicationTemplateId,
         @Value("${detentionEngagementTeamEmailAddress}") String detentionEngagementTeamEmail,
         @Value("${makeAnApplicationFormLink}") String makeAnApplicationFormLink,
-        @Value("${judgesReviewDeadlineDateDelay}") String judgesReviewDeadlineDateDelay,
+        @Value("${judgesReviewDeadlineDateDelay}") int judgesReviewDeadlineDateDelay,
         CustomerServicesProvider customerServicesProvider,
         MakeAnApplicationService makeAnApplicationService,
         DateProvider dateProvider
@@ -61,7 +61,7 @@ public class DetentionEngagementTeamDecideAnApplicationPersonalisation implement
     }
 
     @Override
-    public String getTemplateId(AsylumCase asylumCase) {
+    public String getTemplateId() {
         return detentionEngagementTeamDecideAnApplicationTemplateId;
     }
 
@@ -89,14 +89,18 @@ public class DetentionEngagementTeamDecideAnApplicationPersonalisation implement
         // If the decision maker is a TCW then change "Tribunal Caseworker" into "Legal Officer"
         String decisionMaker = adaptDecisionMakerName(optionalMakeAnApplication);
 
-        String judgesReviewDeadlineDate = dateProvider.dueDate(Integer.parseInt(judgesReviewDeadlineDateDelay));
+        String judgesReviewDeadlineDate = dateProvider.dueDate(judgesReviewDeadlineDateDelay);
+
+        String ariaListingReferenceIfPresent = asylumCase.read(ARIA_LISTING_REFERENCE, String.class)
+            .map(ariaListingReference -> "\nListing reference: " + ariaListingReference)
+            .orElse("");
 
         return ImmutableMap
             .<String, String>builder()
             .putAll(customerServicesProvider.getCustomerServicesPersonalisation())
             .put("subjectPrefix", isAcceleratedDetainedAppeal(asylumCase) ? adaPrefix : nonAdaPrefix)
             .put("appealReferenceNumber", asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
-            .put("ariaListingReferenceIfPresent", "\nListing reference: " + asylumCase.read(ARIA_LISTING_REFERENCE, String.class).orElse(""))
+            .put("ariaListingReferenceIfPresent", ariaListingReferenceIfPresent)
             .put("homeOfficeReferenceNumber", asylumCase.read(AsylumCaseDefinition.HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""))
             .put("appellantGivenNames", asylumCase.read(AsylumCaseDefinition.APPELLANT_GIVEN_NAMES, String.class).orElse(""))
             .put("appellantFamilyName", asylumCase.read(AsylumCaseDefinition.APPELLANT_FAMILY_NAME, String.class).orElse(""))
@@ -153,7 +157,7 @@ public class DetentionEngagementTeamDecideAnApplicationPersonalisation implement
             case ADJOURN:
             case EXPEDITE:
             case TRANSFER:
-                action =  "The details of your hearing will be updated. The Tribunal will contact you when this happens.";
+                action = "The details of your hearing will be updated. The Tribunal will contact you when this happens.";
                 break;
             case JUDGE_REVIEW:
                 action = "The decision on your original request will be overturned. The Tribunal will contact you if there is something you need to do next.";

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamDecideAnApplicationPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamDecideAnApplicationPersonalisation.java
@@ -1,0 +1,180 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.ARIA_LISTING_REFERENCE;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.isAcceleratedDetainedAppeal;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.DateProvider;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplication;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplicationType;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.CustomerServicesProvider;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.MakeAnApplicationService;
+
+@Slf4j
+@Service
+public class DetentionEngagementTeamDecideAnApplicationPersonalisation implements EmailNotificationPersonalisation {
+
+    private static final String DECISION_GRANTED = "Granted";
+    private static final String DECISION_REFUSED = "Refused";
+
+    private final CustomerServicesProvider customerServicesProvider;
+    private final String detentionEngagementTeamDecideAnApplicationTemplateId;
+    private final String makeAnApplicationFormLink;
+    private final String judgesReviewDeadlineDateDelay;
+    private final String detentionEngagementTeamEmail;
+    private final MakeAnApplicationService makeAnApplicationService;
+    private final DateProvider dateProvider;
+
+    @Value("${govnotify.emailPrefix.ada}")
+    private String adaPrefix;
+    @Value("${govnotify.emailPrefix.nonAda}")
+    private String nonAdaPrefix;
+
+    public DetentionEngagementTeamDecideAnApplicationPersonalisation(
+        @Value("${govnotify.template.decideAnApplication.det.email}") String detentionEngagementTeamDecideAnApplicationTemplateId,
+        @Value("${detentionEngagementTeamEmailAddress}") String detentionEngagementTeamEmail,
+        @Value("${makeAnApplicationFormLink}") String makeAnApplicationFormLink,
+        @Value("${judgesReviewDeadlineDateDelay}") String judgesReviewDeadlineDateDelay,
+        CustomerServicesProvider customerServicesProvider,
+        MakeAnApplicationService makeAnApplicationService,
+        DateProvider dateProvider
+    ) {
+        this.detentionEngagementTeamDecideAnApplicationTemplateId = detentionEngagementTeamDecideAnApplicationTemplateId;
+        this.detentionEngagementTeamEmail = detentionEngagementTeamEmail;
+        this.makeAnApplicationFormLink = makeAnApplicationFormLink;
+        this.judgesReviewDeadlineDateDelay = judgesReviewDeadlineDateDelay;
+        this.customerServicesProvider = customerServicesProvider;
+        this.makeAnApplicationService = makeAnApplicationService;
+        this.dateProvider = dateProvider;
+    }
+
+    @Override
+    public String getTemplateId(AsylumCase asylumCase) {
+        return detentionEngagementTeamDecideAnApplicationTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        return Collections.singleton(detentionEngagementTeamEmail);
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_DECIDE_AN_APPLICATION_DET";
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        Optional<MakeAnApplication> optionalMakeAnApplication = getMakeAnApplication(asylumCase);
+
+        // Turn the decision term into the verb to be used in the notification
+        String applicationDecision = getApplicationDecisionVerb(optionalMakeAnApplication);
+
+        String actionToTake = getActionToTakeBasedOnDecision(optionalMakeAnApplication);
+
+        // If the decision maker is a TCW then change "Tribunal Caseworker" into "Legal Officer"
+        String decisionMaker = adaptDecisionMakerName(optionalMakeAnApplication);
+
+        String judgesReviewDeadlineDate = dateProvider.dueDate(Integer.parseInt(judgesReviewDeadlineDateDelay));
+
+        return ImmutableMap
+            .<String, String>builder()
+            .putAll(customerServicesProvider.getCustomerServicesPersonalisation())
+            .put("subjectPrefix", isAcceleratedDetainedAppeal(asylumCase) ? adaPrefix : nonAdaPrefix)
+            .put("appealReferenceNumber", asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+            .put("ariaListingReferenceIfPresent", "\nListing reference: " + asylumCase.read(ARIA_LISTING_REFERENCE, String.class).orElse(""))
+            .put("homeOfficeReferenceNumber", asylumCase.read(AsylumCaseDefinition.HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""))
+            .put("appellantGivenNames", asylumCase.read(AsylumCaseDefinition.APPELLANT_GIVEN_NAMES, String.class).orElse(""))
+            .put("appellantFamilyName", asylumCase.read(AsylumCaseDefinition.APPELLANT_FAMILY_NAME, String.class).orElse(""))
+            .put("decisionMaker", decisionMaker)
+            .put("applicationDecision", applicationDecision)
+            .put("applicationType", optionalMakeAnApplication.map(MakeAnApplication::getType).orElse(""))
+            .put("applicationDecisionReason", getMakeAnApplication(asylumCase).map(MakeAnApplication::getDecisionReason).orElse("No reason given"))
+            .put("action", actionToTake)
+            .put("judgesReviewDeadlineDate", judgesReviewDeadlineDate)
+            .put("makeAnApplicationLink", makeAnApplicationFormLink)
+            .build();
+    }
+
+    private String adaptDecisionMakerName(Optional<MakeAnApplication> optionalMakeAnApplication) {
+        return optionalMakeAnApplication
+            .map(makeAnApplication -> Objects.equals(makeAnApplication.getDecisionMaker(), "Tribunal Caseworker")
+                ? "Legal Officer"
+                : makeAnApplication.getDecisionMaker()
+            )
+            .orElse("");
+    }
+
+    private String getActionToTakeBasedOnDecision(Optional<MakeAnApplication> optionalMakeAnApplication) {
+        return optionalMakeAnApplication
+            .map(makeAnApplication -> {
+                String type = makeAnApplication.getType();
+                MakeAnApplicationType makeAnApplicationType = MakeAnApplicationType.from(type)
+                    .orElseThrow(() -> new IllegalStateException("Unrecognized makeAnApplicationType"));
+                return actionToTakeAfterGrant(makeAnApplicationType);
+            })
+            .orElse("");
+    }
+
+    private String getApplicationDecisionVerb(Optional<MakeAnApplication> optionalMakeAnApplication) {
+        return optionalMakeAnApplication
+            .map(makeAnApplication -> Objects.equals(makeAnApplication.getDecision(), DECISION_GRANTED)
+                ? "grant"
+                : Objects.equals(makeAnApplication.getDecision(), DECISION_REFUSED)
+                ? "refuse"
+                : "")
+            .orElse("");
+    }
+
+    private Optional<MakeAnApplication> getMakeAnApplication(AsylumCase asylumCase) {
+        return makeAnApplicationService.getMakeAnApplication(asylumCase, true);
+    }
+
+    private String actionToTakeAfterGrant(MakeAnApplicationType makeAnApplicationTypes) {
+        String action = "";
+        switch (makeAnApplicationTypes) {
+            case TIME_EXTENSION:
+                action = "The Tribunal will give you more time to complete your next task. You will get a notification with the new date soon.";
+                break;
+            case ADJOURN:
+            case EXPEDITE:
+            case TRANSFER:
+                action =  "The details of your hearing will be updated. The Tribunal will contact you when this happens.";
+                break;
+            case JUDGE_REVIEW:
+                action = "The decision on your original request will be overturned. The Tribunal will contact you if there is something you need to do next.";
+                break;
+            case LINK_OR_UNLINK:
+                action = "This appeal will be linked or unlinked. The Tribunal will contact you when this happens.";
+                break;
+            case REINSTATE:
+                action = "This appeal will be reinstated and will continue from the point where it was ended. The Tribunal will contact you when this happens.";
+                break;
+            case WITHDRAW:
+                action = "The Tribunal will end the appeal. The Tribunal will contact you when this happens.";
+                break;
+            case OTHER:
+                action = "The Tribunal will contact you when it makes the changes you requested.";
+                break;
+        }
+        return action;
+    }
+
+
+
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamDecideAnApplicationPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamDecideAnApplicationPersonalisation.java
@@ -174,6 +174,8 @@ public class DetentionEngagementTeamDecideAnApplicationPersonalisation implement
             case OTHER:
                 action = "The Tribunal will contact you when it makes the changes you requested.";
                 break;
+            default:
+                break;
         }
         return action;
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -11,19 +11,49 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.Message;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.*;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerAdjournHearingWithoutDatePersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerAppealRemissionApprovedPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerAppealSubmittedPayOfflinePersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerAppealSubmittedPendingPaymentPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerChangeToHearingRequirementsPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerDecidedOrEndedAppealPendingPayment;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerEditPaymentMethodPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerFtpaDecisionAppellantPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerFtpaDecisionRespondentPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerFtpaSubmittedPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerReListCasePersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerRemissionDecisionPartiallyApprovedPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerRequestFeeRemissionPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerReviewHearingRequirementsPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerUpperTribunalBundleFailedPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerWithoutHearingRequirementsPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appellant.email.*;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appellant.sms.*;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.caseofficer.*;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.caseofficer.editdocument.CaseOfficerEditDocumentsPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam.DetentionEngagementTeamDecideAnApplicationPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.homeoffice.*;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.homeoffice.linkunlinkappeal.HomeOfficeLinkAppealPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.homeoffice.linkunlinkappeal.HomeOfficeUnlinkAppealPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.legalrepresentative.*;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.legalrepresentative.linkunlinkappeal.LegalRepresentativeLinkAppealPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.legalrepresentative.linkunlinkappeal.LegalRepresentativeUnlinkAppealPersonalisation;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent.*;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.*;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent.RespondentAdjournHearingWithoutDatePersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent.RespondentAppellantFtpaSubmittedPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent.RespondentChangeDirectionDueDatePersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent.RespondentDirectionPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent.RespondentEditAppealAfterSubmitPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent.RespondentEvidenceDirectionPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent.RespondentForceCaseProgressionPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent.RespondentForceCaseToSubmitHearingRequirementsPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent.RespondentFtpaSubmittedPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent.RespondentNonStandardDirectionPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent.RespondentRequestResponseAmendPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.EditListingEmailNotificationGenerator;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.EmailNotificationGenerator;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.NotificationGenerator;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.NotificationIdAppender;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.SmsNotificationGenerator;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.GovNotifyNotificationSender;
 
 @Configuration
@@ -2298,6 +2328,25 @@ public class NotificationGeneratorConfiguration {
                 newArrayList(
                     legalRepresentativeDecideAnApplicationPersonalisation,
                     homeOfficeDecideAnApplicationPersonalisation
+                ),
+                notificationSender,
+                notificationIdAppender
+            )
+        );
+    }
+
+    @Bean("decideAnApplicationDetNotificationGenerator")
+    public List<NotificationGenerator> decideAnApplicationDetNotificationHandler(
+        DetentionEngagementTeamDecideAnApplicationPersonalisation detentionEngagementTeamDecideAnApplicationPersonalisation,
+
+        GovNotifyNotificationSender notificationSender,
+        NotificationIdAppender notificationIdAppender
+    ) {
+
+        return Collections.singletonList(
+            new EmailNotificationGenerator(
+                newArrayList(
+                    detentionEngagementTeamDecideAnApplicationPersonalisation
                 ),
                 notificationSender,
                 notificationIdAppender

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -2314,8 +2314,8 @@ public class NotificationGeneratorConfiguration {
         );
     }
 
-    @Bean("decideAnApplicationNotificationGenerator")
-    public List<NotificationGenerator> decideAnApplicationNotificationHandler(
+    @Bean("decideAnApplicationLegalRepNotificationGenerator")
+    public List<NotificationGenerator> decideAnApplicationLegalRepNotificationGenerator(
         LegalRepresentativeDecideAnApplicationPersonalisation legalRepresentativeDecideAnApplicationPersonalisation,
         HomeOfficeDecideAnApplicationPersonalisation homeOfficeDecideAnApplicationPersonalisation,
 
@@ -2336,7 +2336,7 @@ public class NotificationGeneratorConfiguration {
     }
 
     @Bean("decideAnApplicationDetNotificationGenerator")
-    public List<NotificationGenerator> decideAnApplicationDetNotificationHandler(
+    public List<NotificationGenerator> decideAnApplicationDetNotificationGenerator(
         DetentionEngagementTeamDecideAnApplicationPersonalisation detentionEngagementTeamDecideAnApplicationPersonalisation,
 
         GovNotifyNotificationSender notificationSender,
@@ -2355,7 +2355,7 @@ public class NotificationGeneratorConfiguration {
     }
 
     @Bean("decideAnApplicationAipNotificationGenerator")
-    public List<NotificationGenerator> decideAnApplicationAipNotificationHandler(
+    public List<NotificationGenerator> decideAnApplicationAipNotificationGenerator(
             HomeOfficeDecideAnApplicationPersonalisation homeOfficeDecideAnApplicationPersonalisation,
             AppellantDecideAnApplicationPersonalisationEmail appellantDecideAnApplicationPersonalisationEmail,
             AppellantDecideAnApplicationPersonalisationSms appellantDecideAnApplicationPersonalisationSms,

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -2400,7 +2400,8 @@ public class NotificationHandlerConfiguration {
             (callbackStage, callback) ->
                 callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                 && callback.getEvent() == Event.DECIDE_AN_APPLICATION
-                && isInternalCase(callback.getCaseDetails().getCaseData()),
+                && isInternalCase(callback.getCaseDetails().getCaseData())
+                && isAcceleratedDetainedAppeal(callback.getCaseDetails().getCaseData()),
             notificationGenerators
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -2386,7 +2386,21 @@ public class NotificationHandlerConfiguration {
             (callbackStage, callback) ->
                 callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                 && callback.getEvent() == Event.DECIDE_AN_APPLICATION
-                && isRepJourney(callback.getCaseDetails().getCaseData()),
+                && !isAipJourney(callback.getCaseDetails().getCaseData())
+                && !isInternalCase(callback.getCaseDetails().getCaseData()),
+            notificationGenerators
+        );
+    }
+
+    @Bean
+    public PreSubmitCallbackHandler<AsylumCase> decideAnApplicationDetNotificationHandler(
+        @Qualifier("decideAnApplicationDetNotificationGenerator") List<NotificationGenerator> notificationGenerators) {
+
+        return new NotificationHandler(
+            (callbackStage, callback) ->
+                callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                && callback.getEvent() == Event.DECIDE_AN_APPLICATION
+                && isInternalCase(callback.getCaseDetails().getCaseData()),
             notificationGenerators
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -2379,14 +2379,14 @@ public class NotificationHandlerConfiguration {
     }
 
     @Bean
-    public PreSubmitCallbackHandler<AsylumCase> decideAnApplicationHomeOfficeNotificationHandler(
-        @Qualifier("decideAnApplicationNotificationGenerator") List<NotificationGenerator> notificationGenerators) {
+    public PreSubmitCallbackHandler<AsylumCase> decideAnApplicationLegalRepNotificationHandler(
+        @Qualifier("decideAnApplicationLegalRepNotificationGenerator") List<NotificationGenerator> notificationGenerators) {
 
         return new NotificationHandler(
             (callbackStage, callback) ->
                 callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                 && callback.getEvent() == Event.DECIDE_AN_APPLICATION
-                && !isAipJourney(callback.getCaseDetails().getCaseData())
+                && isRepJourney(callback.getCaseDetails().getCaseData())
                 && !isInternalCase(callback.getCaseDetails().getCaseData()),
             notificationGenerators
         );

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -751,6 +751,8 @@ govnotify:
                 email: 4e079f0c-38e2-4a02-a057-7cca421ee421
               afterListing:
                 email: 53693fc5-31bf-478b-95dc-afe875291a03
+        det:
+          email: 51135c0f-4dc1-4a6b-bcc5-a27db656cb41
     requestNewHearingRequirements:
       legalRep:
         email: afe66f48-e967-49f8-ba57-323e8711dd4d
@@ -1242,8 +1244,15 @@ ftpaSubmitted:
   ctscAdminEmailAddress: ${IA_CTSC_ADMIN_FTPA_SUBMITTED:ctscFtpaSubmitted@example.gov.uk}
   respondentEmailAddress: ${IA_RESPONDENT_FTPA_SUBMITTED:homeOfficeFtpaSubmitted@example.gov.uk}
 
+detentionEngagementTeamEmailAddress: ${DET_EMAIL_ADDRESS:dummyDetentionEngagementTeam@example.gov.uk}
+
+judgesReviewDeadlineDateDelay: ${JUDGES_REVIEW_DEADLINE_DATE_DELAY:14}
+
+makeAnApplicationFormLink: ${MAKE_AN_APPLICATION_FORM_LINK:https://www.gov.uk/government/publications/make-an-application-accelerated-detained-appeal-form-iaftada4}
+
 customerServices:
   emailAddress: ${IA_CUSTOMER_SERVICES_EMAIL:contactia@justice.gov.uk}
+  internalCaseEmailAddress: ${IA_CUSTOMER_SERVICES_UNREPRESENTED_EMAIL:IAC-ADA-HW@justice.gov.uk}
   telephoneNumber: ${IA_CUSTOMER_SERVICES_TELEPHONE:0300 123 1711}
 
 appellantDaysToWait:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -686,6 +686,9 @@ govnotify:
           homeOffice:
             email: 48ed7f47-00c6-462b-8acc-c9b7f38ba1ae
     decideAnApplication:
+        applicant:
+          detentionEngagementTeam:
+            email: 51135c0f-4dc1-4a6b-bcc5-a27db656cb41
         otherParty:
           appellant:
             beforeListing:
@@ -751,8 +754,6 @@ govnotify:
                 email: 4e079f0c-38e2-4a02-a057-7cca421ee421
               afterListing:
                 email: 53693fc5-31bf-478b-95dc-afe875291a03
-        det:
-          email: 51135c0f-4dc1-4a6b-bcc5-a27db656cb41
     requestNewHearingRequirements:
       legalRep:
         email: afe66f48-e967-49f8-ba57-323e8711dd4d

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/MakeAnApplicationTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/MakeAnApplicationTypeTest.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class MakeAnApplicationTypeTest {
+
+    @Test
+    void has_correct_values() {
+        assertEquals("Adjourn", MakeAnApplicationType.ADJOURN.toString());
+        assertEquals("Expedite", MakeAnApplicationType.EXPEDITE.toString());
+        assertEquals("Link/unlink appeals", MakeAnApplicationType.LINK_OR_UNLINK.toString());
+        assertEquals("Judge's review of application decision", MakeAnApplicationType.JUDGE_REVIEW.toString());
+        assertEquals("Judge's review of Legal Officer decision", MakeAnApplicationType.JUDGE_REVIEW_LO.toString());
+        assertEquals("Time extension", MakeAnApplicationType.TIME_EXTENSION.toString());
+        assertEquals("Transfer", MakeAnApplicationType.TRANSFER.toString());
+        assertEquals("Withdraw", MakeAnApplicationType.WITHDRAW.toString());
+        assertEquals("Update hearing requirements", MakeAnApplicationType.UPDATE_HEARING_REQUIREMENTS.toString());
+        assertEquals("Update appeal details", MakeAnApplicationType.UPDATE_APPEAL_DETAILS.toString());
+        assertEquals("Reinstate an ended appeal", MakeAnApplicationType.REINSTATE.toString());
+        assertEquals("Transfer out of accelerated detained appeals process",
+            MakeAnApplicationType.TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.toString());
+        assertEquals("Other", MakeAnApplicationType.OTHER.toString());
+    }
+
+    @Test
+    void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
+        assertEquals(13, MakeAnApplicationType.values().length);
+    }
+}
+

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamDecideAnApplicationPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamDecideAnApplicationPersonalisationTest.java
@@ -158,7 +158,7 @@ class DetentionEngagementTeamDecideAnApplicationPersonalisationTest {
             case ADJOURN:
             case EXPEDITE:
             case TRANSFER:
-                assertEquals( "The details of your hearing will be updated. The Tribunal "
+                assertEquals("The details of your hearing will be updated. The Tribunal "
                               + "will contact you when this happens.", expectedAction);
                 break;
             case JUDGE_REVIEW:
@@ -181,6 +181,8 @@ class DetentionEngagementTeamDecideAnApplicationPersonalisationTest {
             case OTHER:
                 assertEquals("The Tribunal will contact you when it makes the changes you "
                              + "requested.", expectedAction);
+                break;
+            default:
                 break;
         }
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamDecideAnApplicationPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamDecideAnApplicationPersonalisationTest.java
@@ -1,0 +1,212 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPELLANT_FAMILY_NAME;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPELLANT_GIVEN_NAMES;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.ARIA_LISTING_REFERENCE;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.HOME_OFFICE_REFERENCE_NUMBER;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.IS_ACCELERATED_DETAINED_APPEAL;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo.YES;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.utils.SubjectPrefixesInitializer.initializePrefixes;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.DateProvider;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplication;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplicationType;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.CustomerServicesProvider;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.MakeAnApplicationService;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class DetentionEngagementTeamDecideAnApplicationPersonalisationTest {
+
+    @Mock
+    AsylumCase asylumCase;
+    @Mock
+    private CustomerServicesProvider customerServicesProvider;
+    @Mock
+    private MakeAnApplicationService makeAnApplicationService;
+    @Mock
+    private DateProvider dateProvider;
+    @Mock
+    private MakeAnApplication makeAnApplication;
+
+    private final Long caseId = 12345L;
+    private final String appealReferenceNumber = "someReferenceNumber";
+    private final String homeOfficeReferenceNumber = "1234-1234-1234-1234";
+    private final String appellantGivenNames = "someAppellantGivenNames";
+    private final String appellantFamilyName = "someAppellantFamilyName";
+    private final String decisionReason = "someDecisionReason";
+    private final String detentionEngagementTeamDecideAnApplicationTemplateId = "detentionEngagementTeamDecideAnApplicationTemplateId";
+    private final String makeAnApplicationFormLink = "someLink";
+    private final int judgesReviewDeadlineDateDelay = 14;
+    private final String detentionEngagementTeamEmail = "det@email.com";
+    private final String customerServiceTelephone = "0123456789";
+    private final String customerServiceEmail = "hm@email.com";
+    private final String calculatedDeadline = "03 March 2023";
+
+    private DetentionEngagementTeamDecideAnApplicationPersonalisation detentionEngagementTeamDecideAnApplicationPersonalisation;
+
+    @BeforeEach
+    void setup() {
+        detentionEngagementTeamDecideAnApplicationPersonalisation = new DetentionEngagementTeamDecideAnApplicationPersonalisation(
+            detentionEngagementTeamDecideAnApplicationTemplateId,
+            detentionEngagementTeamEmail,
+            makeAnApplicationFormLink,
+            judgesReviewDeadlineDateDelay,
+            customerServicesProvider,
+            makeAnApplicationService,
+            dateProvider
+        );
+    }
+
+    @Test
+    void should_return_given_template_id() {
+        assertEquals(detentionEngagementTeamDecideAnApplicationTemplateId, detentionEngagementTeamDecideAnApplicationPersonalisation.getTemplateId());
+    }
+
+    @Test
+    void should_return_given_reference_id() {
+        assertEquals(caseId + "_DECIDE_AN_APPLICATION_DET",
+            detentionEngagementTeamDecideAnApplicationPersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    void should_return_given_det_email_address() {
+        assertTrue(
+            detentionEngagementTeamDecideAnApplicationPersonalisation.getRecipientsList(asylumCase).contains(detentionEngagementTeamEmail));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = MakeAnApplicationType.class, names = {
+        "ADJOURN",
+        "EXPEDITE",
+        "JUDGE_REVIEW",
+        "JUDGE_REVIEW_LO",
+        "LINK_OR_UNLINK",
+        "TIME_EXTENSION",
+        "TRANSFER",
+        "WITHDRAW",
+        "UPDATE_HEARING_REQUIREMENTS",
+        "UPDATE_APPEAL_DETAILS",
+        "REINSTATE",
+        "TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS",
+        "OTHER"
+    })
+    void should_return_personalisation_of_all_information_given(MakeAnApplicationType makeAnApplicationType) {
+        initializePrefixes(detentionEngagementTeamDecideAnApplicationPersonalisation);
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YES));
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(ARIA_LISTING_REFERENCE, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+
+        when(dateProvider.dueDate(judgesReviewDeadlineDateDelay)).thenReturn(calculatedDeadline);
+
+        when(makeAnApplicationService.getMakeAnApplication(asylumCase, true)).thenReturn(Optional.of(makeAnApplication));
+        when(makeAnApplication.getDecision()).thenReturn("Granted");
+        when(makeAnApplication.getType()).thenReturn(makeAnApplicationType.getValue());
+        when(makeAnApplication.getDecisionMaker()).thenReturn("Judge");
+        when(makeAnApplication.getDecisionReason()).thenReturn(decisionReason);
+        when(customerServicesProvider.getCustomerServicesPersonalisation()).thenReturn(ImmutableMap
+            .<String, String>builder()
+            .put("customerServicesTelephone", customerServiceTelephone)
+            .put("customerServicesEmail", customerServiceEmail)
+            .build());
+
+        Map<String, String> personalisation = detentionEngagementTeamDecideAnApplicationPersonalisation.getPersonalisation(asylumCase);
+
+        assertEquals(customerServiceTelephone, personalisation.get("customerServicesTelephone"));
+        assertEquals(customerServiceEmail, personalisation.get("customerServicesEmail"));
+        assertEquals("Accelerated detained appeal", personalisation.get("subjectPrefix"));
+        assertEquals(appealReferenceNumber, personalisation.get("appealReferenceNumber"));
+        assertEquals("", personalisation.get("ariaListingReferenceIfPresent"));
+        assertEquals(homeOfficeReferenceNumber, personalisation.get("homeOfficeReferenceNumber"));
+        assertEquals(appellantGivenNames, personalisation.get("appellantGivenNames"));
+        assertEquals(appellantFamilyName, personalisation.get("appellantFamilyName"));
+        assertEquals("Judge", personalisation.get("decisionMaker"));
+        assertEquals("grant", personalisation.get("applicationDecision"));
+        assertEquals(makeAnApplicationType.getValue(), personalisation.get("applicationType"));
+        assertEquals(decisionReason, personalisation.get("applicationDecisionReason"));
+        assertEquals(calculatedDeadline, personalisation.get("judgesReviewDeadlineDate"));
+        assertEquals(makeAnApplicationFormLink, personalisation.get("makeAnApplicationLink"));
+
+        String expectedAction = personalisation.get("action");
+
+        switch (makeAnApplicationType) {
+            case TIME_EXTENSION:
+                assertEquals("The Tribunal will give you more time to complete your next task. "
+                             + "You will get a notification with the new date soon.", expectedAction);
+                break;
+            case ADJOURN:
+            case EXPEDITE:
+            case TRANSFER:
+                assertEquals( "The details of your hearing will be updated. The Tribunal "
+                              + "will contact you when this happens.", expectedAction);
+                break;
+            case JUDGE_REVIEW:
+                assertEquals("The decision on your original request will be overturned. "
+                             + "The Tribunal will contact you if there is something you need to do next.",
+                    expectedAction);
+                break;
+            case LINK_OR_UNLINK:
+                assertEquals("This appeal will be linked or unlinked. The Tribunal will contact you "
+                             + "when this happens.", expectedAction);
+                break;
+            case REINSTATE:
+                assertEquals("This appeal will be reinstated and will continue from the point "
+                             + "where it was ended. The Tribunal will contact you when this happens.", expectedAction);
+                break;
+            case WITHDRAW:
+                assertEquals("The Tribunal will end the appeal. The Tribunal will contact you "
+                             + "when this happens.", expectedAction);
+                break;
+            case OTHER:
+                assertEquals("The Tribunal will contact you when it makes the changes you "
+                             + "requested.", expectedAction);
+                break;
+        }
+    }
+
+    @Test
+    void should_return_personalisation_with_formatted_tribunal_caseworker_term() {
+        initializePrefixes(detentionEngagementTeamDecideAnApplicationPersonalisation);
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YES));
+
+        when(dateProvider.dueDate(judgesReviewDeadlineDateDelay)).thenReturn(calculatedDeadline);
+
+        when(makeAnApplicationService.getMakeAnApplication(asylumCase, true)).thenReturn(Optional.of(makeAnApplication));
+        when(makeAnApplication.getDecision()).thenReturn("Refused");
+        when(makeAnApplication.getType()).thenReturn("Expedite");
+        when(makeAnApplication.getDecisionMaker()).thenReturn("Tribunal Caseworker");
+        when(makeAnApplication.getDecisionReason()).thenReturn(decisionReason);
+        when(customerServicesProvider.getCustomerServicesPersonalisation()).thenReturn(ImmutableMap
+            .<String, String>builder()
+            .put("customerServicesTelephone", customerServiceTelephone)
+            .put("customerServicesEmail", customerServiceEmail)
+            .build());
+
+        Map<String, String> personalisation = detentionEngagementTeamDecideAnApplicationPersonalisation.getPersonalisation(asylumCase);
+
+        assertEquals("refuse", personalisation.get("applicationDecision"));
+        assertEquals("Legal Officer", personalisation.get("decisionMaker"));
+    }
+}
+


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6811](https://tools.hmcts.net/jira/browse/RIA-6811)


### Change description ###
- Personalisation for DET for application decided when ADA internal case
- As can be seen from the [NotificationHandlerConfiguration](src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java) :
    - if proper AIP journey (aip frontend):
        - email sent as usual to appellant
    - if not proper AIP journey (LR journey, aka non-aip frontend)
        - if non internal: 
            - if ADA: emails sent as usual to LR and HO
            - if non-ADA: emails sent as usual to LR and HO
        - if internal: 
            - if ADA: email sent to DET
            - if non-ADA: `not set`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
