### PR TITLE
RIA-6940 removeDetainedStatus AIP notifications

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-6940-remove-detention-status-appellant-notification-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-6940-remove-detention-status-appellant-notification-after-listing.json
@@ -1,0 +1,56 @@
+{
+  "description": "RIA-6940: Remove detention status appellant notification unrep journey (Email and SMS) -- After Listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 6940,
+      "eventId": "removeDetainedStatus",
+      "state": "respondentReview",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "currentCaseStateVisibleToHomeOfficeAll":"appealSubmitted",
+          "ariaListingReference": "LR/12345/2023",
+          "email": "example@email.com",
+          "mobileNumber": "07519283526",
+          "contactPreferenceUnRep": [
+            "wantsEmail",
+            "wantsSms"
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "currentCaseStateVisibleToHomeOfficeAll":"appealSubmitted",
+        "ariaListingReference": "LR/12345/2023",
+        "email": "example@email.com",
+        "mobileNumber": "07519283526",
+        "contactPreferenceUnRep": [
+          "wantsEmail",
+          "wantsSms"
+        ],
+        "notificationsSent":[
+          {
+            "id":"6940_REMOVE_DETENTION_STATUS_APPELLANT_EMAIL",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id":"6940_REMOVE_DETENTION_STATUS_HOME_OFFICE",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id":"6940_REMOVE_DETENTION_STATUS_APPELLANT_SMS",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-6940-remove-detention-status-appellant-notification-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-6940-remove-detention-status-appellant-notification-before-listing.json
@@ -1,0 +1,54 @@
+{
+  "description": "RIA-6940: Remove detention status appellant notification unrep journey (Email and SMS) -- Before Listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 6940,
+      "eventId": "removeDetainedStatus",
+      "state": "respondentReview",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "currentCaseStateVisibleToHomeOfficeAll":"appealSubmitted",
+          "email": "example@email.com",
+          "mobileNumber": "07519283526",
+          "contactPreferenceUnRep": [
+            "wantsEmail",
+            "wantsSms"
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "currentCaseStateVisibleToHomeOfficeAll":"appealSubmitted",
+        "email": "example@email.com",
+        "mobileNumber": "07519283526",
+        "contactPreferenceUnRep": [
+          "wantsEmail",
+          "wantsSms"
+        ],
+        "notificationsSent":[
+          {
+            "id":"6940_REMOVE_DETENTION_STATUS_APPELLANT_EMAIL",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id":"6940_REMOVE_DETENTION_STATUS_HOME_OFFICE",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id":"6940_REMOVE_DETENTION_STATUS_APPELLANT_SMS",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-6940-remove-detention-status-appellant-notification-email-only-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-6940-remove-detention-status-appellant-notification-email-only-after-listing.json
@@ -1,0 +1,56 @@
+{
+  "description": "RIA-6940: Remove detention status appellant notification unrep journey (Email and SMS) -- Before Listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 6940,
+      "eventId": "removeDetainedStatus",
+      "state": "respondentReview",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "currentCaseStateVisibleToHomeOfficeAll":"appealSubmitted",
+          "ariaListingReference": "LR/12345/2023",
+          "email": "example@email.com",
+          "mobileNumber": "07519283526",
+          "contactPreferenceUnRep": [
+            "wantsSms",
+            "wantsEmail"
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "currentCaseStateVisibleToHomeOfficeAll":"appealSubmitted",
+        "ariaListingReference": "LR/12345/2023",
+        "email": "example@email.com",
+        "mobileNumber": "07519283526",
+        "contactPreferenceUnRep": [
+          "wantsSms",
+          "wantsEmail"
+        ],
+        "notificationsSent":[
+          {
+            "id":"6940_REMOVE_DETENTION_STATUS_APPELLANT_EMAIL",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id":"6940_REMOVE_DETENTION_STATUS_HOME_OFFICE",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id":"6940_REMOVE_DETENTION_STATUS_APPELLANT_SMS",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-6940-remove-detention-status-appellant-notification-email-only-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-6940-remove-detention-status-appellant-notification-email-only-before-listing.json
@@ -1,0 +1,49 @@
+{
+  "description": "RIA-6940: Remove detention status appellant notification unrep journey (Email) -- Before Listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 6940,
+      "eventId": "removeDetainedStatus",
+      "state": "respondentReview",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "currentCaseStateVisibleToHomeOfficeAll":"appealSubmitted",
+          "email": "example@email.com",
+          "mobileNumber": "07519283526",
+          "ariaListingReference": "LR/12345/2023",
+          "contactPreferenceUnRep": [
+            "wantsEmail"
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "currentCaseStateVisibleToHomeOfficeAll":"appealSubmitted",
+        "email": "example@email.com",
+        "mobileNumber": "07519283526",
+        "contactPreferenceUnRep": [
+          "wantsEmail"
+        ],
+        "notificationsSent":[
+          {
+            "id":"6940_REMOVE_DETENTION_STATUS_APPELLANT_EMAIL",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id":"6940_REMOVE_DETENTION_STATUS_HOME_OFFICE",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-6940-remove-detention-status-appellant-notification-sms-only.json
+++ b/src/functionalTest/resources/scenarios/RIA-6940-remove-detention-status-appellant-notification-sms-only.json
@@ -1,0 +1,48 @@
+{
+  "description": "RIA-6940: Remove detention status appellant notification unrep journey (SMS)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 6940,
+      "eventId": "removeDetainedStatus",
+      "state": "respondentReview",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "currentCaseStateVisibleToHomeOfficeAll":"appealSubmitted",
+          "email": "example@email.com",
+          "mobileNumber": "07519283526",
+          "contactPreferenceUnRep": [
+            "wantsSms"
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "currentCaseStateVisibleToHomeOfficeAll":"appealSubmitted",
+        "email": "example@email.com",
+        "mobileNumber": "07519283526",
+        "contactPreferenceUnRep": [
+          "wantsSms"
+        ],
+        "notificationsSent":[
+          {
+            "id":"6940_REMOVE_DETENTION_STATUS_HOME_OFFICE",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id":"6940_REMOVE_DETENTION_STATUS_APPELLANT_SMS",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-6940-remove-detention-status-no-appellant-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-6940-remove-detention-status-no-appellant-notification.json
@@ -1,0 +1,40 @@
+{
+  "description": "RIA-6940: Remove detention status without Sms/Email contact preference set",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 6940,
+      "eventId": "removeDetainedStatus",
+      "state": "respondentReview",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "currentCaseStateVisibleToHomeOfficeAll":"appealSubmitted",
+          "email": "example@email.com",
+          "mobileNumber": "07519283526",
+          "contactPreferenceUnRep": []
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "currentCaseStateVisibleToHomeOfficeAll":"appealSubmitted",
+        "email": "example@email.com",
+        "mobileNumber": "07519283526",
+        "contactPreferenceUnRep": [],
+        "notificationsSent":[
+          {
+            "id":"6940_REMOVE_DETENTION_STATUS_HOME_OFFICE",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AsylumCaseDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AsylumCaseDefinition.java
@@ -351,6 +351,9 @@ public enum AsylumCaseDefinition {
     CONTACT_PREFERENCE(
         "contactPreference", new TypeReference<ContactPreference>(){}),
 
+    CONTACT_PREFERENCE_UN_REP(
+            "contactPreferenceUnRep", new TypeReference<List<String>>(){}),
+
     FEE_UPDATE_RECORDED(
         "feeUpdateRecorded", new TypeReference<CheckValues<String>>(){}),
 

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ContactPreferenceUnRep.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ContactPreferenceUnRep.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities;
+
+import static java.util.Arrays.stream;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Optional;
+
+public enum ContactPreferenceUnRep {
+
+    WANTS_EMAIL("wantsEmail", "Email"),
+    WANTS_SMS("wantsSms", "Text message"),
+    WANTS_POST("wantsPost", "Postal");
+    @JsonValue
+    private String value;
+
+    private String description;
+
+    ContactPreferenceUnRep(String value, String description) {
+        this.value = value;
+        this.description = description;
+    }
+
+    public static Optional<ContactPreferenceUnRep> from(
+            String value
+    ) {
+        return stream(values())
+                .filter(v -> v.getValue().equals(value))
+                .findFirst();
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public String toString() {
+        return value + ": " + description;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantRemoveDetainedStatusPersonalisationEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantRemoveDetainedStatusPersonalisationEmail.java
@@ -1,0 +1,77 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appellant.email;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.*;
+import javax.validation.constraints.NotNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.RequiredFieldMissingException;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ContactPreferenceUnRep;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
+
+@Service
+public class AppellantRemoveDetainedStatusPersonalisationEmail implements EmailNotificationPersonalisation {
+
+    private final String appellantRemoveDetainedStatusPersonalisationBeforeListingEmailTemplateId;
+    private final String appellantRemoveDetainedStatusPersonalisationAfterListingEmailTemplateId;
+
+    public AppellantRemoveDetainedStatusPersonalisationEmail(
+            @NotNull(message = "appellantRemoveDetainedStatusPersonalisationBeforeListingEmailTemplateId cannot be null")
+            @Value("${govnotify.template.removeDetentionStatus.appellant.email.beforeListing}") String appellantRemoveDetainedStatusPersonalisationBeforeListingEmailTemplateId,
+            @NotNull(message = "appellantRemoveDetainedStatusPersonalisationAfterListingEmailTemplateId cannot be null")
+            @Value("${govnotify.template.removeDetentionStatus.appellant.email.afterListing}") String appellantRemoveDetainedStatusPersonalisationAfterListingEmailTemplateId
+    ) {
+        this.appellantRemoveDetainedStatusPersonalisationBeforeListingEmailTemplateId = appellantRemoveDetainedStatusPersonalisationBeforeListingEmailTemplateId;
+        this.appellantRemoveDetainedStatusPersonalisationAfterListingEmailTemplateId = appellantRemoveDetainedStatusPersonalisationAfterListingEmailTemplateId;
+    }
+
+    @Override
+    public String getTemplateId(AsylumCase asylumCase) {
+        String ariaListingReference = asylumCase.read(ARIA_LISTING_REFERENCE, String.class).orElse("");
+        return ariaListingReference.isBlank()
+                ? appellantRemoveDetainedStatusPersonalisationBeforeListingEmailTemplateId :
+                appellantRemoveDetainedStatusPersonalisationAfterListingEmailTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        Set<String> recipients = new HashSet<>();
+
+        Optional<List<String>> contactPreference = asylumCase.read(CONTACT_PREFERENCE_UN_REP);
+        if (!contactPreference.isPresent()) {
+            throw new RequiredFieldMissingException("No contact preference found. At least one contact method should have been provided.");
+        }
+
+        boolean emailRequired = contactPreference.get().contains(ContactPreferenceUnRep.WANTS_EMAIL.getValue());
+        if (!emailRequired) {
+            return recipients;
+        }
+
+        String emailAddress = asylumCase.read(EMAIL, String.class)
+                .orElseThrow(() -> new RequiredFieldMissingException("Email address not found"));
+
+        recipients.add(emailAddress);
+        return recipients;
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_REMOVE_DETENTION_STATUS_APPELLANT_EMAIL";
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+        String ariaListingReference = asylumCase.read(ARIA_LISTING_REFERENCE, String.class).orElse("");
+        return ImmutableMap
+                .<String, String>builder()
+                .put("ariaListingReference", ariaListingReference)
+                .put("appealReferenceNumber", asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+                .put("homeOfficeReferenceNumber", asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""))
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/sms/AppellantRemoveDetainedStatusPersonalisationSms.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/sms/AppellantRemoveDetainedStatusPersonalisationSms.java
@@ -1,0 +1,71 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appellant.sms;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.*;
+import javax.validation.constraints.NotNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.RequiredFieldMissingException;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ContactPreferenceUnRep;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.SmsNotificationPersonalisation;
+
+@Service
+public class AppellantRemoveDetainedStatusPersonalisationSms implements SmsNotificationPersonalisation {
+
+    private final String removeDetainedStatusSmsTemplateId;
+
+    public AppellantRemoveDetainedStatusPersonalisationSms(
+            @NotNull(message = "removeDetentionStatusSmsTemplateId cannot be null")
+            @Value("${govnotify.template.removeDetentionStatus.appellant.sms}") String removeDetentionStatusSmsTemplateId
+    ) {
+        this.removeDetainedStatusSmsTemplateId = removeDetentionStatusSmsTemplateId;
+    }
+
+
+    @Override
+    public String getTemplateId() {
+        return removeDetainedStatusSmsTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        Set<String> recipients = new HashSet<>();
+
+        Optional<List<String>> contactPreference = asylumCase.read(CONTACT_PREFERENCE_UN_REP);
+        if (!contactPreference.isPresent()) {
+            throw new RequiredFieldMissingException("No contact preference found. At least one contact method should have been provided.");
+        }
+
+        boolean emailRequired = contactPreference.get().contains(ContactPreferenceUnRep.WANTS_SMS.getValue());
+        if (!emailRequired) {
+            return recipients;
+        }
+
+        String emailAddress = asylumCase.read(MOBILE_NUMBER, String.class)
+                .orElseThrow(() -> new RequiredFieldMissingException("Mobile number not found"));
+
+        recipients.add(emailAddress);
+        return recipients;
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_REMOVE_DETENTION_STATUS_APPELLANT_SMS";
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        return
+                ImmutableMap
+                        .<String, String>builder()
+                        .put("appealReferenceNumber", asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+                        .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -3391,16 +3391,24 @@ public class NotificationGeneratorConfiguration {
 
     @Bean("removeDetentionStatusInternalNotificationGenerator")
     public List<NotificationGenerator> removeDetentionStatusInternalNotificationGenerator(
+            AppellantRemoveDetainedStatusPersonalisationEmail appellantRemoveDetainedStatusPersonalisationEmail,
+            AppellantRemoveDetainedStatusPersonalisationSms appellantRemoveDetainedStatusPersonalisationSms,
             HomeOfficeRemoveDetentionStatusPersonalisation homeOfficeRemoveDetentionStatusPersonalisation,
             GovNotifyNotificationSender notificationSender,
             NotificationIdAppender notificationIdAppender
     ) {
 
-        return Collections.singletonList(
+        return Arrays.asList(
                 new EmailNotificationGenerator(
                         newArrayList(
+                                appellantRemoveDetainedStatusPersonalisationEmail,
                                 homeOfficeRemoveDetentionStatusPersonalisation
                         ),
+                        notificationSender,
+                        notificationIdAppender
+                ),
+                new SmsNotificationGenerator(
+                        newArrayList(appellantRemoveDetainedStatusPersonalisationSms),
                         notificationSender,
                         notificationIdAppender
                 )

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -898,6 +898,11 @@ govnotify:
         email: 23669485-ffb0-4ae2-9d36-26c437a57e92
       homeOffice:
         email: 3891dcd8-a9d1-47e8-8b87-3da77789a913
+      appellant:
+        email:
+          beforeListing: 5bc75d7e-37ac-4382-a43a-0d27038c81de
+          afterListing: c2487cec-7ca4-450f-a5ae-b6d93ce99b6e
+        sms: e2dcdeee-c61e-4f56-836a-53116011bb20
   bail:
     key: ${IA_BAIL_GOV_NOTIFY_KEY}
     timeout: 5000

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ContactPreferenceUnRepTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ContactPreferenceUnRepTest.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ContactPreferenceUnRepTest {
+
+    @Test
+    void has_correct_asylum_contact_preference() {
+        assertThat(ContactPreferenceUnRep.from("wantsEmail").get()).isEqualByComparingTo(ContactPreferenceUnRep.WANTS_EMAIL);
+        assertThat(ContactPreferenceUnRep.from("wantsSms").get()).isEqualByComparingTo(ContactPreferenceUnRep.WANTS_SMS);
+        assertThat(ContactPreferenceUnRep.from("wantsPost").get()).isEqualByComparingTo(ContactPreferenceUnRep.WANTS_POST);
+    }
+
+    @Test
+    void has_correct_asylum_contact_preference_description() {
+        assertEquals("Email", ContactPreferenceUnRep.WANTS_EMAIL.getDescription());
+        assertEquals("Text message", ContactPreferenceUnRep.WANTS_SMS.getDescription());
+        assertEquals("Postal", ContactPreferenceUnRep.WANTS_POST.getDescription());
+    }
+
+    @Test
+    void returns_optional_for_unknown_contact_preference() {
+        assertThat(ContactPreferenceUnRep.from("some_unknown_type")).isEmpty();
+    }
+
+    @Test
+    void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
+        assertEquals(3, ContactPreferenceUnRep.values().length);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantRemoveDetainedStatusPersonalisationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantRemoveDetainedStatusPersonalisationEmailTest.java
@@ -1,0 +1,118 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appellant.email;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+import java.util.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class AppellantRemoveDetainedStatusPersonalisationEmailTest {
+
+    @Mock
+    AsylumCase asylumCase;
+
+    private Long caseId = 12345L;
+    private String beforeListingEmailTemplateId = "someEmailTemplateIdBeforeListing";
+    private String afterListingEmailTemplateId = "someEmailTemplateIdAfterListing";
+    private String mockedAppealReferenceNumber = "someReferenceNumber";
+    private String mockedAppealHomeOfficeReferenceNumber = "someHomeOfficeReferenceNumber";
+    private String mockedListingReferenceNumber = "someListingReferenceNumber";
+    private String mockedAppellantEmailAddress = "appellant@example.net";
+    private AppellantRemoveDetainedStatusPersonalisationEmail appellantRemoveDetainedStatusPersonalisationEmail;
+
+    @BeforeEach
+    public void setup() {
+
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class))
+                .thenReturn(Optional.of(mockedAppealReferenceNumber));
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class))
+                .thenReturn(Optional.of(mockedAppealHomeOfficeReferenceNumber));
+
+        appellantRemoveDetainedStatusPersonalisationEmail = new AppellantRemoveDetainedStatusPersonalisationEmail(
+                beforeListingEmailTemplateId,
+                afterListingEmailTemplateId
+        );
+    }
+
+    @Test
+    public void should_return_before_listing_template_id() {
+        assertEquals(beforeListingEmailTemplateId,
+                appellantRemoveDetainedStatusPersonalisationEmail.getTemplateId(asylumCase));
+    }
+
+    @Test
+    public void should_return_after_listing_template_id() {
+        when(asylumCase.read(ARIA_LISTING_REFERENCE, String.class))
+                .thenReturn(Optional.of(mockedListingReferenceNumber));
+        assertEquals(afterListingEmailTemplateId,
+                appellantRemoveDetainedStatusPersonalisationEmail.getTemplateId(asylumCase));
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        assertEquals(caseId + "_REMOVE_DETENTION_STATUS_APPELLANT_EMAIL",
+                appellantRemoveDetainedStatusPersonalisationEmail.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_correct_recipient_email_address() {
+        List<String> mockedContactPreferences = new ArrayList<>(Arrays.asList("wantsEmail"));
+
+        when(asylumCase.read(CONTACT_PREFERENCE_UN_REP))
+                .thenReturn(Optional.of(mockedContactPreferences));
+
+        when(asylumCase.read(EMAIL, String.class))
+                .thenReturn(Optional.of(mockedAppellantEmailAddress));
+
+        assertTrue(appellantRemoveDetainedStatusPersonalisationEmail.getRecipientsList(asylumCase)
+                .contains(mockedAppellantEmailAddress));
+    }
+
+    @Test
+    public void should_return_empty_recipient_set_when_email_contact_preference_not_chosen() {
+        List<String> mockedContactPreferences = new ArrayList<>(Arrays.asList());
+
+        when(asylumCase.read(CONTACT_PREFERENCE_UN_REP))
+                .thenReturn(Optional.ofNullable(mockedContactPreferences));
+
+        assertTrue(appellantRemoveDetainedStatusPersonalisationEmail.getRecipientsList(asylumCase)
+                .isEmpty());
+        verify(asylumCase, times(0)).read(EMAIL);
+
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given_before_listing_case() {
+        Map<String, String> personalisation =
+                appellantRemoveDetainedStatusPersonalisationEmail.getPersonalisation(asylumCase);
+
+        assertEquals(mockedAppealReferenceNumber, personalisation.get("appealReferenceNumber"));
+        assertEquals(mockedAppealHomeOfficeReferenceNumber, personalisation.get("homeOfficeReferenceNumber"));
+        assertEquals("", personalisation.get("ariaListingReference"));
+
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given_after_listing_case() {
+        when(asylumCase.read(ARIA_LISTING_REFERENCE, String.class))
+                .thenReturn(Optional.of(mockedListingReferenceNumber));
+
+        Map<String, String> personalisation =
+                appellantRemoveDetainedStatusPersonalisationEmail.getPersonalisation(asylumCase);
+
+        assertEquals(mockedAppealReferenceNumber, personalisation.get("appealReferenceNumber"));
+        assertEquals(mockedAppealHomeOfficeReferenceNumber, personalisation.get("homeOfficeReferenceNumber"));
+        assertEquals(mockedListingReferenceNumber, personalisation.get("ariaListingReference"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/sms/AppellantRemoveDetainedStatusPersonalisationSmsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/sms/AppellantRemoveDetainedStatusPersonalisationSmsTest.java
@@ -1,0 +1,98 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appellant.sms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.EMAIL;
+
+import java.util.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.*;
+
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class AppellantRemoveDetainedStatusPersonalisationSmsTest {
+
+    @Mock
+    AsylumCase asylumCase;
+
+    private Long caseId = 12345L;
+    private String smsTemplateId = "someSmsTemplateId";
+    private String mockedAppealReferenceNumber = "someReferenceNumber";
+    private String mockedAppellantMobilePhone = "07123456789";
+
+    private AppellantRemoveDetainedStatusPersonalisationSms appellantRemoveDetainedStatusPersonalisationSms;
+
+    @BeforeEach
+    public void setup() {
+        appellantRemoveDetainedStatusPersonalisationSms = new AppellantRemoveDetainedStatusPersonalisationSms(
+                smsTemplateId
+        );
+    }
+
+
+    @Test
+    public void should_return_template_id() {
+        assertEquals(smsTemplateId,
+                appellantRemoveDetainedStatusPersonalisationSms.getTemplateId());
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        assertEquals(caseId + "_REMOVE_DETENTION_STATUS_APPELLANT_SMS",
+                appellantRemoveDetainedStatusPersonalisationSms.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_correct_recipient_mobile_number() {
+        List<String> mockedContactPreferences = new ArrayList<>(Arrays.asList("wantsSms"));
+
+        when(asylumCase.read(CONTACT_PREFERENCE_UN_REP))
+                .thenReturn(Optional.of(mockedContactPreferences));
+
+        when(asylumCase.read(MOBILE_NUMBER, String.class))
+                .thenReturn(Optional.of(mockedAppellantMobilePhone));
+
+        assertTrue(appellantRemoveDetainedStatusPersonalisationSms.getRecipientsList(asylumCase)
+                .contains(mockedAppellantMobilePhone));
+    }
+
+    @Test
+    public void should_return_empty_recipient_set_when_sms_contact_preference_not_chosen() {
+        List<String> mockedContactPreferences = new ArrayList<>(Arrays.asList());
+
+        when(asylumCase.read(CONTACT_PREFERENCE_UN_REP))
+                .thenReturn(Optional.ofNullable(mockedContactPreferences));
+
+        assertTrue(appellantRemoveDetainedStatusPersonalisationSms.getRecipientsList(asylumCase)
+                .isEmpty());
+        verify(asylumCase, times(0)).read(EMAIL);
+
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given() {
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class))
+                .thenReturn(Optional.of(mockedAppealReferenceNumber));
+        Map<String, String> personalisation =
+                appellantRemoveDetainedStatusPersonalisationSms.getPersonalisation(asylumCase);
+
+        assertEquals(mockedAppealReferenceNumber, personalisation.get("appealReferenceNumber"));
+    }
+
+    @Test
+    public void should_return_personalisation_when_appeal_ref_missing() {
+        Map<String, String> personalisation =
+                appellantRemoveDetainedStatusPersonalisationSms.getPersonalisation(asylumCase);
+
+        assertEquals("", personalisation.get("appealReferenceNumber"));
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6940


### Change description ###
Added email/sms notif to appellant for AIP journey when Admin triggers removeDetainedStatus.
    Added Email/SMS personlisations
    Added bean to notification handler/generator
    Added unit/functional tests for personlisations

Testing:
SMS to appellant:
![image](https://user-images.githubusercontent.com/118450580/233158551-d7a71d35-8dc1-4aa0-b876-e688342223a1.png)

Before listing email to appellant:
![image](https://user-images.githubusercontent.com/118450580/233157380-01dec7f4-718a-438b-a2c2-03e520b6cc56.png)

After listing email to appellant:
![image](https://user-images.githubusercontent.com/118450580/233163015-cc37f5c0-62dd-4ac9-a0d6-db2ed94ce83d.png)


When Email + SMS both chosen, 2 emails are sent out (HO/appellant) and 1 text.
![image](https://user-images.githubusercontent.com/118450580/233156962-01fcd743-6d90-4e00-8054-88acce3f6f5f.png)

When SMS chosen and Email is NOT chosen, 1 text is sent and 1 email (to HO) is sent.
![image](https://user-images.githubusercontent.com/118450580/233158440-1fd17fa1-f49c-410e-96c4-060a2bada4e7.png)

When Email chosen and SMS is NOT chosen, only 2 emails sent (HO/appellant)
![image](https://user-images.githubusercontent.com/118450580/233159059-448be083-fa78-4142-9c21-4b7285c79e6e.png)

Tested scenario where mobile number and email address both NOT provided. No screenshots to attach but functional test for this scenario added. Works as expected (only HO notif sent, no appellant email/sms sent).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
