### PR TITLE
RIA-6696 HO decide an application not showing Aria Listing Ref

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -88,5 +88,7 @@
         <cve>CVE-2022-45143</cve>
         <cve>CVE-2022-45688</cve>
         <cve>CVE-2023-24998</cve>
+        <cve>CVE-2023-20861</cve>
+        <cve>CVE-2023-28708</cve>
     </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeDecideAnApplicationPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeDecideAnApplicationPersonalisation.java
@@ -96,14 +96,14 @@ public class HomeOfficeDecideAnApplicationPersonalisation implements EmailNotifi
             String decision = makeAnApplication.getDecision();
             String applicantRole = makeAnApplication.getApplicantRole();
 
-            boolean isApplicationListed = makeAnApplicationService.isApplicationListed(State.get(makeAnApplication.getState()));
+            String listingRef = asylumCase.read(ARIA_LISTING_REFERENCE, String.class).orElse(null);
 
             boolean isHomeOfficeUser = Arrays.asList(HOME_OFFICE_APC,
                     HOME_OFFICE_LART,
                     HOME_OFFICE_POU,
                     HOME_OFFICE_RESPONDENT_OFFICER).contains(applicantRole);
 
-            if (isApplicationListed) {
+            if (listingRef != null) {
                 if ("Granted".equals(decision)) {
                     return isHomeOfficeUser ?  homeOfficeDecideAnApplicationGrantedAfterListingTemplateId : homeOfficeDecideAnApplicationGrantedOtherPartyAfterListingTemplateId;
                 } else {

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeDecideAnApplicationPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeDecideAnApplicationPersonalisationTest.java
@@ -135,7 +135,7 @@ public class HomeOfficeDecideAnApplicationPersonalisationTest {
         when(makeAnApplication.getApplicantRole()).thenReturn(HOME_OFFICE_APC);
         when(makeAnApplication.getDecision()).thenReturn("Granted");
         when(makeAnApplication.getState()).thenReturn("appealSubmitted");
-        assertEquals(homeOfficeDecideAnApplicationGrantedBeforeListingTemplateId,
+        assertEquals(homeOfficeDecideAnApplicationGrantedAfterListingTemplateId,
             homeOfficeDecideAnApplicationPersonalisation.getTemplateId(asylumCase));
 
 
@@ -146,7 +146,7 @@ public class HomeOfficeDecideAnApplicationPersonalisationTest {
         when(makeAnApplication.getApplicantRole()).thenReturn(LEGAL_REP_USER);
         when(makeAnApplication.getState()).thenReturn("listing");
         when(makeAnApplicationService.isApplicationListed(any(State.class))).thenReturn(false);
-        assertEquals(homeOfficeDecideAnApplicationGrantedOtherPartyBeforeListingTemplateId,
+        assertEquals(homeOfficeDecideAnApplicationGrantedOtherPartyAfterListingTemplateId,
             homeOfficeDecideAnApplicationPersonalisation.getTemplateId(asylumCase));
 
 
@@ -158,7 +158,7 @@ public class HomeOfficeDecideAnApplicationPersonalisationTest {
         when(makeAnApplication.getApplicantRole()).thenReturn(HOME_OFFICE_APC);
         when(makeAnApplication.getDecision()).thenReturn("Refused");
         when(makeAnApplication.getState()).thenReturn("appealSubmitted");
-        assertEquals(homeOfficeDecideAnApplicationRefusedBeforeListingTemplateId,
+        assertEquals(homeOfficeDecideAnApplicationRefusedAfterListingTemplateId,
             homeOfficeDecideAnApplicationPersonalisation.getTemplateId(asylumCase));
 
 
@@ -169,7 +169,7 @@ public class HomeOfficeDecideAnApplicationPersonalisationTest {
         when(makeAnApplication.getApplicantRole()).thenReturn(LEGAL_REP_USER);
         when(makeAnApplication.getState()).thenReturn("listing");
         when(makeAnApplicationService.isApplicationListed(any(State.class))).thenReturn(false);
-        assertEquals(homeOfficeDecideAnApplicationRefusedOtherPartyBeforeListingTemplateId,
+        assertEquals(homeOfficeDecideAnApplicationRefusedOtherPartyAfterListingTemplateId,
             homeOfficeDecideAnApplicationPersonalisation.getTemplateId(asylumCase));
 
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6966

### Change description ###
Changed the implementation of obtaining aria listing ref in HO personalisation

Testing:
LR Journey
Made an application with LR after listing and decided application with LO. Generated emails:
![image](https://user-images.githubusercontent.com/118450580/228874183-b7ea1622-3066-4548-98d7-1856836da497.png)
Email to law firm:
![image](https://user-images.githubusercontent.com/118450580/228874544-59f73f9e-096e-4e45-9346-5c6bbe5806d4.png)
Email to HO:
![image](https://user-images.githubusercontent.com/118450580/228874722-ee674e29-6ae0-463c-8a96-d41f2fe2599a.png)

Unrepresented journey. Generated emails:
![image](https://user-images.githubusercontent.com/118450580/228875709-384bf83e-2bf7-4477-a541-69d5852c4511.png)
Email to DET:
![image](https://user-images.githubusercontent.com/118450580/228875859-338fe3d1-28cd-4207-9d61-cfef8050e862.png)
Email to HO:
![image](https://user-images.githubusercontent.com/118450580/228875930-22df3aee-24a0-491c-a854-59adf97bf95b.png)



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
