### PR TITLE
Ria 6781 ada suitability review notification to DET - Unrepresented/internal cases

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-6781-internal-ada-case-ada-suitability-notification-suitable.json
+++ b/src/functionalTest/resources/scenarios/RIA-6781-internal-ada-case-ada-suitability-notification-suitable.json
@@ -1,0 +1,62 @@
+{
+  "description": "RIA-6781: Send ADA suitability review notification to DET (Internal ADA) - Suitable",
+  "enabled": false,
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 6781,
+      "eventId": "adaSuitabilityReview",
+      "state": "respondentReview",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "ariaListingReference": "LR/1234/2345",
+          "appellantGivenNames": "Test",
+          "appellantFamilyName": "User",
+          "suitabilityReviewDecision": "suitable",
+          "listCaseHearingDate": "{$TODAY}",
+          "tribunalDocuments": [
+            {
+              "id": "docId",
+              "value": {
+                "document": {
+                  "document_url": "http://dm-store/docId",
+                  "document_binary_url": "http://dm-store/docId/binary",
+                  "document_filename": "filename"
+                },
+                "description": "description",
+                "dateUploaded": "{$TODAY}",
+                "tag": "adaSuitability"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "ariaListingReference": "LR/1234/2345",
+        "appellantGivenNames": "Test",
+        "appellantFamilyName": "User",
+        "isAdmin": "Yes",
+        "isAcceleratedDetainedAppeal": "Yes",
+        "suitabilityReviewDecision": "suitable",
+        "listCaseHearingDate": "{$TODAY}",
+        "notificationsSent":[
+          {
+            "id":"6781_DETENTION_ENGAGEMENT_TEAM_REQUEST_RESPONSE_REVIEW",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }]
+      }
+    }
+  }
+}
+

--- a/src/functionalTest/resources/scenarios/RIA-6781-internal-ada-case-ada-suitability-notification-unsuitable.json
+++ b/src/functionalTest/resources/scenarios/RIA-6781-internal-ada-case-ada-suitability-notification-unsuitable.json
@@ -1,0 +1,62 @@
+{
+  "description": "RIA-6781: Send ADA suitability review notification to DET (Internal ADA) - Unsuitable",
+  "enabled": false,
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 6781,
+      "eventId": "adaSuitabilityReview",
+      "state": "respondentReview",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "ariaListingReference": "LR/1234/2345",
+          "appellantGivenNames": "Test",
+          "appellantFamilyName": "User",
+          "suitabilityReviewDecision": "unsuitable",
+          "listCaseHearingDate": "{$TODAY}",
+          "tribunalDocuments": [
+            {
+              "id": "docId",
+              "value": {
+                "document": {
+                  "document_url": "http://dm-store/docId",
+                  "document_binary_url": "http://dm-store/docId/binary",
+                  "document_filename": "filename"
+                },
+                "description": "description",
+                "dateUploaded": "{$TODAY}",
+                "tag": "adaSuitability"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "ariaListingReference": "LR/1234/2345",
+        "appellantGivenNames": "Test",
+        "appellantFamilyName": "User",
+        "isAdmin": "Yes",
+        "isAcceleratedDetainedAppeal": "Yes",
+        "suitabilityReviewDecision": "unsuitable",
+        "listCaseHearingDate": "{$TODAY}",
+        "notificationsSent":[
+          {
+            "id":"6781_DETENTION_ENGAGEMENT_TEAM_REQUEST_RESPONSE_REVIEW",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }]
+      }
+    }
+  }
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AsylumCaseDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AsylumCaseDefinition.java
@@ -176,6 +176,9 @@ public enum AsylumCaseDefinition {
     ADDITIONAL_TRIBUNAL_RESPONSE(
         "additionalTribunalResponse", new TypeReference<String>(){}),
 
+    PAST_EXPERIENCES_TRIBUNAL_RESPONSE(
+            "pastExperiencesTribunalResponse", new TypeReference<String>(){}),
+
     CASE_BUNDLES(
         "caseBundles", new TypeReference<List<IdValue<Bundle>>>(){}),
 

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTag.java
@@ -29,6 +29,8 @@ public enum DocumentTag {
     UPLOAD_DOCUMENT("uploadDocument"),
     BAIL_SUBMISSION("bailSubmission"),
     B1_DOCUMENT("b1Document"),
+    ADA_SUITABILITY("adaSuitability"),
+    APPEAL_FORM("appealForm"),
 
     @JsonEnumDefaultValue
     NONE("");

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamAdaSuitabilityReviewPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamAdaSuitabilityReviewPersonalisation.java
@@ -1,0 +1,141 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam;
+
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.*;
+import javax.validation.constraints.NotNull;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.RequiredFieldMissingException;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailWithLinkNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DetEmailService;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.CustomerServicesProvider;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.DateTimeExtractor;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.HearingDetailsFinder;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.DocumentDownloadClient;
+import uk.gov.service.notify.NotificationClientException;
+
+@Slf4j
+@Service
+public class DetentionEngagementTeamAdaSuitabilityReviewPersonalisation implements EmailWithLinkNotificationPersonalisation {
+
+    private final String documentDownloadTitle = "Accelerated Detained Appeal Suitability Decision document";
+    private final String detentionEngagementTeamAdaSuitabilityReviewTemplateId;
+    private final String iaExUiFrontendUrl;
+    private final CustomerServicesProvider customerServicesProvider;
+    private final String adaPrefix;
+    private final DetEmailService detEmailService;
+    private final DocumentDownloadClient documentDownloadClient;
+    private final DateTimeExtractor dateTimeExtractor;
+    private final HearingDetailsFinder hearingDetailsFinder;
+
+
+
+    public DetentionEngagementTeamAdaSuitabilityReviewPersonalisation(
+            @NotNull(message = "adaSuitabilityUnsuitableLegalRepresentativeTemplateId cannot be null")
+            @Value("${govnotify.template.adaSuitabilityReview.detentionEngagementTeam.email}") String detentionEngagementTeamAdaSuitabilityReviewTemplateId,
+            @Value("${iaExUiFrontendUrl}") String iaExUiFrontendUrl,
+            @Value("${govnotify.emailPrefix.ada}") String adaPrefix,
+            CustomerServicesProvider customerServicesProvider,
+            DetEmailService detEmailService,
+            DocumentDownloadClient documentDownloadClient,
+            DateTimeExtractor dateTimeExtractor,
+            HearingDetailsFinder hearingDetailsFinder
+    ) {
+        this.detentionEngagementTeamAdaSuitabilityReviewTemplateId = detentionEngagementTeamAdaSuitabilityReviewTemplateId;
+        this.iaExUiFrontendUrl = iaExUiFrontendUrl;
+        this.customerServicesProvider = customerServicesProvider;
+        this.adaPrefix = adaPrefix;
+        this.detEmailService = detEmailService;
+        this.documentDownloadClient = documentDownloadClient;
+        this.dateTimeExtractor = dateTimeExtractor;
+        this.hearingDetailsFinder = hearingDetailsFinder;
+    }
+
+    @Override
+    public String getTemplateId(AsylumCase asylumCase) {
+        return detentionEngagementTeamAdaSuitabilityReviewTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        return Collections.singleton(detEmailService.getAdaDetEmailAddress());
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_ADA_SUITABILITY_DETERMINED_DET";
+    }
+
+    @Override
+    public Map<String, Object> getPersonalisationForLink(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        String ariaListingReferenceIfPresent = asylumCase.read(ARIA_LISTING_REFERENCE, String.class)
+                .map(ariaListingReference -> "Listing reference: " + ariaListingReference)
+                .orElse("");
+
+        return ImmutableMap
+                .<String, Object>builder()
+                .putAll(customerServicesProvider.getCustomerServicesPersonalisation())
+                .put("subjectPrefix", adaPrefix)
+                .put("appealReferenceNumber", asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+                .put("ariaListingReferenceIfPresent", ariaListingReferenceIfPresent)
+                .put("homeOfficeReferenceNumber", asylumCase.read(AsylumCaseDefinition.HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""))
+                .put("appellantGivenNames", asylumCase.read(AsylumCaseDefinition.APPELLANT_GIVEN_NAMES, String.class).orElse(""))
+                .put("appellantFamilyName", asylumCase.read(AsylumCaseDefinition.APPELLANT_FAMILY_NAME, String.class).orElse(""))
+                .put("adaSuitability", getAdaSuitabilityDecision(asylumCase).toString())
+                .put("hearingDate", dateTimeExtractor.extractHearingDate(hearingDetailsFinder.getHearingDateTime(asylumCase)))
+
+                .put("hearingRequirementVulnerabilities", asylumCase.read(VULNERABILITIES_TRIBUNAL_RESPONSE, String.class)
+                        .orElse("No special adjustments are being made to accommodate vulnerabilities"))
+                .put("hearingRequirementMultimedia", asylumCase.read(MULTIMEDIA_TRIBUNAL_RESPONSE, String.class)
+                        .orElse("No multimedia equipment is being provided"))
+                .put("hearingRequirementSingleSexCourt", asylumCase.read(SINGLE_SEX_COURT_TRIBUNAL_RESPONSE, String.class)
+                        .orElse("The court will not be single sex"))
+                .put("hearingRequirementInCameraCourt", asylumCase.read(IN_CAMERA_COURT_TRIBUNAL_RESPONSE, String.class)
+                        .orElse("The hearing will be held in public court"))
+                .put("hearingRequirementOther", asylumCase.read(ADDITIONAL_TRIBUNAL_RESPONSE, String.class)
+                        .orElse("No other adjustments are being made"))
+                .put("remoteVideoCallTribunalResponse", asylumCase.read(REMOTE_VIDEO_CALL_TRIBUNAL_RESPONSE, String.class)
+                        .orElse("No adjustments have been made for a remote hearing"))
+                .put("pastExperienceTribunalResponse", asylumCase.read(PAST_EXPERIENCES_TRIBUNAL_RESPONSE, String.class)
+                        .orElse("No adjustments for previous experiences are being made"))
+
+                .put("linkToOnlineService", iaExUiFrontendUrl)
+                .put("documentDownloadTitle", documentDownloadTitle)
+                .put("linkToDownloadDocument", getAdaSuitabilityDocument(asylumCase))
+                .build();
+
+    }
+
+    private AdaSuitabilityReviewDecision getAdaSuitabilityDecision(AsylumCase asylumCase) {
+        return asylumCase.read(SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class)
+                .orElseThrow(() -> new RequiredFieldMissingException("ADA suitability decision missing"));
+    }
+
+    private JSONObject getAdaSuitabilityDocument(AsylumCase asylumCase) {
+        Optional<List<IdValue<DocumentWithMetadata>>> optionalRespondentDocuments = asylumCase.read(TRIBUNAL_DOCUMENTS);
+        DocumentWithMetadata document = optionalRespondentDocuments
+                .orElse(Collections.emptyList())
+                .stream()
+                .map(IdValue::getValue)
+                .filter(d -> d.getTag() == DocumentTag.ADA_SUITABILITY)
+                .findFirst().orElseThrow(() -> new IllegalStateException("ADA suitability document not available"));
+
+        try {
+            return documentDownloadClient.getJsonObjectFromDocument(document);
+        } catch (IOException | NotificationClientException e) {
+            log.error("Failed to get ADA suitability document in compatible format", e);
+            throw new IllegalStateException("Failed to get ADA suitability document in compatible format");
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -31,6 +31,7 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appella
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appellant.sms.*;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.caseofficer.*;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.caseofficer.editdocument.CaseOfficerEditDocumentsPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam.DetentionEngagementTeamAdaSuitabilityReviewPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam.DetentionEngagementTeamDecideAnApplicationPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam.DetentionEngagementTeamHearingBundleReadyPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam.DetentionEngagementTeamRequestResponseReviewPersonalisation;
@@ -3193,6 +3194,21 @@ public class NotificationGeneratorConfiguration {
                             legalRepresentativeAdaSuitabilityPersonalisation,
                             homeOfficeAdaSuitabilityPersonalisation
                         ),
+                        notificationSender,
+                        notificationIdAppender
+                )
+        );
+    }
+
+    @Bean("adaSuitabilityInternalAdaNotificationGenerator")
+    public List<NotificationGenerator> adaSuitabilityInternalAdaNotificationGenerator(
+            DetentionEngagementTeamAdaSuitabilityReviewPersonalisation detentionEngagementTeamAdaSuitabilityReviewPersonalisation,
+            GovNotifyNotificationSender notificationSender,
+            NotificationIdAppender notificationIdAppender) {
+
+        return Arrays.asList(
+                new EmailWithLinkNotificationGenerator(
+                        newArrayList(Collections.singleton(detentionEngagementTeamAdaSuitabilityReviewPersonalisation)),
                         notificationSender,
                         notificationIdAppender
                 )

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -3549,7 +3549,26 @@ public class NotificationHandlerConfiguration {
         return new NotificationHandler(
                 (callbackStage, callback) ->
                     callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-                    && callback.getEvent() == Event.ADA_SUITABILITY_REVIEW,
+                    && callback.getEvent() == Event.ADA_SUITABILITY_REVIEW
+                            && isRepJourney(callback.getCaseDetails().getCaseData())
+                            && !AsylumCaseUtils.isInternalCase(callback.getCaseDetails().getCaseData()),
+                notificationGenerators
+        );
+    }
+
+    @Bean
+    public PreSubmitCallbackHandler<AsylumCase> adaSuitabilityInternalAdaNotificationHandler(
+            @Qualifier("adaSuitabilityInternalAdaNotificationGenerator") List<NotificationGenerator> notificationGenerators) {
+
+        return new NotificationHandler(
+                (callbackStage, callback) -> {
+                    AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+                    return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                            && callback.getEvent() == Event.ADA_SUITABILITY_REVIEW
+                            && AsylumCaseUtils.isInternalCase(asylumCase)
+                            && AsylumCaseUtils.isAcceleratedDetainedAppeal(asylumCase);
+                },
                 notificationGenerators
         );
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -855,6 +855,8 @@ govnotify:
           email: 0c8d72c1-7c63-4426-8d73-f178a540e1ff
         suitable:
           email: 1adfdfcf-1eac-44aa-8c2f-90dffd956796
+      detentionEngagementTeam:
+        email: b7019a3f-ad5e-4e03-bdee-01098920b856
     transferOutOfAda:
       homeOffice:
         beforeListing:

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTagTest.java
@@ -37,6 +37,6 @@ public class DocumentTagTest {
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(25, DocumentTag.values().length);
+        assertEquals(27, DocumentTag.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamAdaSuitabilityReviewPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamAdaSuitabilityReviewPersonalisationTest.java
@@ -1,0 +1,241 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.TestUtils.getDocumentWithMetadata;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.RequiredFieldMissingException;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DetEmailService;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.CustomerServicesProvider;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.DateTimeExtractor;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.HearingDetailsFinder;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.DocumentDownloadClient;
+import uk.gov.service.notify.NotificationClientException;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class DetentionEngagementTeamAdaSuitabilityReviewPersonalisationTest {
+
+    @Mock
+    AsylumCase asylumCase;
+    @Mock
+    CustomerServicesProvider customerServicesProvider;
+    @Mock
+    DetEmailService detEmailService;
+    @Mock
+    DocumentDownloadClient documentDownloadClient;
+    @Mock
+    DateTimeExtractor dateTimeExtractor;
+    @Mock
+    HearingDetailsFinder hearingDetailsFinder;
+
+    private final String templateId = "someTemplateId";
+    private final String iaExUiFrontendUrl = "http://somefrontendurl";
+    private final String adaPrefix = "Accelerated detained appeal";
+    private final String hearingDateTime = "2019-08-27T14:25:15.000";
+    private String hearingDate = "2019-08-27";
+    private String hearingTime = "14:25";
+    private final String detEmailAddress = "legalrep@example.com";
+    private final String appealReferenceNumber = "someReferenceNumber";
+    private final String listingReference = "listingReference";
+    private final String homeOfficeReferenceNumber = "1234-1234-1234-1234";
+    private final String appellantGivenNames = "someAppellantGivenNames";
+    private final String appellantFamilyName = "someAppellantFamilyName";
+    private final String customerServicesTelephone = "555 555 555";
+    private final String customerServicesEmail = "customer.services@example.com";
+    private final String hearingRequirementVulnerabilities = "No special adjustments are being made to accommodate vulnerabilities";
+    private final String hearingRequirementMultimedia = "No multimedia equipment is being provided";
+    private final String hearingRequirementSingleSexCourt = "The court will not be single sex";
+    private final String hearingRequirementInCameraCourt = "The hearing will be held in public court";
+    private final String hearingRequirementOther = "No other adjustments are being made";
+    private final String remoteVideoCallTribunalResponse = "No adjustments have been made for a remote hearing";
+    private final String pastExperienceTribunalResponse = "No adjustments for previous experiences are being made";
+    private final JSONObject jsonObject = new JSONObject();
+    DocumentWithMetadata adaSuitabilityDoc = getDocumentWithMetadata(
+            "id", "ada_suitability", "some other desc", DocumentTag.ADA_SUITABILITY);
+    IdValue<DocumentWithMetadata> adaSuitabilityDocId = new IdValue<>("1", adaSuitabilityDoc);
+
+    private DetentionEngagementTeamAdaSuitabilityReviewPersonalisation
+            detentionEngagementTeamAdaSuitabilityReviewPersonalisation;
+
+    DetentionEngagementTeamAdaSuitabilityReviewPersonalisationTest() {
+    }
+
+    @BeforeEach
+    public void setUp() throws NotificationClientException, IOException {
+
+        detentionEngagementTeamAdaSuitabilityReviewPersonalisation =
+                new DetentionEngagementTeamAdaSuitabilityReviewPersonalisation(
+                        templateId,
+                        iaExUiFrontendUrl,
+                        adaPrefix,
+                        customerServicesProvider,
+                        detEmailService,
+                        documentDownloadClient,
+                        dateTimeExtractor,
+                        hearingDetailsFinder
+                );
+
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
+
+        when(asylumCase.read(SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class)).thenReturn(Optional.of(AdaSuitabilityReviewDecision.SUITABLE));
+
+        when(asylumCase.read(VULNERABILITIES_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.of(hearingRequirementVulnerabilities));
+        when(asylumCase.read(MULTIMEDIA_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.of(hearingRequirementMultimedia));
+        when(asylumCase.read(SINGLE_SEX_COURT_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.of(hearingRequirementSingleSexCourt));
+        when(asylumCase.read(IN_CAMERA_COURT_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.of(hearingRequirementInCameraCourt));
+        when(asylumCase.read(ADDITIONAL_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.of(hearingRequirementOther));
+        when(asylumCase.read(REMOTE_VIDEO_CALL_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.of(remoteVideoCallTribunalResponse));
+        when(asylumCase.read(PAST_EXPERIENCES_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.of(pastExperienceTribunalResponse));
+
+        when(hearingDetailsFinder.getHearingDateTime(asylumCase)).thenReturn(hearingDateTime);
+        when(dateTimeExtractor.extractHearingDate(hearingDateTime)).thenReturn(hearingDate);
+        when(dateTimeExtractor.extractHearingTime(hearingDateTime)).thenReturn(hearingTime);
+
+        when(asylumCase.read(TRIBUNAL_DOCUMENTS)).thenReturn(Optional.of(newArrayList(adaSuitabilityDocId)));
+        when(documentDownloadClient.getJsonObjectFromDocument(adaSuitabilityDoc)).thenReturn(jsonObject);
+
+        when(customerServicesProvider.getCustomerServicesTelephone()).thenReturn(customerServicesTelephone);
+        when(customerServicesProvider.getCustomerServicesEmail()).thenReturn(customerServicesEmail);
+        when(detEmailService.getAdaDetEmailAddress()).thenReturn(detEmailAddress);
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        Long caseId = 12345L;
+        assertEquals(caseId + "_ADA_SUITABILITY_DETERMINED_DET",
+                detentionEngagementTeamAdaSuitabilityReviewPersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address_from_asylum_case() {
+        assertTrue(detentionEngagementTeamAdaSuitabilityReviewPersonalisation.getRecipientsList(asylumCase)
+                .contains(detEmailAddress));
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(
+                () -> detentionEngagementTeamAdaSuitabilityReviewPersonalisation.getPersonalisationForLink((AsylumCase) null))
+                .isExactlyInstanceOf(NullPointerException.class)
+                .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_suitability_review_is_missing() {
+        when(asylumCase.read(SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class)).thenReturn(Optional.empty());
+        assertThatThrownBy(
+                () -> detentionEngagementTeamAdaSuitabilityReviewPersonalisation.getPersonalisationForLink(asylumCase))
+                .isExactlyInstanceOf(RequiredFieldMissingException.class)
+                .hasMessage("ADA suitability decision missing");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = AsylumCaseDefinition.class, names = {
+        "VULNERABILITIES_TRIBUNAL_RESPONSE",
+        "MULTIMEDIA_TRIBUNAL_RESPONSE",
+        "SINGLE_SEX_COURT_TRIBUNAL_RESPONSE",
+        "IN_CAMERA_COURT_TRIBUNAL_RESPONSE",
+        "ADDITIONAL_TRIBUNAL_RESPONSE",
+        "REMOTE_VIDEO_CALL_TRIBUNAL_RESPONSE",
+        "PAST_EXPERIENCES_TRIBUNAL_RESPONSE"
+    })
+    public void should_default_hearing_requirements_tribunal_responses_when_missing(AsylumCaseDefinition asylumCaseDefinition) throws NotificationClientException, IOException {
+        when(asylumCase.read(asylumCaseDefinition, String.class)).thenReturn(Optional.empty());
+
+        Map<String, Object> personalisation =
+                detentionEngagementTeamAdaSuitabilityReviewPersonalisation.getPersonalisationForLink(asylumCase);
+        if (asylumCaseDefinition.equals(VULNERABILITIES_TRIBUNAL_RESPONSE)) {
+            assertEquals(hearingRequirementVulnerabilities, personalisation.get("hearingRequirementVulnerabilities"));
+        } else if (asylumCaseDefinition.equals(MULTIMEDIA_TRIBUNAL_RESPONSE)) {
+            assertEquals(hearingRequirementMultimedia, personalisation.get("hearingRequirementMultimedia"));
+
+        } else if (asylumCaseDefinition.equals(SINGLE_SEX_COURT_TRIBUNAL_RESPONSE)) {
+            assertEquals(hearingRequirementSingleSexCourt, personalisation.get("hearingRequirementSingleSexCourt"));
+
+        } else if (asylumCaseDefinition.equals(IN_CAMERA_COURT_TRIBUNAL_RESPONSE)) {
+            assertEquals(hearingRequirementInCameraCourt, personalisation.get("hearingRequirementInCameraCourt"));
+
+        } else if (asylumCaseDefinition.equals(ADDITIONAL_TRIBUNAL_RESPONSE)) {
+            assertEquals(hearingRequirementOther, personalisation.get("hearingRequirementOther"));
+
+        } else if (asylumCaseDefinition.equals(REMOTE_VIDEO_CALL_TRIBUNAL_RESPONSE)) {
+            assertEquals(remoteVideoCallTribunalResponse, personalisation.get("remoteVideoCallTribunalResponse"));
+
+        } else if (asylumCaseDefinition.equals(PAST_EXPERIENCES_TRIBUNAL_RESPONSE)) {
+            assertEquals(pastExperienceTribunalResponse, personalisation.get("pastExperienceTribunalResponse"));
+        }
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_ada_suitability_document_is_missing() throws NotificationClientException, IOException {
+        when(asylumCase.read(TRIBUNAL_DOCUMENTS)).thenReturn(Optional.empty());
+        when(documentDownloadClient.getJsonObjectFromDocument(adaSuitabilityDoc)).thenReturn(jsonObject);
+
+
+        assertThatThrownBy(
+                () -> detentionEngagementTeamAdaSuitabilityReviewPersonalisation.getPersonalisationForLink(asylumCase))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("ADA suitability document not available");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = AdaSuitabilityReviewDecision.class)
+    public void should_return_personalisation_when_all_information_given_maintain(AdaSuitabilityReviewDecision adaSuitabilityReviewDecision) throws NotificationClientException, IOException {
+        final Map<String, Object> expectedPersonalisation =
+                ImmutableMap
+                        .<String, Object>builder()
+                        .putAll(customerServicesProvider.getCustomerServicesPersonalisation())
+                        .put("subjectPrefix", adaPrefix)
+                        .put("appealReferenceNumber", appealReferenceNumber)
+                        .put("ariaListingReferenceIfPresent", listingReference)
+                        .put("homeOfficeReferenceNumber", homeOfficeReferenceNumber)
+                        .put("appellantGivenNames", appellantGivenNames)
+                        .put("appellantFamilyName", appellantFamilyName)
+                        .put("hearingDate", hearingDateTime)
+                        .put("adaSuitability", adaSuitabilityReviewDecision)
+                        .put("hearingRequirementVulnerabilities", hearingRequirementVulnerabilities)
+                        .put("hearingRequirementMultimedia", hearingRequirementMultimedia)
+                        .put("hearingRequirementSingleSexCourt", hearingRequirementSingleSexCourt)
+                        .put("hearingRequirementInCameraCourt", hearingRequirementInCameraCourt)
+                        .put("hearingRequirementOther", hearingRequirementOther)
+                        .put("remoteVideoCallTribunalResponse", remoteVideoCallTribunalResponse)
+                        .put("pastExperienceTribunalResponse", pastExperienceTribunalResponse)
+                        .put("documentDownloadTitle", "some title")
+                        .put("linkToDownloadDocument", "some link")
+                        .put("linkToOnlineService", iaExUiFrontendUrl)
+                        .build();
+
+        Map<String, Object> actualPersonalisation =
+                detentionEngagementTeamAdaSuitabilityReviewPersonalisation.getPersonalisationForLink(asylumCase);
+
+        assertThat(actualPersonalisation).isEqualToComparingOnlyGivenFields(expectedPersonalisation);
+        assertEquals(customerServicesTelephone, customerServicesProvider.getCustomerServicesTelephone());
+        assertEquals(customerServicesEmail, customerServicesProvider.getCustomerServicesEmail());
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6781


### Change description ###
Added new yaml entry for DET internal ADA suitability template.
Added Ada Suitability and appeal form to DocumentTag.
Added bean for DET ADA Suitability notification generator and handler.
Modified existing ADA suitability bean in handler to prevent multiple notifs going out for LR created cases. Now it will only go out for LR created cases, whilst the functionality for internal cases has been implemented within this PR.
Added unit/functional tests.

Testing:
Submitted ADA suitability as judge for:
- Internal ADA case
- LR ADA case
Notifications are sent out as expected

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
