### PR TITLE
RIA-7031 appealSubmitted HO notif content changes + enable appealSubmitted internal notifs

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7031-internal-appeal-submitted-notification-birmingham-hearing-centre-payment-pending.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-internal-appeal-submitted-notification-birmingham-hearing-centre-payment-pending.json
@@ -1,0 +1,48 @@
+{
+    "description": "RIA-7031 Send appeal submitted notification (IAC Birmingham) Unrepped",
+    "launchDarklyKey": "tcw-notifications-feature:true",
+    "request": {
+      "uri": "/asylum/ccdAboutToSubmit",
+      "credentials": "AdminOfficer",
+      "input": {
+        "id": 7031,
+        "eventId": "submitAppeal",
+        "state": "pendingPayment",
+        "caseData": {
+          "template": "minimal-internal-appeal-submitted.json",
+          "replacements": {
+            "hearingCentre": "birmingham"
+          }
+        }
+      }
+    },
+    "expectation": {
+      "status": 200,
+      "errors": [],
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "isAdmin": "Yes",
+          "hearingCentre": "birmingham",
+          "notificationsSent": [
+            {
+              "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+              "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+            }
+          ]
+        }
+      },
+      "notifications": [
+        {
+          "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+          "recipient": "{$hearingCentreEmailAddresses.birmingham}",
+          "subject": "Immigration and Asylum appeal: appeal submitted",
+          "body": [
+            "PA/12345/2019",
+            "Talha Awan",
+            "{$iaExUiFrontendUrl}"
+          ]
+        }
+      ]
+    }
+  }

--- a/src/functionalTest/resources/scenarios/RIA-7031-internal-appeal-submitted-notification-birmingham-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-internal-appeal-submitted-notification-birmingham-hearing-centre.json
@@ -1,0 +1,48 @@
+{
+  "description": "RIA-7031 Send appeal submitted notification (IAC Birmingham) Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "birmingham"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "birmingham",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.birmingham}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-internal-appeal-submitted-notification-glasgow-hearing-centre-payment-pending.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-internal-appeal-submitted-notification-glasgow-hearing-centre-payment-pending.json
@@ -1,0 +1,48 @@
+{
+    "description": "RIA-7031 Send appeal submitted notification (IAC Glasgow) Unrepped",
+    "launchDarklyKey": "tcw-notifications-feature:true",
+    "request": {
+      "uri": "/asylum/ccdAboutToSubmit",
+      "credentials": "AdminOfficer",
+      "input": {
+        "id": 7031,
+        "eventId": "submitAppeal",
+        "state": "pendingPayment",
+        "caseData": {
+          "template": "minimal-internal-appeal-submitted.json",
+          "replacements": {
+            "hearingCentre": "glasgow"
+          }
+        }
+      }
+    },
+    "expectation": {
+      "status": 200,
+      "errors": [],
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "isAdmin": "Yes",
+          "hearingCentre": "glasgow",
+          "notificationsSent": [
+            {
+              "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+              "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+            }
+          ]
+        }
+      },
+      "notifications": [
+        {
+          "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+          "recipient": "{$hearingCentreEmailAddresses.glasgow}",
+          "subject": "Immigration and Asylum appeal: appeal submitted",
+          "body": [
+            "PA/12345/2019",
+            "Talha Awan",
+            "{$iaExUiFrontendUrl}"
+          ]
+        }
+      ]
+    }
+  }

--- a/src/functionalTest/resources/scenarios/RIA-7031-internal-appeal-submitted-notification-glasgow-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-internal-appeal-submitted-notification-glasgow-hearing-centre.json
@@ -1,0 +1,48 @@
+{
+  "description": "RIA-7031 Send appeal submitted notification (IAC Glasgow) Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "glasgow"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "glasgow",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.glasgow}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-internal-appeal-submitted-notification-hatton-cross-hearing-centre-pending-payment.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-internal-appeal-submitted-notification-hatton-cross-hearing-centre-pending-payment.json
@@ -1,0 +1,47 @@
+{
+    "description": "RIA-7031 Send appeal submitted notification (IAC Hatton Cross) Unrepped",
+    "launchDarklyKey": "tcw-notifications-feature:true",
+    "request": {
+      "uri": "/asylum/ccdAboutToSubmit",
+      "credentials": "AdminOfficer",
+      "input": {
+        "id": 7031,
+        "eventId": "submitAppeal",
+        "state": "pendingPayment",
+        "caseData": {
+          "template": "minimal-internal-appeal-submitted.json",
+          "replacements": {
+            "hearingCentre": "hattonCross"
+          }
+        }
+      }
+    },
+    "expectation": {
+      "status": 200,
+      "errors": [],
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "hattonCross",
+          "notificationsSent": [
+            {
+              "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+              "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+            }
+          ]
+        }
+      },
+      "notifications": [
+        {
+          "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+          "recipient": "{$hearingCentreEmailAddresses.hattonCross}",
+          "subject": "Immigration and Asylum appeal: appeal submitted",
+          "body": [
+            "PA/12345/2019",
+            "Talha Awan",
+            "{$iaExUiFrontendUrl}"
+          ]
+        }
+      ]
+    }
+  }

--- a/src/functionalTest/resources/scenarios/RIA-7031-internal-appeal-submitted-notification-hatton-cross-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-internal-appeal-submitted-notification-hatton-cross-hearing-centre.json
@@ -1,0 +1,48 @@
+{
+  "description": "RIA-7031 Send appeal submitted notification (IAC Hatton Cross) Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "hattonCross"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "hattonCross",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.hattonCross}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-internal-appeal-submitted-notification-north-shields-hearing-centre-pending-payment.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-internal-appeal-submitted-notification-north-shields-hearing-centre-pending-payment.json
@@ -1,0 +1,47 @@
+{
+  "description": "RIA-7031 Send appeal submitted notification (IAC North Shields) Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "request": {
+      "uri": "/asylum/ccdAboutToSubmit",
+      "credentials": "AdminOfficer",
+      "input": {
+        "id": 7031,
+        "eventId": "submitAppeal",
+        "state": "pendingPayment",
+        "caseData": {
+          "template": "minimal-internal-appeal-submitted.json",
+          "replacements": {
+            "hearingCentre": "northShields"
+          }
+        }
+      }
+    },
+    "expectation": {
+      "status": 200,
+      "errors": [],
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "northShields",
+          "notificationsSent": [
+            {
+              "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+              "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+            }
+          ]
+        }
+      },
+      "notifications": [
+        {
+          "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+          "recipient": "{$hearingCentreEmailAddresses.northShields}",
+          "subject": "Immigration and Asylum appeal: appeal submitted",
+          "body": [
+            "PA/12345/2019",
+            "Talha Awan",
+            "{$iaExUiFrontendUrl}"
+          ]
+        }
+      ]
+    }
+  }

--- a/src/functionalTest/resources/scenarios/RIA-7031-internal-appeal-submitted-notification-north-shields-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-internal-appeal-submitted-notification-north-shields-hearing-centre.json
@@ -1,0 +1,48 @@
+{
+  "description": "RIA-7031 Send appeal submitted notification (IAC North Shields) Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "northShields"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "northShields",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.northShields}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-new-way-of-paying-internal-appeal-submitted-notification-to-ho.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-new-way-of-paying-internal-appeal-submitted-notification-to-ho.json
@@ -1,0 +1,37 @@
+{
+  "description": "RIA-7031 New way of paying HO notification appeal submitted PA pay now Unrepped",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appealType": "protection",
+          "paAppealTypePaymentOption":"payNow",
+          "hasServiceRequestAlready": "No"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-and-paylater-notifications.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-and-paylater-notifications.json
@@ -1,0 +1,75 @@
+{
+  "description": "RIA-7031 Send appeal submitted PA appeal type and payLater notification Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "taylorHouse",
+          "listCaseHearingCentre": "taylorHouse",
+          "ariaListingReference": "LP/12345/2019",
+          "legalRepReferenceNumber": "REF54321",
+          "paAppealTypePaymentOption":"payLater",
+          "appealType":"protection"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "taylorHouse",
+        "listCaseHearingCentre": "taylorHouse",
+        "ariaListingReference": "LP/12345/2019",
+        "legalRepReferenceNumber": "REF54321",
+        "paAppealTypePaymentOption":"payLater",
+        "appealType":"protection",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "7031_APPEAL_SUBMITTED_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      },
+      {
+        "reference": "7031_APPEAL_SUBMITTED_HOME_OFFICE",
+        "recipient": "{$apcPrivateHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}",
+          "{$customerServices.telephoneNumber}",
+          "{$customerServices.emailAddress}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-dc-appeal-type-notifications.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-dc-appeal-type-notifications.json
@@ -1,0 +1,57 @@
+{
+  "description": "RIA-7031 Send appeal submitted DC appeal type notification (HO Notification disabled) Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "disabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "taylorHouse",
+          "listCaseHearingCentre": "taylorHouse",
+          "ariaListingReference": "LP/12345/2019",
+          "legalRepReferenceNumber": "REF54321",
+          "appealType":"deprivation"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "taylorHouse",
+        "listCaseHearingCentre": "taylorHouse",
+        "ariaListingReference": "LP/12345/2019",
+        "legalRepReferenceNumber": "REF54321",
+        "appealType":"deprivation",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-ho-disabled.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-ho-disabled.json
@@ -1,0 +1,49 @@
+{
+  "description": "RIA-7031 Do not Send appeal submitted notification to Home Office - (HO Notification disabled) Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "disabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "manchester"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "manchester",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.manchester}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-notification-to-bradford-hearing-centre-payment-pending.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-notification-to-bradford-hearing-centre-payment-pending.json
@@ -1,0 +1,48 @@
+{
+  "description": "RIA-7031 Send appeal submitted notification to Phoenix House (Bradford hearing centre) Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "pendingPayment",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "bradford"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "bradford",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.bradford}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-notification-to-bradford-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-notification-to-bradford-hearing-centre.json
@@ -1,0 +1,48 @@
+{
+  "description": "RIA-7031 Send appeal submitted notification to Phoenix House (Bradford hearing centre) Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "bradford"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "bradford",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.bradford}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-notification-to-manchester-payment-pending.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-notification-to-manchester-payment-pending.json
@@ -1,0 +1,48 @@
+{
+  "description": "RIA-7031 Send appeal submitted notification to Manchester hearing centre Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "request": {
+      "uri": "/asylum/ccdAboutToSubmit",
+      "credentials": "AdminOfficer",
+      "input": {
+        "id": 7031,
+        "eventId": "submitAppeal",
+        "state": "pendingPayment",
+        "caseData": {
+          "template": "minimal-internal-appeal-submitted.json",
+          "replacements": {
+            "hearingCentre": "manchester"
+          }
+        }
+      }
+    },
+    "expectation": {
+      "status": 200,
+      "errors": [],
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "isAdmin": "Yes",
+          "hearingCentre": "manchester",
+          "notificationsSent": [
+            {
+              "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+              "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+            }
+          ]
+        }
+      },
+      "notifications": [
+        {
+          "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+          "recipient": "{$hearingCentreEmailAddresses.manchester}",
+          "subject": "Immigration and Asylum appeal: appeal submitted",
+          "body": [
+            "PA/12345/2019",
+            "Talha Awan",
+            "{$iaExUiFrontendUrl}"
+          ]
+        }
+      ]
+    }
+  }

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-notification-to-manchester.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-notification-to-manchester.json
@@ -1,0 +1,48 @@
+{
+  "description": "RIA-7031 Send appeal submitted notification to Manchester hearing centre (unrep)",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "manchester"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "manchester",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.manchester}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-notification-to-newport-hearing-centre-payment-pending.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-notification-to-newport-hearing-centre-payment-pending.json
@@ -1,0 +1,48 @@
+{
+  "description": "RIA-7031 Send appeal submitted notification to Columbus House (Newport hearing centre) Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "request": {
+      "uri": "/asylum/ccdAboutToSubmit",
+      "credentials": "AdminOfficer",
+      "input": {
+        "id": 7031,
+        "eventId": "submitAppeal",
+        "state": "pendingPayment",
+        "caseData": {
+          "template": "minimal-internal-appeal-submitted.json",
+          "replacements": {
+            "hearingCentre": "newport"
+          }
+        }
+      }
+    },
+    "expectation": {
+      "status": 200,
+      "errors": [],
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "isAdmin": "Yes",
+          "hearingCentre": "newport",
+          "notificationsSent": [
+            {
+              "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+              "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+            }
+          ]
+        }
+      },
+      "notifications": [
+        {
+          "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+          "recipient": "{$hearingCentreEmailAddresses.newport}",
+          "subject": "Immigration and Asylum appeal: appeal submitted",
+          "body": [
+            "PA/12345/2019",
+            "Talha Awan",
+            "{$iaExUiFrontendUrl}"
+          ]
+        }
+      ]
+    }
+  }

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-notification-to-newport-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-notification-to-newport-hearing-centre.json
@@ -1,0 +1,47 @@
+{
+  "description": "RIA-7031 Send appeal submitted notification to Columbus House (Newport hearing centre) Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "newport"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "hearingCentre": "newport",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.newport}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-notification-to-taylor-house.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-notification-to-taylor-house.json
@@ -1,0 +1,50 @@
+{
+  "description": "RIA-7031 Send appeal submitted notification to Taylor House hearing centre (unrep)",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "taylorHouse",
+          "paymentStatus": "Paid"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "taylorHouse",
+        "paymentStatus": "Paid",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_HOME_OFFICE",
+        "recipient": "{$apcPrivateHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-payment-pending-pay-offline-notifications.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-payment-pending-pay-offline-notifications.json
@@ -1,0 +1,86 @@
+{
+  "description": "RIA-7031 Send appeal submitted and payment pending notification to legal representative Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "taylorHouse",
+          "paAppealTypePaymentOption": null,
+          "isRemissionsEnabled": "Yes",
+          "remissionType": "hoWaiverRemission",
+          "appealType": "protection"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "paAppealTypePaymentOption": null,
+        "isRemissionsEnabled": "Yes",
+        "remissionType": "hoWaiverRemission",
+        "appealType": "protection",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "7031_APPEAL_SUBMITTED_PAY_OFFLINE_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "7031_APPEAL_SUBMITTED_PAY_OFFLINE_ADMIN_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      },
+      {
+        "reference": "7031_APPEAL_SUBMITTED_PAY_OFFLINE_HOME_OFFICE",
+        "recipient": "{$apcPrivateHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}",
+          "{$customerServices.telephoneNumber}",
+          "{$customerServices.emailAddress}"
+        ]
+      },
+      {
+        "reference": "7031_APPEAL_SUBMITTED_PAY_OFFLINE_ADMIN_OFFICER",
+        "recipient": "payment-exceptions-ao-aat-test@example.com",
+        "subject": "Immigration and Asylum appeal: appeal submitted with remission application",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-pending-payment-ea-appeal-type-notification-ho-disabled.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-pending-payment-ea-appeal-type-notification-ho-disabled.json
@@ -1,0 +1,52 @@
+{
+  "description": "RIA-7031 send appeal submitted and payment pending notification - Home Office notifications disabled Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "disabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "pendingPayment",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "eaHuAppealTypePaymentOption":"payOffline",
+          "appealType":"refusalOfEu"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "taylorHouse",
+        "eaHuAppealTypePaymentOption":"payOffline",
+        "appealType":"refusalOfEu",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_ADMIN_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_ADMIN_OFFICER",
+        "recipient": "{$FEES_ADMIN_OFFICER_EMAIL}",
+        "subject": "Immigration and Asylum appeal: appeal submitted pending payment",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-pending-payment-ea-appeal-type-notifications.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-pending-payment-ea-appeal-type-notifications.json
@@ -1,0 +1,68 @@
+{
+  "description": "RIA-7031 send appeal submitted and payment pending notification Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "pendingPayment",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "eaHuAppealTypePaymentOption":"payOffline",
+          "appealType":"refusalOfEu"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "taylorHouse",
+        "eaHuAppealTypePaymentOption":"payOffline",
+        "appealType":"refusalOfEu",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_ADMIN_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_HOME_OFFICE",
+        "recipient": "{$apcPrivateHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}",
+          "{$customerServices.telephoneNumber}",
+          "{$customerServices.emailAddress}"
+        ]
+      },
+      {
+        "reference": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_ADMIN_OFFICER",
+        "recipient": "{$FEES_ADMIN_OFFICER_EMAIL}",
+        "subject": "Immigration and Asylum appeal: appeal submitted pending payment",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-pending-payment-hu-appeal-type-notification-ho-disabled.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-pending-payment-hu-appeal-type-notification-ho-disabled.json
@@ -1,0 +1,52 @@
+{
+  "description": "RIA-7031 send appeal submitted and payment pending notification - Home Office notifications disabled Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "disabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "pendingPayment",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "eaHuAppealTypePaymentOption":"payOffline",
+          "appealType":"refusalOfHumanRights"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "taylorHouse",
+        "eaHuAppealTypePaymentOption":"payOffline",
+        "appealType":"refusalOfHumanRights",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_ADMIN_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_ADMIN_OFFICER",
+        "recipient": "{$FEES_ADMIN_OFFICER_EMAIL}",
+        "subject": "Immigration and Asylum appeal: appeal submitted pending payment",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-pending-payment-hu-appeal-type-notifications.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-pending-payment-hu-appeal-type-notifications.json
@@ -1,0 +1,68 @@
+{
+  "description": "RIA-7031 send appeal submitted and payment pending notification Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "pendingPayment",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "eaHuAppealTypePaymentOption":"payOffline",
+          "appealType":"refusalOfHumanRights"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "taylorHouse",
+        "eaHuAppealTypePaymentOption":"payOffline",
+        "appealType":"refusalOfHumanRights",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_ADMIN_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_HOME_OFFICE",
+        "recipient": "{$apcPrivateHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}",
+          "{$customerServices.telephoneNumber}",
+          "{$customerServices.emailAddress}"
+        ]
+      },
+      {
+        "reference": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_ADMIN_OFFICER",
+        "recipient": "{$FEES_ADMIN_OFFICER_EMAIL}",
+        "subject": "Immigration and Asylum appeal: appeal submitted pending payment",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-rp-appeal-type-notification-ho-disabled.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-rp-appeal-type-notification-ho-disabled.json
@@ -1,0 +1,57 @@
+{
+  "description": "RIA-7031 Send appeal submitted RP appeal type notification (HO Notification disabled) Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "disabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "taylorHouse",
+          "listCaseHearingCentre": "taylorHouse",
+          "ariaListingReference": "LP/12345/2019",
+          "legalRepReferenceNumber": "REF54321",
+          "appealType":"revocationOfProtection"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "taylorHouse",
+        "listCaseHearingCentre": "taylorHouse",
+        "ariaListingReference": "LP/12345/2019",
+        "legalRepReferenceNumber": "REF54321",
+        "appealType":"revocationOfProtection",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-rp-appeal-type-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-rp-appeal-type-notification.json
@@ -1,0 +1,60 @@
+{
+  "description": "RIA-7031 Send appeal submitted RP appeal type notification Unrepped",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "taylorHouse",
+          "listCaseHearingCentre": "taylorHouse",
+          "ariaListingReference": "LP/12345/2019",
+          "legalRepReferenceNumber": "REF54321",
+          "appealType":"revocationOfProtection",
+          "paAppealTypePaymentOption": "payLater"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "taylorHouse",
+        "listCaseHearingCentre": "taylorHouse",
+        "ariaListingReference": "LP/12345/2019",
+        "legalRepReferenceNumber": "REF54321",
+        "appealType":"revocationOfProtection",
+        "paAppealTypePaymentOption": "payLater",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_HOME_OFFICE",
+        "recipient": "{$apcPrivateHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}",
+          "{$customerServices.telephoneNumber}",
+          "{$customerServices.emailAddress}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-to-home-office-payment-pending.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-to-home-office-payment-pending.json
@@ -1,0 +1,50 @@
+{
+  "description": "RIA-7031 Send appeal submitted notification to Home Office Unrepped",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+    "request": {
+      "uri": "/asylum/ccdAboutToSubmit",
+      "credentials": "AdminOfficer",
+      "input": {
+        "id": 7031,
+        "eventId": "submitAppeal",
+        "state": "pendingPayment",
+        "caseData": {
+          "template": "minimal-internal-appeal-submitted.json",
+          "replacements": {
+            "hearingCentre": "manchester",
+            "paymentStatus": "Paid"
+          }
+        }
+      }
+    },
+    "expectation": {
+      "status": 200,
+      "errors": [],
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "isAdmin": "Yes",
+          "hearingCentre": "manchester",
+          "paymentStatus": "Paid",
+          "notificationsSent": [
+            {
+              "id": "7031_APPEAL_SUBMITTED_HOME_OFFICE",
+              "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+            }
+          ]
+        }
+      },
+      "notifications": [
+        {
+          "reference": "7031_APPEAL_SUBMITTED_HOME_OFFICE",
+          "recipient": "{$apcPrivateHomeOfficeEmailAddress}",
+          "subject": "Immigration and Asylum appeal: appeal submitted",
+          "body": [
+            "PA/12345/2019",
+            "Talha Awan",
+            "{$iaExUiFrontendUrl}"
+          ]
+        }
+      ]
+    }
+  }

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-to-home-office.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-to-home-office.json
@@ -1,0 +1,65 @@
+{
+  "description": "RIA-7031 Send appeal submitted notification to Home Office Unrepped",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "manchester",
+          "paAppealTypePaymentOption": "payLater"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "manchester",
+        "paAppealTypePaymentOption": "payLater",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "7031_APPEAL_SUBMITTED_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.manchester}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      },
+      {
+        "reference": "7031_APPEAL_SUBMITTED_HOME_OFFICE",
+        "recipient": "{$apcPrivateHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-with-remission-pa-appeal-type-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-with-remission-pa-appeal-type-notification.json
@@ -1,0 +1,69 @@
+{
+  "description": "RIA-7031 send appeal submitted with remission and payOffline, for PA appeal notification (Unrepped)",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "isRemissionsEnabled": "Yes",
+          "remissionType": "hoWaiverRemission",
+          "appealType": "protection"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "taylorHouse",
+        "isRemissionsEnabled": "Yes",
+        "remissionType":"hoWaiverRemission",
+        "appealType":"protection",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_PAY_OFFLINE_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "7031_APPEAL_SUBMITTED_PAY_OFFLINE_ADMIN_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_PAY_OFFLINE_HOME_OFFICE",
+        "recipient": "{$apcPrivateHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}",
+          "{$customerServices.telephoneNumber}",
+          "{$customerServices.emailAddress}"
+        ]
+      },
+      {
+        "reference": "7031_APPEAL_SUBMITTED_PAY_OFFLINE_ADMIN_OFFICER",
+        "recipient": "payment-exceptions-ao-aat-test@example.com",
+        "subject": "Immigration and Asylum appeal: appeal submitted with remission application",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-with-remission-pending-payment-ea-appeal-type-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-with-remission-pending-payment-ea-appeal-type-notification.json
@@ -1,0 +1,71 @@
+{
+  "description": "RIA-7031 send appeal submitted with remission and payment pending, for EA appeal notification Unrepped",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "pendingPayment",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "isRemissionsEnabled": "Yes",
+          "remissionType":"hoWaiverRemission",
+          "appealType":"refusalOfEu",
+          "eaHuAppealTypePaymentOption": "payLater"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "taylorHouse",
+        "isRemissionsEnabled": "Yes",
+        "remissionType":"hoWaiverRemission",
+        "appealType":"refusalOfEu",
+        "eaHuAppealTypePaymentOption": "payLater",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_ADMIN_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_HOME_OFFICE",
+        "recipient": "{$apcPrivateHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}",
+          "{$customerServices.telephoneNumber}",
+          "{$customerServices.emailAddress}"
+        ]
+      },
+      {
+        "reference": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_ADMIN_OFFICER",
+        "recipient": "{$PAYMENT_EXCEPTIONS_ADMIN_OFFICER_EMAIL}",
+        "subject": "Immigration and Asylum appeal: appeal submitted with remission application",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-with-remission-pending-payment-hu-appeal-type-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-appeal-submitted-with-remission-pending-payment-hu-appeal-type-notification.json
@@ -1,0 +1,71 @@
+{
+  "description": "RIA-7031 send appeal submitted with remission and payment pending, for HU appeal notification Unrepped",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "pendingPayment",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "isRemissionsEnabled": "Yes",
+          "remissionType":"hoWaiverRemission",
+          "appealType":"refusalOfHumanRights",
+          "eaHuAppealTypePaymentOption": "payLater"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "taylorHouse",
+        "isRemissionsEnabled": "Yes",
+        "remissionType":"hoWaiverRemission",
+        "appealType":"refusalOfHumanRights",
+        "eaHuAppealTypePaymentOption": "payLater",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_ADMIN_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_HOME_OFFICE",
+        "recipient": "{$apcPrivateHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}",
+          "{$customerServices.telephoneNumber}",
+          "{$customerServices.emailAddress}"
+        ]
+      },
+      {
+        "reference": "7031_APPEAL_SUBMITTED_PENDING_PAYMENT_ADMIN_OFFICER",
+        "recipient": "{$PAYMENT_EXCEPTIONS_ADMIN_OFFICER_EMAIL}",
+        "subject": "Immigration and Asylum appeal: appeal submitted with remission application",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7031-send-internal-paid-appeal-submitted-dc-appeal-type-notifications.json
+++ b/src/functionalTest/resources/scenarios/RIA-7031-send-internal-paid-appeal-submitted-dc-appeal-type-notifications.json
@@ -1,0 +1,60 @@
+{
+  "description": "RIA-7031 Send paid appeal submitted DC appeal type notification Unrepped",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7031,
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "taylorHouse",
+          "listCaseHearingCentre": "taylorHouse",
+          "ariaListingReference": "LP/12345/2019",
+          "legalRepReferenceNumber": "REF54321",
+          "appealType":"deprivation",
+          "paymentStatus": "Paid"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "hearingCentre": "taylorHouse",
+        "listCaseHearingCentre": "taylorHouse",
+        "ariaListingReference": "LP/12345/2019",
+        "legalRepReferenceNumber": "REF54321",
+        "appealType":"deprivation",
+        "paymentStatus": "Paid",
+        "notificationsSent": [
+          {
+            "id": "7031_APPEAL_SUBMITTED_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7031_APPEAL_SUBMITTED_HOME_OFFICE",
+        "recipient": "{$apcPrivateHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: appeal submitted",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan",
+          "{$iaExUiFrontendUrl}",
+          "{$customerServices.telephoneNumber}",
+          "{$customerServices.emailAddress}"
+        ]
+      }
+    ]
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -2317,6 +2317,25 @@ public class NotificationGeneratorConfiguration {
         );
     }
 
+    @Bean("submitAppealPayOfflineInternalNotificationGenerator")
+    public List<NotificationGenerator> submitAppealPayOfflineInternalNotificationGenerator(
+            AdminOfficerAppealSubmittedPayOfflinePersonalisation adminOfficerAppealSubmittedPayOfflinePersonalisation,
+            HomeOfficeAppealSubmittedPayOfflinePersonalisation homeOfficeAppealSubmittedPayOfflinePersonalisation,
+            GovNotifyNotificationSender notificationSender,
+            NotificationIdAppender notificationIdAppender
+    ) {
+        //RIA-6682
+        List<EmailNotificationPersonalisation> personalisations = newArrayList(homeOfficeAppealSubmittedPayOfflinePersonalisation, adminOfficerAppealSubmittedPayOfflinePersonalisation);
+
+        return Collections.singletonList(
+                new EmailNotificationGenerator(
+                        personalisations,
+                        notificationSender,
+                        notificationIdAppender
+                )
+        );
+    }
+
     @Bean("submitAppealPendingPaymentNotificationGenerator")
     public List<NotificationGenerator> submitAppealPendingPaymentNotificationHandler(
             LegalRepresentativeAppealSubmittedPendingPaymentPersonalisation legalRepresentativeAppealSubmittedPendingPaymentPersonalisation,
@@ -2337,6 +2356,28 @@ public class NotificationGeneratorConfiguration {
                 notificationSender,
                 notificationIdAppender
             )
+        );
+    }
+
+    @Bean("submitAppealPendingPaymentInternalNotificationGenerator")
+    public List<NotificationGenerator> submitAppealPendingPaymentInternalNotificationGenerator(
+            HomeOfficeAppealSubmittedPendingPaymentPersonalisation homeOfficeAppealSubmittedPendingPaymentPersonalisation,
+            AdminOfficerAppealSubmittedPendingPaymentPersonalisation adminOfficerAppealSubmittedPendingPaymentPersonalisation,
+            GovNotifyNotificationSender notificationSender,
+            NotificationIdAppender notificationIdAppender
+    ) {
+
+        // RIA-3631 - submitAppeal This needs to be changed as per ACs
+        List<EmailNotificationPersonalisation> personalisations = isHomeOfficeGovNotifyEnabled
+                ?  newArrayList(homeOfficeAppealSubmittedPendingPaymentPersonalisation, adminOfficerAppealSubmittedPendingPaymentPersonalisation)
+                : newArrayList(adminOfficerAppealSubmittedPendingPaymentPersonalisation);
+
+        return Collections.singletonList(
+                new EmailNotificationGenerator(
+                        personalisations,
+                        notificationSender,
+                        notificationIdAppender
+                )
         );
     }
 
@@ -3061,6 +3102,31 @@ public class NotificationGeneratorConfiguration {
         );
     }
 
+    @Bean("payAndSubmitAppealEmailInternalNotificationGenerator")
+    public List<NotificationGenerator> payAndSubmitAppealEmailInternalNotificationGenerator(
+            HomeOfficeSubmitAppealPersonalisation homeOfficeSubmitAppealPersonalisation,
+            CaseOfficerSubmitAppealPersonalisation caseOfficerSubmitAppealPersonalisation,
+            GovNotifyNotificationSender notificationSender,
+            NotificationIdAppender notificationIdAppender
+    ) {
+
+        return Collections.singletonList(
+                new EmailNotificationGenerator(
+                        newArrayList(
+                                homeOfficeSubmitAppealPersonalisation,
+                                caseOfficerSubmitAppealPersonalisation
+                        ),
+                        notificationSender,
+                        notificationIdAppender
+                ) {
+                    @Override
+                    public Message getSuccessMessage() {
+                        return new Message("success","body");
+                    }
+                }
+        );
+    }
+
     @Bean("payAndSubmitAppealFailedEmailNotificationGenerator")
     public List<NotificationGenerator> payAndSubmitAppealFailedEmailNotificationHandler(
         LegalRepresentativeAppealSubmittedPaidPersonalisation legalRepresentativeAppealSubmittedPaidPersonalisation,
@@ -3085,6 +3151,31 @@ public class NotificationGeneratorConfiguration {
                     return new Message("success","body");
                 }
             }
+        );
+    }
+
+    @Bean("payAndSubmitAppealFailedEmailInternalNotificationGenerator")
+    public List<NotificationGenerator> payAndSubmitAppealFailedEmailInternalNotificationGenerator(
+            HomeOfficeSubmitAppealPersonalisation homeOfficeSubmitAppealPersonalisation,
+            CaseOfficerSubmitAppealPersonalisation caseOfficerSubmitAppealPersonalisation,
+            GovNotifyNotificationSender notificationSender,
+            NotificationIdAppender notificationIdAppender
+    ) {
+
+        return Collections.singletonList(
+                new EmailNotificationGenerator(
+                        newArrayList(
+                                homeOfficeSubmitAppealPersonalisation,
+                                caseOfficerSubmitAppealPersonalisation
+                        ),
+                        notificationSender,
+                        notificationIdAppender
+                ) {
+                    @Override
+                    public Message getSuccessMessage() {
+                        return new Message("success","body");
+                    }
+                }
         );
     }
 
@@ -3281,6 +3372,24 @@ public class NotificationGeneratorConfiguration {
                 notificationSender,
                 notificationIdAppender
             )
+        );
+    }
+
+    @Bean("submitAppealLrHoWaysToPayPaPayNowInternalNotificationGenerator")
+    public List<NotificationGenerator> submitAppealLrHoWaysToPayPaPayNowInternalNotificationGenerator(
+            HomeOfficeSubmitAppealPersonalisation homeOfficeSubmitAppealPersonalisation,
+            GovNotifyNotificationSender notificationSender,
+            NotificationIdAppender notificationIdAppender
+    ) {
+
+        return Collections.singletonList(
+                new EmailNotificationGenerator(
+                        newArrayList(
+                                homeOfficeSubmitAppealPersonalisation
+                        ),
+                        notificationSender,
+                        notificationIdAppender
+                )
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -769,9 +769,10 @@ public class NotificationHandlerConfiguration {
 
                 return (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                         && callback.getEvent() == Event.SUBMIT_APPEAL
-                        && callback.getCaseDetails().getCaseData()
+                        && (callback.getCaseDetails().getCaseData()
                             .read(JOURNEY_TYPE, JourneyType.class)
                             .map(type -> type == REP).orElse(true)
+                            || isInternalCase(asylumCase))
                         && (!paymentFailed || paymentFailedChangedToPayLater)
                         && !isPaymentPendingForEaOrHuAppeal(callback))
                        || (callback.getEvent() == Event.RECORD_REMISSION_DECISION
@@ -818,7 +819,7 @@ public class NotificationHandlerConfiguration {
 
                 return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                        && callback.getEvent() == Event.SUBMIT_APPEAL
-                       && isRepJourney(asylumCase)
+                       && (isRepJourney(asylumCase) || isInternalCase(asylumCase))
                        && (paymentPaid || payLater);
 
             }, notificationGenerators,
@@ -2302,8 +2303,33 @@ public class NotificationHandlerConfiguration {
                 return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                        && callback.getEvent() == Event.SUBMIT_APPEAL
                        && isCorrectAppealType
+                       && !isInternalCase(asylumCase)
                        && (paPaymentOption.equals("payOffline") || isRemissionOptedForEaOrHuOrPaAppeal(callback));
             }, notificationGenerators
+        );
+    }
+
+    @Bean
+    public PreSubmitCallbackHandler<AsylumCase> submitAppealPayOfflineInternalNotificationHandler(
+            @Qualifier("submitAppealPayOfflineInternalNotificationGenerator") List<NotificationGenerator> notificationGenerators) {
+
+        return new NotificationHandler(
+                (callbackStage, callback) -> {
+                    AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+                    boolean isCorrectAppealType = asylumCase
+                            .read(APPEAL_TYPE, AppealType.class)
+                            .map(type -> type == PA).orElse(false);
+
+                    String paPaymentOption = asylumCase
+                            .read(AsylumCaseDefinition.PA_APPEAL_TYPE_PAYMENT_OPTION, String.class).orElse("");
+
+                    return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                            && callback.getEvent() == Event.SUBMIT_APPEAL
+                            && isInternalCase(asylumCase)
+                            && isCorrectAppealType
+                            && (paPaymentOption.equals("payOffline") || isRemissionOptedForEaOrHuOrPaAppeal(callback));
+                }, notificationGenerators
         );
     }
 
@@ -2317,10 +2343,29 @@ public class NotificationHandlerConfiguration {
             (callbackStage, callback) ->
                 callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                 && callback.getEvent() == Event.SUBMIT_APPEAL
+                && !isInternalCase(callback.getCaseDetails().getCaseData())
                 && (isPaymentPendingForEaOrHuAppeal(callback)
                     || isPaymentPendingForEaOrHuAppealWithRemission(callback)),
             notificationGenerators,
             getErrorHandler()
+        );
+    }
+
+    @Bean
+    public PreSubmitCallbackHandler<AsylumCase> submitAppealPendingPaymentInternalNotificationHandler(
+            @Qualifier("submitAppealPendingPaymentInternalNotificationGenerator")
+            List<NotificationGenerator> notificationGenerators) {
+
+        // RIA-3631 - submitAppeal This needs to be changed as per ACs
+        return new NotificationHandler(
+                (callbackStage, callback) ->
+                        callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                                && callback.getEvent() == Event.SUBMIT_APPEAL
+                                && isInternalCase(callback.getCaseDetails().getCaseData())
+                                && (isPaymentPendingForEaOrHuAppeal(callback)
+                                || isPaymentPendingForEaOrHuAppealWithRemission(callback)),
+                notificationGenerators,
+                getErrorHandler()
         );
     }
 
@@ -3104,12 +3149,50 @@ public class NotificationHandlerConfiguration {
                         && callback.getCaseDetails().getCaseData()
                             .read(JOURNEY_TYPE, JourneyType.class)
                             .map(type -> type == REP).orElse(true)
+                        && !isInternalCase(callback.getCaseDetails().getCaseData())
                         && (!paymentFailed || paymentFailedChangedToPayLater)
                         && !isPaymentPendingForEaOrHuAppeal(callback))
                        || (callback.getEvent() == Event.RECORD_REMISSION_DECISION
                            && isRemissionApproved
                            && isEaHuEuAppeal(asylumCase));
             }, notificationGenerators
+        );
+    }
+
+    @Bean
+    public PostSubmitCallbackHandler<AsylumCase> payAndSubmitAppealEmailInternalNotificationHandler(
+            @Qualifier("payAndSubmitAppealEmailInternalNotificationGenerator")
+            List<NotificationGenerator> notificationGenerators) {
+
+        return new PostSubmitNotificationHandler(
+                (callbackStage, callback) -> {
+
+                    AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+                    boolean paymentFailed = asylumCase
+                            .read(AsylumCaseDefinition.PAYMENT_STATUS, PaymentStatus.class)
+                            .map(paymentStatus -> paymentStatus == FAILED || paymentStatus == TIMEOUT).orElse(false);
+
+                    boolean payLater = asylumCase
+                            .read(PA_APPEAL_TYPE_PAYMENT_OPTION, String.class)
+                            .map(paymentOption -> paymentOption.equals("payOffline") || paymentOption.equals("payLater"))
+                            .orElse(false);
+
+                    boolean paymentFailedChangedToPayLater = paymentFailed && payLater;
+
+                    boolean isRemissionApproved = asylumCase.read(REMISSION_DECISION, RemissionDecision.class)
+                            .map(decision -> APPROVED == decision)
+                            .orElse(false);
+
+                    return (callbackStage == PostSubmitCallbackStage.CCD_SUBMITTED
+                            && callback.getEvent() == Event.PAY_AND_SUBMIT_APPEAL
+                            && isInternalCase(asylumCase)
+                            && (!paymentFailed || paymentFailedChangedToPayLater)
+                            && !isPaymentPendingForEaOrHuAppeal(callback))
+                            || (callback.getEvent() == Event.RECORD_REMISSION_DECISION
+                            && isRemissionApproved
+                            && isEaHuEuAppeal(asylumCase));
+                }, notificationGenerators
         );
     }
 
@@ -3134,9 +3217,38 @@ public class NotificationHandlerConfiguration {
 
                 return callbackStage == PostSubmitCallbackStage.CCD_SUBMITTED
                        && callback.getEvent() == Event.PAY_AND_SUBMIT_APPEAL
+                       && !isInternalCase(asylumCase)
                        && paymentFailed
                        && isPaAppealType;
             }, notificationGenerators
+        );
+    }
+
+    @Bean
+    public PostSubmitCallbackHandler<AsylumCase> payAndSubmitAppealFailedEmailInternalNotificationHandler(
+            @Qualifier("payAndSubmitAppealFailedEmailInternalNotificationGenerator")
+            List<NotificationGenerator> notificationGenerators
+    ) {
+
+        return new PostSubmitNotificationHandler(
+                (callbackStage, callback) -> {
+
+                    AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+                    boolean paymentFailed = asylumCase
+                            .read(AsylumCaseDefinition.PAYMENT_STATUS, PaymentStatus.class)
+                            .map(paymentStatus -> paymentStatus == FAILED || paymentStatus == TIMEOUT).orElse(false);
+
+                    boolean isPaAppealType = asylumCase
+                            .read(APPEAL_TYPE, AppealType.class)
+                            .map(type -> type == PA).orElse(false);
+
+                    return callbackStage == PostSubmitCallbackStage.CCD_SUBMITTED
+                            && callback.getEvent() == Event.PAY_AND_SUBMIT_APPEAL
+                            && isInternalCase(asylumCase)
+                            && paymentFailed
+                            && isPaAppealType;
+                }, notificationGenerators
         );
     }
 
@@ -3597,6 +3709,7 @@ public class NotificationHandlerConfiguration {
 
                 return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                        && callback.getEvent() == Event.SUBMIT_APPEAL
+                       && !isInternalCase(asylumCase)
                        && asylumCase.read(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.class).isPresent()
                        && (isPaAppealType
                            && paAppealTypePaymentOption.equals("payNow"))
@@ -3604,6 +3717,35 @@ public class NotificationHandlerConfiguration {
             },
             notificationGenerators,
             getErrorHandler()
+        );
+    }
+
+    @Bean
+    public PreSubmitCallbackHandler<AsylumCase> submitAppealLrHoWaysToPayPaPayNowInternalNotificationHandler(
+            @Qualifier("submitAppealLrHoWaysToPayPaPayNowInternalNotificationGenerator")
+            List<NotificationGenerator> notificationGenerators) {
+
+        return new NotificationHandler(
+                (callbackStage, callback) -> {
+                    AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+                    boolean isPaAppealType = asylumCase
+                            .read(APPEAL_TYPE, AppealType.class)
+                            .map(type -> type == PA).orElse(false);
+
+                    String paAppealTypePaymentOption = asylumCase
+                            .read(AsylumCaseDefinition.PA_APPEAL_TYPE_PAYMENT_OPTION, String.class).orElse("");
+
+                    return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                            && callback.getEvent() == Event.SUBMIT_APPEAL
+                            && isInternalCase(asylumCase)
+                            && asylumCase.read(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.class).isPresent()
+                            && (isPaAppealType
+                            && paAppealTypePaymentOption.equals("payNow"))
+                            && !isAcceleratedDetainedAppeal(asylumCase);
+                },
+                notificationGenerators,
+                getErrorHandler()
         );
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -88,9 +88,9 @@ govnotify:
       caseOfficer:
         email: 5964b437-eee1-48e2-b0b6-daf71be9decb
       homeOffice:
-        email: 9ecbd284-315e-489f-9c52-f17a44424ba5
+        email: 28892700-c3f2-4ed5-92e5-3519dac399c9
         pendingPaymentEaHu:
-          email: bcea839a-9829-4200-8217-059479dd20cf
+          email: a579dcf7-6ddd-43ba-9b2c-495c1b1f8f7c
       adminOfficer:
         pendingPaymentPa:
           email: b90bbc57-1ee9-40cb-9037-fe5a2552a136


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7031


### Change description ###
* Created handlers to duplicate LR submitAppeal handlers (which trigger notifs for AO/CO/HO) but for unrepped journey
* Updated LR submitAppeal handlers to check if internalCase (where notif was going out to AO/CO/HO)
* Created new generators to complement the newly created handlers and use AO/CO/HO personalisations
* Created functional tests for unrepped cases which complement the LR submitAppeal FTs. These include FTs from RIAs 3488/1976/2936.

Note - There are a lot of FTs. This is because some of the FTs have a duplicate test which tests the same scenario except in a different pre-state (appealSubmitted/paymentPending). This has been done intentionally to cover all scenarios, in the same way the FTs for submitAppeal have been implemented (when LR is triggering the event).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
