### PR TITLE
RIA-6133 Enable existing notifications for AO and HO (AIP FTPA submitted)

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-6112-ftpa-submitted-aip.json
+++ b/src/functionalTest/resources/scenarios/RIA-6112-ftpa-submitted-aip.json
@@ -39,6 +39,14 @@
           {
             "id": "6112_APPELLANT_IN_PERSON_FTPA_SUBMITTED",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "6112_FTPA_SUBMITTED_ADMIN_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "6112_RESPONDENT_APPELLANT_FTPA_SUBMITTED",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
         ]
       }
@@ -54,6 +62,31 @@
           "LP/12345/2019",
           "Talha Awan",
           "{$iaAipFrontendUrl}",
+          "{$customerServices.telephoneNumber}",
+          "{$customerServices.emailAddress}"
+        ]
+      },
+      {
+        "reference": "6112_FTPA_SUBMITTED_ADMIN_OFFICER",
+        "recipient": "{$ftpaSubmitted.ctscAdminEmailAddress}",
+        "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal",
+        "body": [
+          "PA/12345/2019",
+          "LP/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      },
+      {
+        "reference": "6112_RESPONDENT_APPELLANT_FTPA_SUBMITTED",
+        "recipient": "{$homeOfficeFtpaEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal",
+        "body": [
+          "PA/12345/2019",
+          "LP/12345/2019",
+          "A1234567",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}",
           "{$customerServices.telephoneNumber}",
           "{$customerServices.emailAddress}"
         ]

--- a/src/functionalTest/resources/scenarios/RIA-6112-ftpa-submitted-aip.json
+++ b/src/functionalTest/resources/scenarios/RIA-6112-ftpa-submitted-aip.json
@@ -11,6 +11,7 @@
         "template": "minimal-appeal-submitted.json",
         "replacements": {
           "journeyType": "aip",
+          "listCaseHearingCentre": "taylorHouse",
           "ariaListingReference": "LP/12345/2019",
           "subscriptions": [
             {

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -1540,13 +1540,17 @@ public class NotificationGeneratorConfiguration {
     @Bean("ftpaSubmittedAipNotificationGenerator")
     public List<NotificationGenerator> ftpaSubmittedAip(
         AppellantFtpaSubmittedPersonalisationEmail appellantFtpaSubmittedPersonalisationEmail,
+        AdminOfficerFtpaSubmittedPersonalisation adminOfficerFtpaSubmittedPersonalisation,
+        RespondentAppellantFtpaSubmittedPersonalisation respondentAppellantFtpaSubmittedPersonalisation,
         GovNotifyNotificationSender notificationSender,
         NotificationIdAppender notificationIdAppender
     ) {
 
-        return Collections.singletonList(
+        return List.of(
             new EmailNotificationGenerator(
-                newArrayList(appellantFtpaSubmittedPersonalisationEmail),
+                List.of(appellantFtpaSubmittedPersonalisationEmail,
+                    adminOfficerFtpaSubmittedPersonalisation,
+                    respondentAppellantFtpaSubmittedPersonalisation),
                 notificationSender,
                 notificationIdAppender
             )


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6133](https://tools.hmcts.net/jira/browse/RIA-6133)


### Change description ###
- Enabled existing AO and HO notifications to be triggered when a citizen triggers `APPLY_FOR_FTPA_APPELLANT` (in addition to the new appellant notification)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
