### PR TITLE
RIA-6957 Updated DetentionEngagementTeamDecideAnApplicationPersonalis…

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamDecideAnApplicationPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamDecideAnApplicationPersonalisation.java
@@ -96,10 +96,16 @@ public class DetentionEngagementTeamDecideAnApplicationPersonalisation implement
         }
 
         boolean applicationGranted = DECISION_GRANTED.equals(decision);
-        boolean adjournExpediteOrTransfer = Arrays.asList(
+        boolean adjournExpediteTransferOrUpdateHearingReqs = Arrays.asList(
             ADJOURN.toString(),
             EXPEDITE.toString(),
-            TRANSFER.toString()
+            TRANSFER.toString(),
+            UPDATE_HEARING_REQUIREMENTS.toString()
+        ).contains(applicationType);
+
+        boolean updateHearingDetailsOrOther = Arrays.asList(
+                UPDATE_APPEAL_DETAILS.toString(),
+                OTHER.toString()
         ).contains(applicationType);
 
 
@@ -121,12 +127,14 @@ public class DetentionEngagementTeamDecideAnApplicationPersonalisation implement
             .put("applicationDecisionReason", applicationDecisionReason)
             .put("granted", applicationGranted ? "yes" : "no")
             .put("grantedAndTimeExtension", applicationGranted && (Objects.equals(TIME_EXTENSION.toString(), applicationType)) ? "yes" : "no")
-            .put("grantedAdjournExpediteOrTransfer", applicationGranted && adjournExpediteOrTransfer ? "yes" : "no")
+            .put("grantedAdjournExpediteTransferOrUpdateHearingReqs", applicationGranted && adjournExpediteTransferOrUpdateHearingReqs ? "yes" : "no")
             .put("grantedJudgesReview", applicationGranted && (Objects.equals(JUDGE_REVIEW_LO.toString(), applicationType)) ? "yes" : "no")
             .put("grantedLinkOrUnlik", applicationGranted && (Objects.equals(LINK_OR_UNLINK.toString(), applicationType)) ? "yes" : "no")
             .put("grantedReinstate", applicationGranted && (Objects.equals(REINSTATE.toString(), applicationType)) ? "yes" : "no")
             .put("grantedWithdraw", applicationGranted && (Objects.equals(WITHDRAW.toString(), applicationType)) ? "yes" : "no")
-            .put("grantedOther", applicationGranted && (Objects.equals(OTHER.toString(), applicationType)) ? "yes" : "no");
+            .put("grantedUpdateAppealDetailsOrOther", applicationGranted && updateHearingDetailsOrOther ? "yes" : "no")
+            .put("grantedTransferOutOfAda", applicationGranted && (Objects.equals(TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.toString(), applicationType)) ? "yes" : "no");
+
 
         if (isApplicant(optionalMakeAnApplication)) {
             // If the decision maker is a TCW then change "Tribunal Caseworker" into "Legal Officer"

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamDecideAnApplicationPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamDecideAnApplicationPersonalisationTest.java
@@ -165,64 +165,76 @@ class DetentionEngagementTeamDecideAnApplicationPersonalisationTest {
         switch (makeAnApplicationType) {
             case TIME_EXTENSION:
                 assertEquals("yes", personalisation.get("grantedAndTimeExtension"));
-                assertEquals("no", personalisation.get("grantedAdjournExpediteOrTransfer"));
+                assertEquals("no", personalisation.get("grantedAdjournExpediteTransferOrUpdateHearingReqs"));
                 assertEquals("no", personalisation.get("grantedJudgesReview"));
                 assertEquals("no", personalisation.get("grantedLinkOrUnlik"));
                 assertEquals("no", personalisation.get("grantedReinstate"));
                 assertEquals("no", personalisation.get("grantedWithdraw"));
-                assertEquals("no", personalisation.get("grantedOther"));
+                assertEquals("no", personalisation.get("grantedUpdateAppealDetailsOrOther"));
                 break;
             case ADJOURN:
             case EXPEDITE:
+            case UPDATE_HEARING_REQUIREMENTS:
             case TRANSFER:
-                assertEquals("yes", personalisation.get("grantedAdjournExpediteOrTransfer"));
+                assertEquals("yes", personalisation.get("grantedAdjournExpediteTransferOrUpdateHearingReqs"));
                 assertEquals("no", personalisation.get("grantedAndTimeExtension"));
                 assertEquals("no", personalisation.get("grantedJudgesReview"));
                 assertEquals("no", personalisation.get("grantedLinkOrUnlik"));
                 assertEquals("no", personalisation.get("grantedReinstate"));
                 assertEquals("no", personalisation.get("grantedWithdraw"));
-                assertEquals("no", personalisation.get("grantedOther"));
+                assertEquals("no", personalisation.get("grantedUpdateAppealDetailsOrOther"));
                 break;
             case JUDGE_REVIEW_LO:
                 assertEquals("yes", personalisation.get("grantedJudgesReview"));
                 assertEquals("no", personalisation.get("grantedAndTimeExtension"));
-                assertEquals("no", personalisation.get("grantedAdjournExpediteOrTransfer"));
+                assertEquals("no", personalisation.get("grantedAdjournExpediteTransferOrUpdateHearingReqs"));
                 assertEquals("no", personalisation.get("grantedLinkOrUnlik"));
                 assertEquals("no", personalisation.get("grantedReinstate"));
                 assertEquals("no", personalisation.get("grantedWithdraw"));
-                assertEquals("no", personalisation.get("grantedOther"));
+                assertEquals("no", personalisation.get("grantedUpdateAppealDetailsOrOther"));
                 break;
             case LINK_OR_UNLINK:
                 assertEquals("yes", personalisation.get("grantedLinkOrUnlik"));
                 assertEquals("no", personalisation.get("grantedAndTimeExtension"));
-                assertEquals("no", personalisation.get("grantedAdjournExpediteOrTransfer"));
+                assertEquals("no", personalisation.get("grantedAdjournExpediteTransferOrUpdateHearingReqs"));
                 assertEquals("no", personalisation.get("grantedJudgesReview"));
                 assertEquals("no", personalisation.get("grantedReinstate"));
                 assertEquals("no", personalisation.get("grantedWithdraw"));
-                assertEquals("no", personalisation.get("grantedOther"));
+                assertEquals("no", personalisation.get("grantedUpdateAppealDetailsOrOther"));
                 break;
             case REINSTATE:
                 assertEquals("yes", personalisation.get("grantedReinstate"));
                 assertEquals("no", personalisation.get("grantedAndTimeExtension"));
-                assertEquals("no", personalisation.get("grantedAdjournExpediteOrTransfer"));
+                assertEquals("no", personalisation.get("grantedAdjournExpediteTransferOrUpdateHearingReqs"));
                 assertEquals("no", personalisation.get("grantedJudgesReview"));
                 assertEquals("no", personalisation.get("grantedLinkOrUnlik"));
                 assertEquals("no", personalisation.get("grantedWithdraw"));
-                assertEquals("no", personalisation.get("grantedOther"));
+                assertEquals("no", personalisation.get("grantedUpdateAppealDetailsOrOther"));
                 break;
             case WITHDRAW:
                 assertEquals("yes", personalisation.get("grantedWithdraw"));
                 assertEquals("no", personalisation.get("grantedAndTimeExtension"));
-                assertEquals("no", personalisation.get("grantedAdjournExpediteOrTransfer"));
+                assertEquals("no", personalisation.get("grantedAdjournExpediteTransferOrUpdateHearingReqs"));
                 assertEquals("no", personalisation.get("grantedJudgesReview"));
                 assertEquals("no", personalisation.get("grantedLinkOrUnlik"));
                 assertEquals("no", personalisation.get("grantedReinstate"));
-                assertEquals("no", personalisation.get("grantedOther"));
+                assertEquals("no", personalisation.get("grantedUpdateAppealDetailsOrOther"));
                 break;
+            case UPDATE_APPEAL_DETAILS:
             case OTHER:
-                assertEquals("yes", personalisation.get("grantedOther"));
+                assertEquals("yes", personalisation.get("grantedUpdateAppealDetailsOrOther"));
                 assertEquals("no", personalisation.get("grantedAndTimeExtension"));
-                assertEquals("no", personalisation.get("grantedAdjournExpediteOrTransfer"));
+                assertEquals("no", personalisation.get("grantedAdjournExpediteTransferOrUpdateHearingReqs"));
+                assertEquals("no", personalisation.get("grantedJudgesReview"));
+                assertEquals("no", personalisation.get("grantedLinkOrUnlik"));
+                assertEquals("no", personalisation.get("grantedReinstate"));
+                assertEquals("no", personalisation.get("grantedWithdraw"));
+                break;
+            case TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS:
+                assertEquals("yes", personalisation.get("grantedTransferOutOfAda"));
+                assertEquals("no", personalisation.get("grantedUpdateAppealDetailsOrOther"));
+                assertEquals("no", personalisation.get("grantedAndTimeExtension"));
+                assertEquals("no", personalisation.get("grantedAdjournExpediteTransferOrUpdateHearingReqs"));
                 assertEquals("no", personalisation.get("grantedJudgesReview"));
                 assertEquals("no", personalisation.get("grantedLinkOrUnlik"));
                 assertEquals("no", personalisation.get("grantedReinstate"));
@@ -288,64 +300,64 @@ class DetentionEngagementTeamDecideAnApplicationPersonalisationTest {
         switch (makeAnApplicationType) {
             case TIME_EXTENSION:
                 assertEquals("yes", personalisation.get("grantedAndTimeExtension"));
-                assertEquals("no", personalisation.get("grantedAdjournExpediteOrTransfer"));
+                assertEquals("no", personalisation.get("grantedAdjournExpediteTransferOrUpdateHearingReqs"));
                 assertEquals("no", personalisation.get("grantedJudgesReview"));
                 assertEquals("no", personalisation.get("grantedLinkOrUnlik"));
                 assertEquals("no", personalisation.get("grantedReinstate"));
                 assertEquals("no", personalisation.get("grantedWithdraw"));
-                assertEquals("no", personalisation.get("grantedOther"));
+                assertEquals("no", personalisation.get("grantedUpdateAppealDetailsOrOther"));
                 break;
             case ADJOURN:
             case EXPEDITE:
             case TRANSFER:
-                assertEquals("yes", personalisation.get("grantedAdjournExpediteOrTransfer"));
+                assertEquals("yes", personalisation.get("grantedAdjournExpediteTransferOrUpdateHearingReqs"));
                 assertEquals("no", personalisation.get("grantedAndTimeExtension"));
                 assertEquals("no", personalisation.get("grantedJudgesReview"));
                 assertEquals("no", personalisation.get("grantedLinkOrUnlik"));
                 assertEquals("no", personalisation.get("grantedReinstate"));
                 assertEquals("no", personalisation.get("grantedWithdraw"));
-                assertEquals("no", personalisation.get("grantedOther"));
+                assertEquals("no", personalisation.get("grantedUpdateAppealDetailsOrOther"));
                 break;
             case JUDGE_REVIEW_LO:
                 assertEquals("yes", personalisation.get("grantedJudgesReview"));
                 assertEquals("no", personalisation.get("grantedAndTimeExtension"));
-                assertEquals("no", personalisation.get("grantedAdjournExpediteOrTransfer"));
+                assertEquals("no", personalisation.get("grantedAdjournExpediteTransferOrUpdateHearingReqs"));
                 assertEquals("no", personalisation.get("grantedLinkOrUnlik"));
                 assertEquals("no", personalisation.get("grantedReinstate"));
                 assertEquals("no", personalisation.get("grantedWithdraw"));
-                assertEquals("no", personalisation.get("grantedOther"));
+                assertEquals("no", personalisation.get("grantedUpdateAppealDetailsOrOther"));
                 break;
             case LINK_OR_UNLINK:
                 assertEquals("yes", personalisation.get("grantedLinkOrUnlik"));
                 assertEquals("no", personalisation.get("grantedAndTimeExtension"));
-                assertEquals("no", personalisation.get("grantedAdjournExpediteOrTransfer"));
+                assertEquals("no", personalisation.get("grantedAdjournExpediteTransferOrUpdateHearingReqs"));
                 assertEquals("no", personalisation.get("grantedJudgesReview"));
                 assertEquals("no", personalisation.get("grantedReinstate"));
                 assertEquals("no", personalisation.get("grantedWithdraw"));
-                assertEquals("no", personalisation.get("grantedOther"));
+                assertEquals("no", personalisation.get("grantedUpdateAppealDetailsOrOther"));
                 break;
             case REINSTATE:
                 assertEquals("yes", personalisation.get("grantedReinstate"));
                 assertEquals("no", personalisation.get("grantedAndTimeExtension"));
-                assertEquals("no", personalisation.get("grantedAdjournExpediteOrTransfer"));
+                assertEquals("no", personalisation.get("grantedAdjournExpediteTransferOrUpdateHearingReqs"));
                 assertEquals("no", personalisation.get("grantedJudgesReview"));
                 assertEquals("no", personalisation.get("grantedLinkOrUnlik"));
                 assertEquals("no", personalisation.get("grantedWithdraw"));
-                assertEquals("no", personalisation.get("grantedOther"));
+                assertEquals("no", personalisation.get("grantedUpdateAppealDetailsOrOther"));
                 break;
             case WITHDRAW:
                 assertEquals("yes", personalisation.get("grantedWithdraw"));
                 assertEquals("no", personalisation.get("grantedAndTimeExtension"));
-                assertEquals("no", personalisation.get("grantedAdjournExpediteOrTransfer"));
+                assertEquals("no", personalisation.get("grantedAdjournExpediteTransferOrUpdateHearingReqs"));
                 assertEquals("no", personalisation.get("grantedJudgesReview"));
                 assertEquals("no", personalisation.get("grantedLinkOrUnlik"));
                 assertEquals("no", personalisation.get("grantedReinstate"));
-                assertEquals("no", personalisation.get("grantedOther"));
+                assertEquals("no", personalisation.get("grantedUpdateAppealDetailsOrOther"));
                 break;
             case OTHER:
-                assertEquals("yes", personalisation.get("grantedOther"));
+                assertEquals("yes", personalisation.get("grantedUpdateAppealDetailsOrOther"));
                 assertEquals("no", personalisation.get("grantedAndTimeExtension"));
-                assertEquals("no", personalisation.get("grantedAdjournExpediteOrTransfer"));
+                assertEquals("no", personalisation.get("grantedAdjournExpediteTransferOrUpdateHearingReqs"));
                 assertEquals("no", personalisation.get("grantedJudgesReview"));
                 assertEquals("no", personalisation.get("grantedLinkOrUnlik"));
                 assertEquals("no", personalisation.get("grantedReinstate"));


### PR DESCRIPTION
…ation and its unit test to add logic for the following applications notifications:

 Update appeal details/Update hearing requirement/ Transfer out of accelerated detained appeal

Updated templates:
51135c0f-4dc1-4a6b-bcc5-a27db656cb41
47289033-479f-45e2-aa17-2c785378733a

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6957

Testing: (Note the reasons in screenshots are dynamic values which I set to random letters)
Update hearing requirements
![image](https://user-images.githubusercontent.com/118450580/230416234-3a3e94cc-ceff-4caf-a26e-3e854544ce94.png)

Update appeal details
![image](https://user-images.githubusercontent.com/118450580/230418384-e4c2ec35-3501-4a4b-b9c3-5ecc965551cd.png)

Xfer out of ADA
![image](https://user-images.githubusercontent.com/118450580/230418698-0c008583-cfb2-4b17-8c47-aafd6f0a24ba.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
