### PR TITLE
RIA-7030 reinstate appeal notification

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -92,5 +92,6 @@
         <cve>CVE-2023-28708</cve>
         <cve>CVE-2023-20861</cve>
         <cve>CVE-2023-20860</cve>
+        <cve>CVE-2023-20863</cve>
     </suppress>
 </suppressions>

--- a/src/functionalTest/resources/scenarios/RIA-7030-reinstate-appeal-internal-notification-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7030-reinstate-appeal-internal-notification-after-listing.json
@@ -1,0 +1,56 @@
+{
+  "description": "RIA-7030 Send reinstate appeal notification after listing to HO (unrepped case)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7030,
+      "eventId": "reinstateAppeal",
+      "state": "submitHearingRequirements",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "listCaseHearingCentre": "taylorHouse",
+          "ariaListingReference": "LP/12345/2019",
+          "stateBeforeEndAppeal": "prepareForHearing",
+          "reinstateAppealDate": "{$TODAY}",
+          "reinstateAppealReason": "Withdraw",
+          "reinstatedDecisionMaker": "Admin Officer"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "listCaseHearingCentre": "taylorHouse",
+        "ariaListingReference": "LP/12345/2019",
+        "stateBeforeEndAppeal": "prepareForHearing",
+        "reinstateAppealDate": "{$TODAY}",
+        "reinstateAppealReason": "Withdraw",
+        "reinstatedDecisionMaker": "Admin Officer",
+        "notificationsSent": [
+          {
+            "id": "7030_REINSTATE_APPEAL_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7030_REINSTATE_APPEAL_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: appeal reinstated",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7030-reinstate-appeal-internal-notification-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7030-reinstate-appeal-internal-notification-before-listing.json
@@ -1,0 +1,52 @@
+{
+  "description": "RIA-7030 Send reinstate appeal notification before listing to HO (unrepped case)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7030,
+      "eventId": "reinstateAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "stateBeforeEndAppeal": "appealSubmitted",
+          "reinstateAppealDate": "{$TODAY}",
+          "reinstateAppealReason": "Withdraw",
+          "reinstatedDecisionMaker": "Admin Officer"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "stateBeforeEndAppeal": "appealSubmitted",
+        "reinstateAppealDate": "{$TODAY}",
+        "reinstateAppealReason": "Withdraw",
+        "reinstatedDecisionMaker": "Admin Officer",
+        "notificationsSent": [
+          {
+            "id": "7030_REINSTATE_APPEAL_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7030_REINSTATE_APPEAL_HOME_OFFICE",
+        "recipient": "{$apcHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: appeal reinstated",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -2424,6 +2424,24 @@ public class NotificationGeneratorConfiguration {
         );
     }
 
+    @Bean("reinstateAppealInternalNotificationGenerator")
+    public List<NotificationGenerator> reinstateAppealInternalNotificationHandler(
+            HomeOfficeReinstateAppealPersonalisation homeOfficeReinstateAppealPersonalisation,
+            GovNotifyNotificationSender notificationSender,
+            NotificationIdAppender notificationIdAppender
+    ) {
+
+        return Collections.singletonList(
+                new EmailNotificationGenerator(
+                        newArrayList(
+                                homeOfficeReinstateAppealPersonalisation
+                        ),
+                        notificationSender,
+                        notificationIdAppender
+                )
+        );
+    }
+
     @Bean("makeAnApplicationNotificationGenerator")
     public List<NotificationGenerator> makeAnApplicationNotificationHandler(
             LegalRepresentativeMakeAnApplicationPersonalisation legalRepresentativeMakeApplicationPersonalisation,

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -2475,7 +2475,8 @@ public class NotificationHandlerConfiguration {
             (callbackStage, callback) ->
                  callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                          && callback.getEvent() == Event.REINSTATE_APPEAL
-                         && isRepJourney(callback.getCaseDetails().getCaseData()),
+                         && isRepJourney(callback.getCaseDetails().getCaseData())
+                         && !isInternalCase(callback.getCaseDetails().getCaseData()),
             notificationGenerators
         );
     }
@@ -2489,6 +2490,19 @@ public class NotificationHandlerConfiguration {
                         callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                                 && callback.getEvent() == Event.REINSTATE_APPEAL
                                 && isAipJourney(callback.getCaseDetails().getCaseData()),
+                notificationGenerators
+        );
+    }
+
+    @Bean
+    public PreSubmitCallbackHandler<AsylumCase> reinstateAppealInternalNotificationHandler(
+            @Qualifier("reinstateAppealInternalNotificationGenerator") List<NotificationGenerator> notificationGenerators) {
+
+        return new NotificationHandler(
+                (callbackStage, callback) ->
+                        callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                                && callback.getEvent() == Event.REINSTATE_APPEAL
+                                && isInternalCase(callback.getCaseDetails().getCaseData()),
                 notificationGenerators
         );
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -648,14 +648,14 @@ govnotify:
     reinstateAppeal:
       legalRep:
         beforeListing:
-          email: 64a6c31c-5c7b-486d-8fdd-d51e72d2aec0
+          email: 28f1eb01-16e0-4ec8-a783-05c5754cdbe8
         afterListing:
-          email: 10d1ab62-f521-4cdc-8778-ca9202299776
+          email: 222e5fcd-b6a5-41ac-a3be-f1d849b96dac
       homeOffice:
         beforeListing:
-          email: e91c46b7-5cd1-4a58-a22a-76d3986c47fa
+          email: 18deee1b-635a-4821-8119-34c146e14c03
         afterListing:
-          email: 50f69e87-5e12-45ca-bdce-d4620ec1d511
+          email: 15242842-2a21-4ac2-921c-1b125efe0dba
       appellant:
         beforeListing:
           email: cdae7658-29d9-48ce-a477-1e542b7d3c8b


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7030


### Change description ###
Added new notification handler/generator for internal cases where reinstate appeal event is triggered
Updated handler for normal (non aip non unrepped) cases to not trigger when case is unrepped
Updated yaml values for gov notify template IDs


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
