### PR TITLE
RIA-6803 HO's FTPA granted/partially granted notification

### DIFF
--- a/charts/ia-case-notifications-api/Chart.yaml
+++ b/charts/ia-case-notifications-api/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
     email: ImmigrationandAsylum@HMCTS.NET
 dependencies:
   - name: java
-    version: 4.0.12
+    version: 4.0.13
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/

--- a/src/functionalTest/resources/scenarios/RIA-6803-ftpa-respondent-granted-internal-ada-case.json
+++ b/src/functionalTest/resources/scenarios/RIA-6803-ftpa-respondent-granted-internal-ada-case.json
@@ -1,0 +1,79 @@
+{
+  "description": "RIA-6803  Respondent FTPA Application is granted for internal ADA case",
+  "enabled": false,
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 68031,
+      "eventId": "leadershipJudgeFtpaDecision",
+      "state": "ftpaSubmitted",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "currentCaseStateVisibleToJudge": "ftpaSubmitted",
+          "listCaseHearingCentre": "birmingham",
+          "ariaListingReference": "LR/1234/2345",
+          "appealType": "refusalOfEu",
+          "isAdmin": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "ftpaRespondentRjDecisionOutcomeType": "granted",
+          "ftpaApplicantType": "respondent",
+          "ftpaRespondentDecisionDocument": [
+            {
+              "id": "docId",
+              "value": {
+                "document": {
+                  "document_url": "http://dm-store/docId",
+                  "document_binary_url": "http://dm-store/docId/binary",
+                  "document_filename": "filename"
+                },
+                "description": "description"
+              }
+            }
+          ],
+          "ftpaRespondentGroundsDocuments": [
+            {
+              "id": "docId",
+              "value": {
+                "document": {
+                  "document_url": "http://dm-store/docId",
+                  "document_binary_url": "http://dm-store/docId/binary",
+                  "document_filename": "filename"
+                },
+                "description": "description"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "currentCaseStateVisibleToJudge": "ftpaSubmitted",
+        "listCaseHearingCentre": "birmingham",
+        "ariaListingReference": "LR/1234/2345",
+        "appealType": "refusalOfEu",
+        "isAdmin": "Yes",
+        "isAcceleratedDetainedAppeal": "Yes",
+        "ftpaRespondentRjDecisionOutcomeType": "granted",
+        "ftpaApplicantType": "respondent",
+        "notificationsSent": [
+          {
+            "id": "68031_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "68031_RESPONDENT_FTPA_APPLICATION_DECISION_DETENTION_ENGAGEMENT_TEAM",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-6803-ftpa-respondent-partially-granted-internal-ada-case.json
+++ b/src/functionalTest/resources/scenarios/RIA-6803-ftpa-respondent-partially-granted-internal-ada-case.json
@@ -1,0 +1,79 @@
+{
+  "description": "RIA-6803  Respondent FTPA Application is partiallygranted for internal ADA case",
+  "enabled": false,
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 68032,
+      "eventId": "residentJudgeFtpaDecision",
+      "state": "ftpaSubmitted",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "currentCaseStateVisibleToJudge": "ftpaSubmitted",
+          "listCaseHearingCentre": "birmingham",
+          "ariaListingReference": "LR/1234/2345",
+          "appealType": "refusalOfEu",
+          "isAdmin": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "ftpaRespondentRjDecisionOutcomeType": "partiallyGranted",
+          "ftpaApplicantType": "respondent",
+          "ftpaRespondentDecisionDocument": [
+            {
+              "id": "docId",
+              "value": {
+                "document": {
+                  "document_url": "http://dm-store/docId",
+                  "document_binary_url": "http://dm-store/docId/binary",
+                  "document_filename": "filename"
+                },
+                "description": "description"
+              }
+            }
+          ],
+          "ftpaRespondentGroundsDocuments": [
+            {
+              "id": "docId",
+              "value": {
+                "document": {
+                  "document_url": "http://dm-store/docId",
+                  "document_binary_url": "http://dm-store/docId/binary",
+                  "document_filename": "filename"
+                },
+                "description": "description"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "currentCaseStateVisibleToJudge": "ftpaSubmitted",
+        "listCaseHearingCentre": "birmingham",
+        "ariaListingReference": "LR/1234/2345",
+        "appealType": "refusalOfEu",
+        "isAdmin": "Yes",
+        "isAcceleratedDetainedAppeal": "Yes",
+        "ftpaRespondentRjDecisionOutcomeType": "partiallyGranted",
+        "ftpaApplicantType": "respondent",
+        "notificationsSent": [
+          {
+            "id": "68032_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "68032_RESPONDENT_FTPA_APPLICATION_DECISION_DETENTION_ENGAGEMENT_TEAM",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/utils/AsylumCaseUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/utils/AsylumCaseUtils.java
@@ -1,13 +1,14 @@
 package uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils;
 
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPEAL_TYPE;
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.IS_ACCELERATED_DETAINED_APPEAL;
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.IS_ADMIN;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_RESPONDENT_RJ_DECISION_OUTCOME_TYPE;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo.NO;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo.YES;
 
+import java.util.Optional;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
 
 public class AsylumCaseUtils {
@@ -28,5 +29,14 @@ public class AsylumCaseUtils {
 
     public static boolean isInternalCase(AsylumCase asylumCase) {
         return asylumCase.read(IS_ADMIN, YesOrNo.class).map(isAdmin -> YES == isAdmin).orElse(false);
+    }
+
+    public static Optional<FtpaDecisionOutcomeType> getFtpaDecisionOutcomeType(AsylumCase asylumCase) {
+        Optional<FtpaDecisionOutcomeType> ftpaDecisionOutcomeType = asylumCase
+            .read(FTPA_RESPONDENT_DECISION_OUTCOME_TYPE, FtpaDecisionOutcomeType.class);
+        if (ftpaDecisionOutcomeType.isPresent()) {
+            return ftpaDecisionOutcomeType;
+        }
+        return asylumCase.read(FTPA_RESPONDENT_RJ_DECISION_OUTCOME_TYPE, FtpaDecisionOutcomeType.class);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -2120,8 +2120,8 @@ public class NotificationGeneratorConfiguration {
         );
     }
 
-    @Bean("internalAdaRespondentFtpaApplicationRefusedOrNotAdmittedNotificationGenerator")
-    public List<NotificationGenerator> internalAdaRespondentFtpaApplicationRefusedOrNotAdmittedNotificationGenerator(
+    @Bean("internalAdaRespondentFtpaApplicationNotificationGenerator")
+    public List<NotificationGenerator> internalAdaRespondentFtpaApplicationNotificationGenerator(
         HomeOfficeFtpaApplicationDecisionRespondentPersonalisation homeOfficeFtpaApplicationDecisionRespondentPersonalisation,
         DetentionEngagementTeamRespondentFtpaApplicationDecidedPersonalisation detentionEngagementTeamRespondentFtpaApplicationDecidedPersonalisation,
         GovNotifyNotificationSender notificationSender,

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -2115,8 +2115,8 @@ public class NotificationHandlerConfiguration {
     }
 
     @Bean
-    public PreSubmitCallbackHandler<AsylumCase> internalAdaRespondentFtpaApplicationRefusedOrNotAdmittedNotificationHandler(
-        @Qualifier("internalAdaRespondentFtpaApplicationRefusedOrNotAdmittedNotificationGenerator")
+    public PreSubmitCallbackHandler<AsylumCase> internalAdaRespondentFtpaApplicationNotificationHandler(
+        @Qualifier("internalAdaRespondentFtpaApplicationNotificationGenerator")
         List<NotificationGenerator> notificationGenerators) {
 
         return new NotificationHandler(
@@ -2125,11 +2125,20 @@ public class NotificationHandlerConfiguration {
                 AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
                 boolean isRespondentApplication = asylumCase.read(FTPA_APPLICANT_TYPE, ApplicantType.class)
                     .map(applicantType -> RESPONDENT == applicantType).orElse(false);
+                FtpaDecisionOutcomeType decisionOutcomeType = AsylumCaseUtils.getFtpaDecisionOutcomeType(asylumCase)
+                    .orElse(null);
+                Set<FtpaDecisionOutcomeType> validDecisionOutcomeTypes = Set.of(
+                    FTPA_REFUSED,
+                    FTPA_GRANTED,
+                    FTPA_NOT_ADMITTED,
+                    FTPA_PARTIALLY_GRANTED
+                );
 
                 return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                     && (callback.getEvent() == Event.LEADERSHIP_JUDGE_FTPA_DECISION
                     || callback.getEvent() == Event.RESIDENT_JUDGE_FTPA_DECISION)
                     && isRespondentApplication
+                    && validDecisionOutcomeTypes.contains(decisionOutcomeType)
                     && AsylumCaseUtils.isAcceleratedDetainedAppeal(asylumCase)
                     && AsylumCaseUtils.isInternalCase(asylumCase);
             },

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -615,6 +615,10 @@ govnotify:
       otherParty:
         detentionEngagementTeam:
           email: a75a4356-da57-4eaf-b986-e1417b8dce81
+    applicationGrantedOrPartiallyGranted:
+      otherParty:
+        detentionEngagementTeam:
+          email: f655d716-7c04-4c6b-b64c-80d6e7f2b4b7
     applicationReheardEnabled:
       caseOfficer:
         email: 9698e02a-1e45-4a25-8741-85a260c359c4

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/utils/AsylumCaseUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/utils/AsylumCaseUtilsTest.java
@@ -1,11 +1,8 @@
 package uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.powermock.api.mockito.PowerMockito.when;
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPEAL_TYPE;
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.IS_ACCELERATED_DETAINED_APPEAL;
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.IS_ADMIN;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo.NO;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo.YES;
 
@@ -16,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,5 +44,21 @@ public class AsylumCaseUtilsTest {
     void isAdmin_should_return_false() {
         when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(NO));
         assertFalse(AsylumCaseUtils.isInternalCase(asylumCase));
+    }
+
+    @Test
+    void getFtpaDecisionOutcomeType_should_return_granted() {
+        when(asylumCase.read(FTPA_RESPONDENT_DECISION_OUTCOME_TYPE, FtpaDecisionOutcomeType.class))
+            .thenReturn(Optional.of(FtpaDecisionOutcomeType.FTPA_GRANTED));
+        assertEquals(FtpaDecisionOutcomeType.FTPA_GRANTED, AsylumCaseUtils.getFtpaDecisionOutcomeType(asylumCase).orElse(null));
+    }
+
+    @Test
+    void getFtpaDecisionOutcomeType_should_return_refused() {
+        when(asylumCase.read(FTPA_RESPONDENT_RJ_DECISION_OUTCOME_TYPE, FtpaDecisionOutcomeType.class))
+            .thenReturn(Optional.of(FtpaDecisionOutcomeType.FTPA_REFUSED));
+        when(asylumCase.read(FTPA_RESPONDENT_DECISION_OUTCOME_TYPE, FtpaDecisionOutcomeType.class))
+            .thenReturn(Optional.empty());
+        assertEquals(FtpaDecisionOutcomeType.FTPA_REFUSED, AsylumCaseUtils.getFtpaDecisionOutcomeType(asylumCase).orElse(null));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6803


### Change description ###
* Some refactoring
* Update handler to handle only currently implemented decision types when respondent ftpa application is decided for internal cases (granted, partially granted, refused, not admitted)
* Update existing personalisation to support 'granted' and 'partially granted' decision types.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
