### PR TITLE
Ria 6920 enable preexisting notifications

### DIFF
--- a/charts/ia-case-notifications-api/Chart.yaml
+++ b/charts/ia-case-notifications-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ia-case-notifications-api
 home: https://github.com/hmcts/ia-case-notifications-api
-version: 0.0.37
+version: 0.0.38
 description: Immigration & Asylum Case Notifications Service
 maintainers:
   - name: HMCTS Immigration & Asylum Team

--- a/src/functionalTest/resources/scenarios/RIA-6811-internal-ada-case-decide-an-application-applicant-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-6811-internal-ada-case-decide-an-application-applicant-granted.json
@@ -63,9 +63,12 @@
           {
             "id":"68111_DECIDE_AN_APPLICATION_DET",
             "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id":"68111_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }]
       }
     }
   }
 }
-

--- a/src/functionalTest/resources/scenarios/RIA-6811-internal-ada-case-decide-an-application-applicant-refused.json
+++ b/src/functionalTest/resources/scenarios/RIA-6811-internal-ada-case-decide-an-application-applicant-refused.json
@@ -63,6 +63,10 @@
           {
             "id":"68112_DECIDE_AN_APPLICATION_DET",
             "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id":"68112_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }]
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-6812-internal-ada-case-decide-an-application-other-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-6812-internal-ada-case-decide-an-application-other-granted.json
@@ -63,6 +63,10 @@
           {
             "id":"68121_DECIDE_AN_APPLICATION_DET",
             "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id":"68121_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }]
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-6812-internal-ada-case-decide-an-application-other-refused.json
+++ b/src/functionalTest/resources/scenarios/RIA-6812-internal-ada-case-decide-an-application-other-refused.json
@@ -63,6 +63,10 @@
           {
             "id":"68122_DECIDE_AN_APPLICATION_DET",
             "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id":"68122_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }]
       }
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeDecideAnApplicationPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeDecideAnApplicationPersonalisation.java
@@ -28,6 +28,7 @@ public class HomeOfficeDecideAnApplicationPersonalisation implements EmailNotifi
     private static final String HOME_OFFICE_LART = "caseworker-ia-homeofficelart";
     private static final String HOME_OFFICE_APC = "caseworker-ia-homeofficeapc";
     private static final String HOME_OFFICE_POU = "caseworker-ia-homeofficepou";
+    private static final String ADMIN_OFFICER = "caseworker-ia-admofficer";
     private static final String CITIZEN = "citizen";
 
 
@@ -131,8 +132,15 @@ public class HomeOfficeDecideAnApplicationPersonalisation implements EmailNotifi
 
             String applicantRole = makeAnApplication.getApplicantRole();
 
+            boolean hasValidRole = Set.of(
+                ROLE_LEGAL_REP,
+                CITIZEN,
+                HOME_OFFICE_RESPONDENT_OFFICER,
+                ADMIN_OFFICER)
+                .contains(applicantRole);
+
             if (applicantRole.equals(HOME_OFFICE_APC)
-                    || (Arrays.asList(ROLE_LEGAL_REP, CITIZEN, HOME_OFFICE_RESPONDENT_OFFICER).contains(applicantRole)
+                    || (hasValidRole
                     && Arrays.asList(
                                 State.APPEAL_SUBMITTED,
                                 State.PENDING_PAYMENT,
@@ -145,14 +153,14 @@ public class HomeOfficeDecideAnApplicationPersonalisation implements EmailNotifi
                                 State.ENDED).contains(applicationState))) {
                 return Collections.singleton(apcHomeOfficeEmailAddress);
             } else if (HOME_OFFICE_LART.equals(applicantRole)
-                    || (Arrays.asList(ROLE_LEGAL_REP, CITIZEN, HOME_OFFICE_RESPONDENT_OFFICER).contains(applicantRole)
+                    || (hasValidRole
                     && Arrays.asList(
                     State.RESPONDENT_REVIEW,
                     State.LISTING,
                     State.SUBMIT_HEARING_REQUIREMENTS).contains(applicationState))) {
                 return Collections.singleton(lartHomeOfficeEmailAddress);
             } else if (HOME_OFFICE_POU.equals(applicantRole)
-                    || (Arrays.asList(ROLE_LEGAL_REP, CITIZEN, HOME_OFFICE_RESPONDENT_OFFICER).contains(applicantRole)
+                    || (hasValidRole
                     &&  isAppealListed)) {
                 final Optional<HearingCentre> maybeCaseIsListed = asylumCase
                         .read(AsylumCaseDefinition.LIST_CASE_HEARING_CENTRE, HearingCentre.class);

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeMakeAnApplicationPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeMakeAnApplicationPersonalisation.java
@@ -35,6 +35,7 @@ public class HomeOfficeMakeAnApplicationPersonalisation implements EmailNotifica
     private static final String HOME_OFFICE_LART = "caseworker-ia-homeofficelart";
     private static final String HOME_OFFICE_APC = "caseworker-ia-homeofficeapc";
     private static final String HOME_OFFICE_POU = "caseworker-ia-homeofficepou";
+    private static final String ADMIN_OFFICER = "caseworker-ia-admofficer";
     private static final String CITIZEN = "citizen";
 
 
@@ -109,7 +110,11 @@ public class HomeOfficeMakeAnApplicationPersonalisation implements EmailNotifica
             return Collections.emptySet();
         }
 
-        boolean hasValidRoles = hasRoles(Arrays.asList(ROLE_LEGAL_REP, CITIZEN, HOME_OFFICE_RESPONDENT_OFFICER));
+        boolean hasValidRoles = hasRoles(Arrays.asList(
+            ROLE_LEGAL_REP,
+            CITIZEN,
+            HOME_OFFICE_RESPONDENT_OFFICER,
+            ADMIN_OFFICER));
 
         if (hasRoles(Arrays.asList(HOME_OFFICE_APC))
                 || (hasValidRoles && isValidStateForHomeOfficeApc(currentState))) {

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeMakeAnApplicationPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeMakeAnApplicationPersonalisation.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.legalr
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.isAcceleratedDetainedAppeal;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.isInternalCase;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.*;
@@ -56,6 +57,13 @@ public class LegalRepresentativeMakeAnApplicationPersonalisation implements Lega
         this.appealService = appealService;
         this.userDetailsProvider = userDetailsProvider;
         this.makeAnApplicationService = makeAnApplicationService;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        return isInternalCase(asylumCase)
+            ? Collections.emptySet()
+            : LegalRepresentativeEmailNotificationPersonalisation.super.getRecipientsList(asylumCase);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -2388,6 +2388,7 @@ public class NotificationGeneratorConfiguration {
     @Bean("decideAnApplicationDetNotificationGenerator")
     public List<NotificationGenerator> decideAnApplicationDetNotificationGenerator(
         DetentionEngagementTeamDecideAnApplicationPersonalisation detentionEngagementTeamDecideAnApplicationPersonalisation,
+        HomeOfficeDecideAnApplicationPersonalisation homeOfficeDecideAnApplicationPersonalisation,
 
         GovNotifyNotificationSender notificationSender,
         NotificationIdAppender notificationIdAppender
@@ -2396,7 +2397,8 @@ public class NotificationGeneratorConfiguration {
         return Collections.singletonList(
             new EmailNotificationGenerator(
                 newArrayList(
-                    detentionEngagementTeamDecideAnApplicationPersonalisation
+                    detentionEngagementTeamDecideAnApplicationPersonalisation,
+                    homeOfficeDecideAnApplicationPersonalisation
                 ),
                 notificationSender,
                 notificationIdAppender

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeMakeAnApplicationPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeMakeAnApplicationPersonalisationTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -46,6 +47,14 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.MakeAnApplicati
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class HomeOfficeMakeAnApplicationPersonalisationTest {
+
+    private static final String ADMIN_OFFICER = "caseworker-ia-admofficer";
+    private static final String LEGAL_REP_USER = "caseworker-ia-legalrep-solicitor";
+    private static final String CITIZEN_USER = "citizen";
+    private static final String HOME_OFFICE_LART = "caseworker-ia-homeofficelart";
+    private static final String HOME_OFFICE_APC = "caseworker-ia-homeofficeapc";
+    private static final String HOME_OFFICE_POU = "caseworker-ia-homeofficepou";
+    private static final String HOME_OFFICE_RESPONDENT = "caseworker-ia-respondentofficer";
 
     @Mock
     AsylumCase asylumCase;
@@ -86,13 +95,6 @@ public class HomeOfficeMakeAnApplicationPersonalisationTest {
     private String respondentReviewDirectionEmail = "homeoffice-respondent@example.com";
     private String homeOfficeHearingCentreEmail = "hc-taylorhouse@example.com";
     private String homeOfficeEmail = "ho-taylorhouse@example.com";
-
-    private String legalRepUser = "caseworker-ia-legalrep-solicitor";
-    private String citizenUser = "citizen";
-    private String homeOfficeLart = "caseworker-ia-homeofficelart";
-    private String homeOfficeApc = "caseworker-ia-homeofficeapc";
-    private String homeOfficePou = "caseworker-ia-homeofficepou";
-    private String homeOfficeRespondent = "caseworker-ia-respondentofficer";
 
 
     private HomeOfficeMakeAnApplicationPersonalisation homeOfficeMakeAnApplicationPersonalisation;
@@ -136,21 +138,21 @@ public class HomeOfficeMakeAnApplicationPersonalisationTest {
     @Test
     public void should_return_given_template_id() {
         when(userDetails.getRoles()).thenReturn(
-            Arrays.asList(legalRepUser)
+            Arrays.asList(LEGAL_REP_USER)
         );
         when(appealService.isAppealListed(asylumCase)).thenReturn(false);
         assertEquals(homeOfficeMakeAnApplicationBeforeListingTemplateId,
             homeOfficeMakeAnApplicationPersonalisation.getTemplateId(asylumCase));
 
         when(userDetails.getRoles()).thenReturn(
-                Arrays.asList(citizenUser)
+                Arrays.asList(CITIZEN_USER)
         );
         when(appealService.isAppealListed(asylumCase)).thenReturn(true);
         assertEquals(homeOfficeMakeAnApplicationAfterListingTemplateId,
             homeOfficeMakeAnApplicationPersonalisation.getTemplateId(asylumCase));
 
 
-        List<String> roles = Arrays.asList(homeOfficeApc, homeOfficeLart, homeOfficeRespondent, homeOfficePou);
+        List<String> roles = Arrays.asList(HOME_OFFICE_APC, HOME_OFFICE_LART, HOME_OFFICE_RESPONDENT, HOME_OFFICE_POU);
         for (String role : roles) {
             when(userDetails.getRoles()).thenReturn(
                 Arrays.asList(role)
@@ -184,19 +186,19 @@ public class HomeOfficeMakeAnApplicationPersonalisationTest {
             .thenReturn(Optional.of(State.APPEAL_SUBMITTED));
 
         when(userDetails.getRoles()).thenReturn(
-            Arrays.asList(homeOfficeApc)
+            Arrays.asList(HOME_OFFICE_APC)
         );
         assertTrue(homeOfficeMakeAnApplicationPersonalisation.getRecipientsList(asylumCase)
             .contains(apcPrivateBetaInboxHomeOfficeEmailAddress));
 
         when(userDetails.getRoles()).thenReturn(
-            Arrays.asList(homeOfficeLart)
+            Arrays.asList(HOME_OFFICE_LART)
         );
         assertTrue(homeOfficeMakeAnApplicationPersonalisation.getRecipientsList(asylumCase)
             .contains(respondentReviewDirectionEmail));
 
         when(userDetails.getRoles()).thenReturn(
-            Arrays.asList(homeOfficePou)
+            Arrays.asList(HOME_OFFICE_POU)
         );
         when(appealService.isAppealListed(asylumCase)).thenReturn(true);
         assertTrue(homeOfficeMakeAnApplicationPersonalisation.getRecipientsList(asylumCase)
@@ -207,11 +209,12 @@ public class HomeOfficeMakeAnApplicationPersonalisationTest {
 
     }
 
-    @Test
-    public void test_email_address_for_home_office_when_legal_rep_applied() {
+    @ParameterizedTest
+    @ValueSource(strings = { LEGAL_REP_USER, ADMIN_OFFICER })
+    public void test_email_address_for_home_office_when_legal_rep_or_admin_applied(String role) {
 
         when(userDetails.getRoles()).thenReturn(
-            Arrays.asList(legalRepUser)
+            Arrays.asList(role)
         );
 
         List<State> apcEmail = newArrayList(
@@ -276,7 +279,7 @@ public class HomeOfficeMakeAnApplicationPersonalisationTest {
     public void test_email_address_for_home_office_when_generic_ho_applied() {
 
         when(userDetails.getRoles()).thenReturn(
-            Arrays.asList(homeOfficeRespondent)
+            Arrays.asList(HOME_OFFICE_RESPONDENT)
         );
 
         List<State> apcEmail = newArrayList(

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeMakeAnApplicationPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeMakeAnApplicationPersonalisationTest.java
@@ -10,6 +10,7 @@ import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumC
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPELLANT_GIVEN_NAMES;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.ARIA_LISTING_REFERENCE;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.IS_ACCELERATED_DETAINED_APPEAL;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.IS_ADMIN;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.LEGAL_REPRESENTATIVE_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.LEGAL_REP_REFERENCE_NUMBER;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.utils.SubjectPrefixesInitializer.initializePrefixes;
@@ -104,6 +105,19 @@ public class LegalRepresentativeMakeAnApplicationPersonalisationTest {
             userDetailsProvider,
             makeAnApplicationService
         );
+    }
+
+    @Test
+    public void should_return_empty_recipients_list_if_internal_case() {
+        when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        assertTrue(legalRepresentativeMakeAnApplicationPersonalisation.getRecipientsList(asylumCase).isEmpty());
+    }
+
+    @Test
+    public void should_return_appropriate_recipients_list_if_not_internal_case() {
+        when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.empty());
+        assertTrue(legalRepresentativeMakeAnApplicationPersonalisation.getRecipientsList(asylumCase)
+            .contains(legalRepEmailAddress));
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6920](https://tools.hmcts.net/jira/browse/RIA-6920)


### Change description ###
- Added admin role to HO personalizations for `makeAnApplication` and `decideAnApplication`
- Made the LR personalization for `makeAnApplication` return an empty recipients list for an internal case (no LR email present) so that it doesn't throw an error


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
