### PR TITLE
RIA-7001 Unrep FTPA decision callback error - Appellant notif being sent causing event to fail

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -90,5 +90,6 @@
         <cve>CVE-2023-24998</cve>
         <cve>CVE-2023-20861</cve>
         <cve>CVE-2023-28708</cve>
+        <cve>CVE-2023-20860</cve>
     </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -1922,6 +1922,7 @@ public class NotificationHandlerConfiguration {
                 return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                        && (callback.getEvent() == Event.LEADERSHIP_JUDGE_FTPA_DECISION
                            || callback.getEvent() == Event.RESIDENT_JUDGE_FTPA_DECISION)
+                       && !AsylumCaseUtils.isInternalCase(asylumCase)
                        && isAllowedOrDismissedOrRefusedOrNotAdmittedDecisionOutcome
                        && !hasThisNotificationSentBefore(asylumCase, callback,
                     "_FTPA_APPLICATION_DECISION_LEGAL_REPRESENTATIVE_APPELLANT");
@@ -1958,6 +1959,7 @@ public class NotificationHandlerConfiguration {
                 return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                        && (callback.getEvent() == Event.LEADERSHIP_JUDGE_FTPA_DECISION
                            || callback.getEvent() == Event.RESIDENT_JUDGE_FTPA_DECISION)
+                       && !AsylumCaseUtils.isInternalCase(asylumCase)
                        && isGrantedOrPartiallyGrantedOutcome
                        && !hasThisNotificationSentBefore(asylumCase, callback,
                     "_FTPA_APPLICATION_DECISION_LEGAL_REPRESENTATIVE_APPELLANT");
@@ -2017,6 +2019,7 @@ public class NotificationHandlerConfiguration {
 
                 return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                        && callback.getEvent() == Event.RESIDENT_JUDGE_FTPA_DECISION
+                       && !AsylumCaseUtils.isInternalCase(asylumCase)
                        && isReheardDecisionOutcome
                        && !hasThisNotificationSentBefore(asylumCase, callback,
                     "_FTPA_APPLICATION_DECISION_LEGAL_REPRESENTATIVE_APPELLANT");


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7001


### Change description ###
RIA-7001 Added isInternalCase check on appellant notifications for FTPA decision by judge. Affected beans are:
ftpaApplicationDecisionRefusedOrNotAdmittedAppellantNotificationHandler

ftpaApplicationDecisionGrantedOrPartiallyGrantedAppellantNotificationHandler

ftpaApplicationDecisionReheardAppellantNotificationHandler

Testing:
Created 4 unrep cases
Case 1 permission granted
![image](https://user-images.githubusercontent.com/118450580/229806241-43247d90-c78e-4500-8ebf-48cc9740fafb.png)
case 2 permission partially granted
![image](https://user-images.githubusercontent.com/118450580/229806759-58b5ae7c-fa87-4a42-b621-01b2ff1a12e6.png)
case 3 permission refused
![image](https://user-images.githubusercontent.com/118450580/229807234-4067cee2-8e0a-446d-a3f1-fe129508fe68.png)
case 4 application not permitted
![image](https://user-images.githubusercontent.com/118450580/229807567-a645d619-9b9f-494f-ab22-408cad933893.png)





**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
