### PR TITLE
RIA-6782: Enabled notification for DET when Hearing bundle is ready

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-6782-hearing-bundle-is-ready-notification-to-det-ada.json
+++ b/src/functionalTest/resources/scenarios/RIA-6782-hearing-bundle-is-ready-notification-to-det-ada.json
@@ -1,0 +1,90 @@
+{
+  "description": "RIA-6782 Hearing bundle is ready notification to DET Email (For ADA)",
+  "enabled": false,
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 6782,
+      "eventId": "asyncStitchingComplete",
+      "state": "preHearing",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "listCaseHearingCentre": "harmondsworth",
+          "ariaListingReference": "LP/12345/2019",
+          "hearingDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "document": {
+                  "document_url": "http://document-store/BBB",
+                  "document_binary_url": "http://document-store/BBB/binary",
+                  "document_filename": "Talha-Awan-hearing-bundle.pdf"
+                },
+                "description": "",
+                "dateUploaded": "{$TODAY}",
+                "tag": "hearingBundle"
+              }
+            }],
+          "caseBundles": [{
+            "id": "1",
+            "value": {
+              "stitchStatus": "DONE"
+            }
+          }]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "listCaseHearingCentre": "harmondsworth",
+        "ariaListingReference": "LP/12345/2019",
+        "notificationsSent": [
+          {
+            "id": "6782_HEARING_BUNDLE_IS_READY_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": " 6782_HEARING_BUNDLE_IS_READY_DET_ADA_EMAIL",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "6782_HEARING_BUNDLE_IS_READY_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.northShields}",
+        "subject": "Immigration and Asylum appeal: hearing bundle is ready",
+        "body": [
+          "PA/12345/2019",
+          "LP/12345/2019",
+          "A1234567",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}",
+          "{$customerServices.telephoneNumber}",
+          "{$customerServices.emailAddress}"
+        ]
+      },
+      {
+        "reference": "6782_HEARING_BUNDLE_IS_READY_DET_ADA_EMAIL",
+        "recipient": "{$IA_UNREPRESENTED_ADA_DET_EMAIL}",
+        "subject": "Accelerated detained appeal: The hearing bundle is ready",
+        "body": [
+          "PA/12345/2019",
+          "LP/12345/2019",
+          "A1234567",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/templates/minimal-internal-appeal-submitted.json
+++ b/src/functionalTest/resources/templates/minimal-internal-appeal-submitted.json
@@ -1,0 +1,29 @@
+{
+  "homeOfficeReferenceNumber": "A1234567",
+  "isAdmin": "Yes",
+  "homeOfficeDecisionDate": "{$TODAY}",
+  "appellantTitle": "Mr",
+  "appellantGivenNames": "Talha",
+  "appellantFamilyName": "Awan",
+  "appellantDateOfBirth": "{$TODAY-7300}",
+  "appellantNationalities": [
+    {
+      "id": "1",
+      "value": {
+        "Iceland": "IS"
+      }
+    }
+  ],
+  "appellantHasFixedAddress": "No",
+  "appealType": "protection",
+  "appealGroundsProtection": {
+    "values": [
+      "refugeeConvention"
+    ]
+  },
+  "hasNewMatters": "No",
+  "hasOtherAppeals": "No",
+  "appealReferenceNumber": "PA/12345/2019",
+  "sendDirectionActionAvailable": "Yes",
+  "hearingCentre": "taylorHouse"
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamHearingBundleReadyPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamHearingBundleReadyPersonalisation.java
@@ -1,0 +1,93 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.RequiredFieldMissingException;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailWithLinkNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DetEmailService;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.DocumentDownloadClient;
+import uk.gov.service.notify.NotificationClientException;
+
+@Service
+@Slf4j
+public class DetentionEngagementTeamHearingBundleReadyPersonalisation implements EmailWithLinkNotificationPersonalisation {
+
+    private final String detHearingBundleReadyTemplateId;
+    private final DocumentDownloadClient documentDownloadClient;
+    @Value("${govnotify.emailPrefix.ada}")
+    private String adaPrefix;
+    private final DetEmailService detEmailService;
+
+    public DetentionEngagementTeamHearingBundleReadyPersonalisation(
+        @Value("${govnotify.template.hearingBundleReady.detentionEngagementTeam.email}") String detHearingBundleReadyTemplateId,
+        DetEmailService detEmailService,
+        DocumentDownloadClient documentDownloadClient
+    ) {
+        this.detHearingBundleReadyTemplateId = detHearingBundleReadyTemplateId;
+        this.detEmailService = detEmailService;
+        this.documentDownloadClient = documentDownloadClient;
+    }
+
+    @Override
+    public String getTemplateId() {
+        return detHearingBundleReadyTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(final AsylumCase asylumCase) {
+        return Collections.singleton(detEmailService.getAdaDetEmailAddress());
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_HEARING_BUNDLE_IS_READY_DET_ADA_EMAIL";
+    }
+
+    @Override
+    public Map<String, Object> getPersonalisationForLink(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        return ImmutableMap
+            .<String, Object>builder()
+            .put("subjectPrefix", adaPrefix)
+            .put("appealReferenceNumber", asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+            .put("ariaListingReference", asylumCase.read(ARIA_LISTING_REFERENCE, String.class).orElse(""))
+            .put("homeOfficeReferenceNumber", asylumCase.read(AsylumCaseDefinition.HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""))
+            .put("appellantGivenNames", asylumCase.read(AsylumCaseDefinition.APPELLANT_GIVEN_NAMES, String.class).orElse(""))
+            .put("appellantFamilyName", asylumCase.read(AsylumCaseDefinition.APPELLANT_FAMILY_NAME, String.class).orElse(""))
+            .put("link_to_hearing_bundle", getHearingBundleDocumentInJsonObject(asylumCase))
+            .build();
+    }
+
+    private JSONObject getHearingBundleDocumentInJsonObject(AsylumCase asylumCase) {
+        Optional<List<IdValue<DocumentWithMetadata>>> maybeLegalRepresentativeDocuments = asylumCase.read(HEARING_DOCUMENTS);
+        List<DocumentWithMetadata> documents = maybeLegalRepresentativeDocuments
+                .orElse(Collections.emptyList())
+                .stream()
+                .map(IdValue::getValue)
+                .filter(document -> document.getTag() == DocumentTag.HEARING_BUNDLE)
+                .collect(Collectors.toList());
+
+        if (documents.size() == 0) {
+            throw new RequiredFieldMissingException("Hearing Bundle is not available");
+        }
+        DocumentWithMetadata document = documents.get(0);
+        try {
+            return documentDownloadClient.getJsonObjectFromDocument(document);
+        } catch (IOException | NotificationClientException e) {
+            log.error("Failed to get Hearing bundle document in compatible format", e);
+            throw new IllegalStateException("Failed to get Hearing bundle document document in compatible format");
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -32,6 +32,7 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appella
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.caseofficer.*;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.caseofficer.editdocument.CaseOfficerEditDocumentsPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam.DetentionEngagementTeamDecideAnApplicationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam.DetentionEngagementTeamHearingBundleReadyPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam.DetentionEngagementTeamRequestResponseReviewPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.homeoffice.*;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.homeoffice.linkunlinkappeal.HomeOfficeLinkAppealPersonalisation;
@@ -1181,6 +1182,26 @@ public class NotificationGeneratorConfiguration {
                 notificationSender,
                 notificationIdAppender
             )
+        );
+    }
+
+    @Bean("HearingBundleReadyDetAdaNotificationGenerator")
+    public List<NotificationGenerator> hearingBundleReadyAdaDetNotificationGenerator(
+            HomeOfficeHearingBundleReadyPersonalisation homeOfficeHearingBundleReadyPersonalisation,
+            DetentionEngagementTeamHearingBundleReadyPersonalisation detentionEngagementTeamHearingBundleReadyPersonalisation,
+            GovNotifyNotificationSender notificationSender,
+            NotificationIdAppender notificationIdAppender
+    ) {
+        return Arrays.asList(
+                new EmailWithLinkNotificationGenerator(
+                        newArrayList(detentionEngagementTeamHearingBundleReadyPersonalisation),
+                        notificationSender,
+                        notificationIdAppender
+                ),
+                new EmailNotificationGenerator(
+                        newArrayList(homeOfficeHearingBundleReadyPersonalisation),
+                        notificationSender,
+                        notificationIdAppender)
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -1171,7 +1171,8 @@ public class NotificationHandlerConfiguration {
                     && callback.getEvent() == Event.ASYNC_STITCHING_COMPLETE
                     && callback.getCaseDetails().getState() != State.FTPA_DECIDED
                     && "DONE".equalsIgnoreCase(getStitchStatus(callback))
-                    && isRepJourney(callback.getCaseDetails().getCaseData()),
+                    && isRepJourney(callback.getCaseDetails().getCaseData())
+                    && !isInternalCase(callback.getCaseDetails().getCaseData()),
             notificationGenerators
         );
     }
@@ -1188,6 +1189,24 @@ public class NotificationHandlerConfiguration {
                         && "DONE".equalsIgnoreCase(getStitchStatus(callback))
                         && isAipJourney(callback.getCaseDetails().getCaseData()),
             notificationGenerators
+        );
+    }
+
+    @Bean
+    public PreSubmitCallbackHandler<AsylumCase> hearingBundleReadyAdaDetNotificationHandler(
+            @Qualifier("HearingBundleReadyDetAdaNotificationGenerator") List<NotificationGenerator> notificationGenerators) {
+
+        return new NotificationHandler(
+                (callbackStage, callback) -> {
+                    return
+                            callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                                    && callback.getEvent() == Event.ASYNC_STITCHING_COMPLETE
+                                    && callback.getCaseDetails().getState() != State.FTPA_DECIDED
+                                    && "DONE".equalsIgnoreCase(getStitchStatus(callback))
+                                    && AsylumCaseUtils.isInternalCase(callback.getCaseDetails().getCaseData())
+                                    && AsylumCaseUtils.isAcceleratedDetainedAppeal(callback.getCaseDetails().getCaseData());
+                },
+                notificationGenerators
         );
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -317,6 +317,8 @@ govnotify:
       caseOfficer:
         email: 0df260d7-fd82-430b-86bb-047083a8172a
     hearingBundleReady:
+      detentionEngagementTeam:
+        email: 734a1474-aa91-40bf-b227-96be926d846c
       legalRep:
         email: 33f23316-8283-4968-90a0-aac4a1faebce
       homeOffice:

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/TestUtils.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/TestUtils.java
@@ -14,12 +14,16 @@ public class TestUtils {
 
     }
 
-    public static List<IdValue<DocumentWithMetadata>> getDocumentWithMetadata(String docId, String filename,
-                                                                               String description, DocumentTag tag) {
+    public static List<IdValue<DocumentWithMetadata>> getDocumentWithMetadataList(String docId, String filename,
+                                                                                  String description, DocumentTag tag) {
+        return Arrays.asList(new IdValue<>(docId, getDocumentWithMetadata(docId, filename, description, tag)));
+    }
+
+    public static DocumentWithMetadata getDocumentWithMetadata(String docId, String filename,
+                                                                                  String description, DocumentTag tag) {
         String documentUrl = "http://dm-store/" + docId;
         Document document = new Document(documentUrl, documentUrl + "/binary", filename);
 
-        return Arrays.asList(new IdValue<>(docId, new DocumentWithMetadata(document, description,
-            LocalDate.now().toString(), tag)));
+        return new DocumentWithMetadata(document, description, LocalDate.now().toString(), tag);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamHearingBundleReadyPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamHearingBundleReadyPersonalisationTest.java
@@ -1,0 +1,131 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo.YES;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.hmcts.reform.iacasenotificationsapi.TestUtils;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.RequiredFieldMissingException;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DetEmailService;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.DocumentDownloadClient;
+import uk.gov.service.notify.NotificationClientException;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class DetentionEngagementTeamHearingBundleReadyPersonalisationTest {
+
+    @Mock
+    AsylumCase asylumCase;
+    @Mock
+    private DocumentDownloadClient documentDownloadClient;
+    @Mock
+    private DetEmailService detEmailService;
+
+    private final Long caseId = 12345L;
+    private final String appealReferenceNumber = "someReferenceNumber";
+    private final String homeOfficeReferenceNumber = "1234-1234-1234-1234";
+    private final String ariaListingReference = "LP-1234";
+    private final String appellantGivenNames = "someAppellantGivenNames";
+    private final String appellantFamilyName = "someAppellantFamilyName";
+    private final String detHearingBundleReadyTemplateId = "detHearingBundleReadyTemplateId";
+    private final String detentionEngagementTeamEmail = "det@email.com";
+
+    private final JSONObject jsonObject = new JSONObject("{\"title\": \"Hearing bundle JsonDocument\"}");
+    DocumentWithMetadata hearingBundleDoc = TestUtils.getDocumentWithMetadata(
+            "id", "hearing_bundle", "some other desc", DocumentTag.HEARING_BUNDLE);
+    IdValue<DocumentWithMetadata> hearingBundle = new IdValue<>("1", hearingBundleDoc);
+    private DetentionEngagementTeamHearingBundleReadyPersonalisation detentionEngagementTeamHearingBundleReadyPersonalisation;
+
+    DetentionEngagementTeamHearingBundleReadyPersonalisationTest() {
+    }
+
+    @BeforeEach
+    void setup() throws NotificationClientException, IOException {
+        detentionEngagementTeamHearingBundleReadyPersonalisation = new DetentionEngagementTeamHearingBundleReadyPersonalisation(
+                detHearingBundleReadyTemplateId,
+                detEmailService,
+                documentDownloadClient
+        );
+        ReflectionTestUtils.setField(detentionEngagementTeamHearingBundleReadyPersonalisation, "adaPrefix", "Accelerated detained appeal");
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YES));
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(ARIA_LISTING_REFERENCE, String.class)).thenReturn(Optional.of(ariaListingReference));
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(asylumCase.read(HEARING_DOCUMENTS)).thenReturn(Optional.of(newArrayList(hearingBundle)));
+        when(documentDownloadClient.getJsonObjectFromDocument(any(DocumentWithMetadata.class))).thenReturn(jsonObject);
+    }
+
+    @Test
+    void should_return_given_reference_id() {
+        assertEquals(caseId + "_HEARING_BUNDLE_IS_READY_DET_ADA_EMAIL",
+            detentionEngagementTeamHearingBundleReadyPersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    void should_return_given_det_email_address() {
+        when(detEmailService.getAdaDetEmailAddress()).thenReturn(detentionEngagementTeamEmail);
+        assertTrue(
+            detentionEngagementTeamHearingBundleReadyPersonalisation.getRecipientsList(asylumCase).contains(detentionEngagementTeamEmail));
+    }
+
+    @Test
+    void should_return_personalisation_of_all_information() throws NotificationClientException, IOException {
+        Map<String, Object> personalisation = detentionEngagementTeamHearingBundleReadyPersonalisation.getPersonalisationForLink(asylumCase);
+
+        assertEquals("Accelerated detained appeal", personalisation.get("subjectPrefix"));
+        assertEquals(appealReferenceNumber, personalisation.get("appealReferenceNumber"));
+        assertEquals(ariaListingReference, personalisation.get("ariaListingReference"));
+        assertEquals(homeOfficeReferenceNumber, personalisation.get("homeOfficeReferenceNumber"));
+        assertEquals(appellantGivenNames, personalisation.get("appellantGivenNames"));
+        assertEquals(appellantFamilyName, personalisation.get("appellantFamilyName"));
+        assertEquals(jsonObject, personalisation.get("link_to_hearing_bundle"));
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(() -> detentionEngagementTeamHearingBundleReadyPersonalisation.getPersonalisationForLink((AsylumCase) null))
+                .isExactlyInstanceOf(NullPointerException.class)
+                .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_throw_exception_when_hearing_bundle_is_empty() {
+        when(asylumCase.read(HEARING_DOCUMENTS)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> detentionEngagementTeamHearingBundleReadyPersonalisation.getPersonalisationForLink(asylumCase))
+                .isExactlyInstanceOf(RequiredFieldMissingException.class)
+                .hasMessage("Hearing Bundle is not available");
+    }
+
+    @Test
+    public void should_throw_exception_when_notification_client_throws_Exception() throws NotificationClientException, IOException {
+        when(documentDownloadClient.getJsonObjectFromDocument(hearingBundleDoc)).thenThrow(new NotificationClientException("File size is more than 2MB"));
+        assertThatThrownBy(() -> detentionEngagementTeamHearingBundleReadyPersonalisation.getPersonalisationForLink(asylumCase))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("Failed to get Hearing bundle document document in compatible format");
+    }
+
+}
+

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamRequestResponseReviewPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamRequestResponseReviewPersonalisationTest.java
@@ -73,7 +73,7 @@ public class DetentionEngagementTeamRequestResponseReviewPersonalisationTest {
         when(asylumCase.read(APPEAL_REVIEW_OUTCOME, AppealReviewOutcome.class))
             .thenReturn(Optional.of(AppealReviewOutcome.DECISION_WITHDRAWN));
 
-        List<IdValue<DocumentWithMetadata>> appealResponseDocuments = TestUtils.getDocumentWithMetadata("docId", "filename", "description", DocumentTag.APPEAL_RESPONSE);
+        List<IdValue<DocumentWithMetadata>> appealResponseDocuments = TestUtils.getDocumentWithMetadataList("docId", "filename", "description", DocumentTag.APPEAL_RESPONSE);
         appealResponseJsonDocument =  new JSONObject("{\"title\": \"Home Office Response JsonDocument\"}");
         when(asylumCase.read(RESPONDENT_DOCUMENTS)).thenReturn(Optional.of(appealResponseDocuments));
 


### PR DESCRIPTION
- Added personalisation to set the map for DET notification when ASYNC_STITCHING_COMPLETE is complete and status is DONE.
- Added a check to disable LR configuration when ASYNC_STITCHING_COMPLETE is complete for internal case.
- Tested the notifications for internal ADA appeal. two notifications sent out: *_HEARING_BUNDLE_IS_READY_DET_ADA_EMAIL and *_HEARING_BUNDLE_IS_READY_HOME_OFFICE
- Refactored methods in TestUtils to help getDocument or DocumentinList.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
