### PR TITLE
RIA-6948 MakeAnApplication notifications

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-6072-aip-make-an-application-notification-home-office-apc-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-6072-aip-make-an-application-notification-home-office-apc-after-listing.json
@@ -177,7 +177,7 @@
       {
         "reference": "6072001_MAKE_AN_APPLICATION_APPELLANT_AIP_EMAIL",
         "recipient": "{$TEST_CITIZEN_USERNAME}",
-        "subject": "Immigration and Asylum appeal: The Home Office want to Withdraw",
+        "subject": "Immigration and Asylum appeal: The Home Office want to withdraw from the appeal",
         "body": [
           "PA/12345/2019",
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6072-aip-make-an-application-notification-home-office-apc-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-6072-aip-make-an-application-notification-home-office-apc-before-listing.json
@@ -109,7 +109,7 @@
       {
         "reference": "6072002_MAKE_AN_APPLICATION_APPELLANT_AIP_EMAIL",
         "recipient": "{$TEST_CITIZEN_USERNAME}",
-        "subject": "Immigration and Asylum appeal: The Home Office want to Withdraw",
+        "subject": "Immigration and Asylum appeal: The Home Office want to withdraw from the appeal",
         "body": [
           "PA/12345/2019",
           "A1234567",

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/MakeAnApplicationTypes.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/MakeAnApplicationTypes.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum  MakeAnApplicationTypes {
+
+    ADJOURN("Adjourn"),
+    EXPEDITE("Expedite"),
+    JUDGE_REVIEW("Judge's review of application decision"),
+    LINK_OR_UNLINK("Link/unlink appeals"),
+    TIME_EXTENSION("Time extension"),
+    TRANSFER("Transfer"),
+    WITHDRAW("Withdraw"),
+    UPDATE_HEARING_REQUIREMENTS("Update hearing requirements"),
+    UPDATE_APPEAL_DETAILS("Update appeal details"),
+    REINSTATE("Reinstate an ended appeal"),
+    OTHER("Other");
+
+    @JsonValue
+    private final String value;
+
+    MakeAnApplicationTypes(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantMakeAnApplicationPersonalisationEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantMakeAnApplicationPersonalisationEmail.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.UserDetailsProvider;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplication;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.NotificationType;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.RecipientsFinder;
@@ -81,6 +80,10 @@ public class AppellantMakeAnApplicationPersonalisationEmail implements EmailNoti
     public Map<String, String> getPersonalisation(AsylumCase asylumCase) {
         requireNonNull(asylumCase, "asylumCase must not be null");
 
+        String applicationType = makeAnApplicationService.getMakeAnApplication(asylumCase, false)
+            .map(makeAnApplicationService::mapApplicationTypeToPhrase)
+            .orElse("");
+
         return
             ImmutableMap
                 .<String, String>builder()
@@ -89,7 +92,7 @@ public class AppellantMakeAnApplicationPersonalisationEmail implements EmailNoti
                 .put("ariaListingReference", asylumCase.read(ARIA_LISTING_REFERENCE, String.class).orElse(""))
                 .put("Given names", asylumCase.read(AsylumCaseDefinition.APPELLANT_GIVEN_NAMES, String.class).orElse(""))
                 .put("Family name", asylumCase.read(AsylumCaseDefinition.APPELLANT_FAMILY_NAME, String.class).orElse(""))
-                .put("applicationType", makeAnApplicationService.getMakeAnApplication(asylumCase, false).map(MakeAnApplication::getType).orElse(""))
+                .put("applicationType", applicationType)
                 .put("Hyperlink to service", iaAipFrontendUrl)
                 .build();
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantMakeAnApplicationPersonalisationEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantMakeAnApplicationPersonalisationEmail.java
@@ -81,7 +81,9 @@ public class AppellantMakeAnApplicationPersonalisationEmail implements EmailNoti
         requireNonNull(asylumCase, "asylumCase must not be null");
 
         String applicationType = makeAnApplicationService.getMakeAnApplication(asylumCase, false)
-            .map(makeAnApplicationService::mapApplicationTypeToPhrase)
+            .map(application -> !hasRole(ROLE_CITIZEN)
+                ? makeAnApplicationService.mapApplicationTypeToPhrase(application)
+                : application.getType())
             .orElse("");
 
         return

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/sms/AppellantMakeAnApplicationPersonalisationSms.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/sms/AppellantMakeAnApplicationPersonalisationSms.java
@@ -64,7 +64,9 @@ public class AppellantMakeAnApplicationPersonalisationSms implements SmsNotifica
         requireNonNull(asylumCase, "asylumCase must not be null");
 
         String applicationType = makeAnApplicationService.getMakeAnApplication(asylumCase, false)
-            .map(makeAnApplicationService::mapApplicationTypeToPhrase)
+            .map(application -> !hasRole(ROLE_CITIZEN)
+                ? makeAnApplicationService.mapApplicationTypeToPhrase(application)
+                : application.getType())
             .orElse("");
 
         return

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/sms/AppellantMakeAnApplicationPersonalisationSms.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/sms/AppellantMakeAnApplicationPersonalisationSms.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.UserDetailsProvider;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplication;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.NotificationType;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.SmsNotificationPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.RecipientsFinder;
@@ -64,11 +63,15 @@ public class AppellantMakeAnApplicationPersonalisationSms implements SmsNotifica
     public Map<String, String> getPersonalisation(AsylumCase asylumCase) {
         requireNonNull(asylumCase, "asylumCase must not be null");
 
+        String applicationType = makeAnApplicationService.getMakeAnApplication(asylumCase, false)
+            .map(makeAnApplicationService::mapApplicationTypeToPhrase)
+            .orElse("");
+
         return
             ImmutableMap
                 .<String, String>builder()
                 .put("Appeal Ref Number", asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
-                .put("applicationType", makeAnApplicationService.getMakeAnApplication(asylumCase, false).map(MakeAnApplication::getType).orElse(""))
+                .put("applicationType", applicationType)
                 .put("Hyperlink to service", iaAipFrontendUrl)
                 .build();
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/MakeAnApplicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/MakeAnApplicationService.java
@@ -2,19 +2,48 @@ package uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure;
 
 
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.DECIDE_AN_APPLICATION_ID;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplicationTypes.ADJOURN;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplicationTypes.EXPEDITE;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplicationTypes.JUDGE_REVIEW;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplicationTypes.LINK_OR_UNLINK;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplicationTypes.OTHER;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplicationTypes.REINSTATE;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplicationTypes.TIME_EXTENSION;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplicationTypes.TRANSFER;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplicationTypes.UPDATE_APPEAL_DETAILS;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplicationTypes.UPDATE_HEARING_REQUIREMENTS;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplicationTypes.WITHDRAW;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplication;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
 
 @Service
 public class MakeAnApplicationService {
+
+    private final static Map<String,String> APPLICATION_PHRASE = Map.ofEntries(
+        Map.entry(ADJOURN.toString(), "change the hearing date"),
+        Map.entry(EXPEDITE.toString(), "have the hearing sooner"),
+        Map.entry(JUDGE_REVIEW.toString(), "ask a judge to review the decision"),
+        Map.entry(LINK_OR_UNLINK.toString(), "link or unlink the appeal"),
+        Map.entry(TIME_EXTENSION.toString(), "ask for more time"),
+        Map.entry(TRANSFER.toString(), "move the hearing to a different location"),
+        Map.entry(WITHDRAW.toString(), "withdraw from the appeal"),
+        Map.entry(UPDATE_HEARING_REQUIREMENTS.toString(), "change some of the hearing requirements"),
+        Map.entry(UPDATE_APPEAL_DETAILS.toString(), "change some of the appeal details"),
+        Map.entry(REINSTATE.toString(), "reinstate the appeal"),
+        Map.entry(OTHER.toString(), "change something about the appeal")
+    );
+
     public Optional<MakeAnApplication> getMakeAnApplication(AsylumCase asylumCase, boolean decided) {
         Optional<MakeAnApplication> makeApplicationOptional = Optional.empty();
         Optional<List<IdValue<MakeAnApplication>>> makeAnApplicationsOptional = asylumCase.read(AsylumCaseDefinition.MAKE_AN_APPLICATIONS);
@@ -49,5 +78,9 @@ public class MakeAnApplicationService {
         } else {
             return false;
         }
+    }
+
+    public String mapApplicationTypeToPhrase(MakeAnApplication application) {
+        return APPLICATION_PHRASE.get(application.getType());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/MakeAnApplicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/MakeAnApplicationService.java
@@ -30,18 +30,18 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdVa
 @Service
 public class MakeAnApplicationService {
 
-    private final static Map<String,String> APPLICATION_PHRASE = Map.ofEntries(
-        Map.entry(ADJOURN.toString(), "change the hearing date"),
-        Map.entry(EXPEDITE.toString(), "have the hearing sooner"),
-        Map.entry(JUDGE_REVIEW.toString(), "ask a judge to review the decision"),
-        Map.entry(LINK_OR_UNLINK.toString(), "link or unlink the appeal"),
-        Map.entry(TIME_EXTENSION.toString(), "ask for more time"),
-        Map.entry(TRANSFER.toString(), "move the hearing to a different location"),
-        Map.entry(WITHDRAW.toString(), "withdraw from the appeal"),
-        Map.entry(UPDATE_HEARING_REQUIREMENTS.toString(), "change some of the hearing requirements"),
-        Map.entry(UPDATE_APPEAL_DETAILS.toString(), "change some of the appeal details"),
-        Map.entry(REINSTATE.toString(), "reinstate the appeal"),
-        Map.entry(OTHER.toString(), "change something about the appeal")
+    private static final Map<String,String> APPLICATION_PHRASE = Map.ofEntries(
+        Map.entry(ADJOURN.name(), "change the hearing date"),
+        Map.entry(EXPEDITE.name(), "have the hearing sooner"),
+        Map.entry(JUDGE_REVIEW.name(), "ask a judge to review the decision"),
+        Map.entry(LINK_OR_UNLINK.name(), "link or unlink the appeal"),
+        Map.entry(TIME_EXTENSION.name(), "ask for more time"),
+        Map.entry(TRANSFER.name(), "move the hearing to a different location"),
+        Map.entry(WITHDRAW.name(), "withdraw from the appeal"),
+        Map.entry(UPDATE_HEARING_REQUIREMENTS.name(), "change some of the hearing requirements"),
+        Map.entry(UPDATE_APPEAL_DETAILS.name(), "change some of the appeal details"),
+        Map.entry(REINSTATE.name(), "reinstate the appeal"),
+        Map.entry(OTHER.name(), "change something about the appeal")
     );
 
     public Optional<MakeAnApplication> getMakeAnApplication(AsylumCase asylumCase, boolean decided) {

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/MakeAnApplicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/MakeAnApplicationService.java
@@ -31,17 +31,17 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdVa
 public class MakeAnApplicationService {
 
     private static final Map<String,String> APPLICATION_PHRASE = Map.ofEntries(
-        Map.entry(ADJOURN.name(), "change the hearing date"),
-        Map.entry(EXPEDITE.name(), "have the hearing sooner"),
-        Map.entry(JUDGE_REVIEW.name(), "ask a judge to review the decision"),
-        Map.entry(LINK_OR_UNLINK.name(), "link or unlink the appeal"),
-        Map.entry(TIME_EXTENSION.name(), "ask for more time"),
-        Map.entry(TRANSFER.name(), "move the hearing to a different location"),
-        Map.entry(WITHDRAW.name(), "withdraw from the appeal"),
-        Map.entry(UPDATE_HEARING_REQUIREMENTS.name(), "change some of the hearing requirements"),
-        Map.entry(UPDATE_APPEAL_DETAILS.name(), "change some of the appeal details"),
-        Map.entry(REINSTATE.name(), "reinstate the appeal"),
-        Map.entry(OTHER.name(), "change something about the appeal")
+        Map.entry(ADJOURN.toString(), "change the hearing date"),
+        Map.entry(EXPEDITE.toString(), "have the hearing sooner"),
+        Map.entry(JUDGE_REVIEW.toString(), "ask a judge to review the decision"),
+        Map.entry(LINK_OR_UNLINK.toString(), "link or unlink the appeal"),
+        Map.entry(TIME_EXTENSION.toString(), "ask for more time"),
+        Map.entry(TRANSFER.toString(), "move the hearing to a different location"),
+        Map.entry(WITHDRAW.toString(), "withdraw from the appeal"),
+        Map.entry(UPDATE_HEARING_REQUIREMENTS.toString(), "change some of the hearing requirements"),
+        Map.entry(UPDATE_APPEAL_DETAILS.toString(), "change some of the appeal details"),
+        Map.entry(REINSTATE.toString(), "reinstate the appeal"),
+        Map.entry(OTHER.toString(), "change something about the appeal")
     );
 
     public Optional<MakeAnApplication> getMakeAnApplication(AsylumCase asylumCase, boolean decided) {

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantMakeAnApplicationPersonalisationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantMakeAnApplicationPersonalisationEmailTest.java
@@ -54,7 +54,7 @@ public class AppellantMakeAnApplicationPersonalisationEmailTest {
     private String otherBeforeListingEmailTemplateId = "otherBeforeListingEmailTemplateId";
     private String otherAfterListingEmailTemplateId = "otherAfterListingEmailtemplateId";
     private String iaAipFrontendUrl = "http://localhost";
-    private String applicationType = "someApplicationType";
+    private String applicationTypePhrase = "some application type";
 
     private String mockedAppealReferenceNumber = "someReferenceNumber";
     private String mockedAppealHomeOfficeReferenceNumber = "someHomeOfficeReferenceNumber";
@@ -78,7 +78,6 @@ public class AppellantMakeAnApplicationPersonalisationEmailTest {
         when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(mockedAppellantGivenNames));
         when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(mockedAppellantFamilyName));
         when(makeAnApplicationService.getMakeAnApplication(asylumCase, false)).thenReturn(Optional.of(makeAnApplication));
-        when(makeAnApplication.getType()).thenReturn(applicationType);
         when(userDetailsProvider.getUserDetails()).thenReturn(userDetails);
 
         appellantMakeAnApplicationPersonalisationEmail = new AppellantMakeAnApplicationPersonalisationEmail(
@@ -138,6 +137,8 @@ public class AppellantMakeAnApplicationPersonalisationEmailTest {
     @Test
     public void should_return_personalisation_when_all_information_given() {
 
+        when(makeAnApplicationService.mapApplicationTypeToPhrase(makeAnApplication))
+            .thenReturn(applicationTypePhrase);
         Map<String, String> personalisation =
             appellantMakeAnApplicationPersonalisationEmail.getPersonalisation(asylumCase);
 
@@ -146,7 +147,7 @@ public class AppellantMakeAnApplicationPersonalisationEmailTest {
         assertEquals(mockedAppellantGivenNames, personalisation.get("Given names"));
         assertEquals(mockedAppellantFamilyName, personalisation.get("Family name"));
         assertEquals(iaAipFrontendUrl, personalisation.get("Hyperlink to service"));
-        assertEquals(applicationType, personalisation.get("applicationType"));
+        assertEquals(applicationTypePhrase, personalisation.get("applicationType"));
 
         verify(makeAnApplicationService).getMakeAnApplication(asylumCase, false);
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantMakeAnApplicationPersonalisationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantMakeAnApplicationPersonalisationEmailTest.java
@@ -11,11 +11,14 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -54,6 +57,7 @@ public class AppellantMakeAnApplicationPersonalisationEmailTest {
     private String otherBeforeListingEmailTemplateId = "otherBeforeListingEmailTemplateId";
     private String otherAfterListingEmailTemplateId = "otherAfterListingEmailtemplateId";
     private String iaAipFrontendUrl = "http://localhost";
+    private String applicationType = "someApplicationType";
     private String applicationTypePhrase = "some application type";
 
     private String mockedAppealReferenceNumber = "someReferenceNumber";
@@ -62,8 +66,8 @@ public class AppellantMakeAnApplicationPersonalisationEmailTest {
     private String mockedAppellantGivenNames = "someAppellantGivenNames";
     private String mockedAppellantFamilyName = "someAppellantFamilyName";
     private String mockedAppellantEmailAddress = "appelant@example.net";
-    private String homeOfficeUser = "caseworker-ia-homeofficelart";
-    private String citizenUser = "citizen";
+    private final String homeOfficeUser = "caseworker-ia-homeofficelart";
+    private final String citizenUser = "citizen";
 
     private AppellantMakeAnApplicationPersonalisationEmail appellantMakeAnApplicationPersonalisationEmail;
 
@@ -134,11 +138,16 @@ public class AppellantMakeAnApplicationPersonalisationEmailTest {
             .hasMessage("asylumCase must not be null");
     }
 
-    @Test
-    public void should_return_personalisation_when_all_information_given() {
-
+    @ParameterizedTest
+    @ValueSource(strings = { citizenUser, homeOfficeUser })
+    public void should_return_personalisation_when_all_information_given(String user) {
+        when(userDetails.getRoles()).thenReturn(List.of(user));
+        when(makeAnApplicationService.getMakeAnApplication(asylumCase, false))
+            .thenReturn(Optional.of(makeAnApplication));
+        when(makeAnApplication.getType()).thenReturn(applicationType);
         when(makeAnApplicationService.mapApplicationTypeToPhrase(makeAnApplication))
             .thenReturn(applicationTypePhrase);
+
         Map<String, String> personalisation =
             appellantMakeAnApplicationPersonalisationEmail.getPersonalisation(asylumCase);
 
@@ -147,7 +156,8 @@ public class AppellantMakeAnApplicationPersonalisationEmailTest {
         assertEquals(mockedAppellantGivenNames, personalisation.get("Given names"));
         assertEquals(mockedAppellantFamilyName, personalisation.get("Family name"));
         assertEquals(iaAipFrontendUrl, personalisation.get("Hyperlink to service"));
-        assertEquals(applicationTypePhrase, personalisation.get("applicationType"));
+        assertEquals(user.equals(citizenUser) ? applicationType : applicationTypePhrase,
+            personalisation.get("applicationType"));
 
         verify(makeAnApplicationService).getMakeAnApplication(asylumCase, false);
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/sms/AppellantMakeAnApplicationPersonalisationSmsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/sms/AppellantMakeAnApplicationPersonalisationSmsTest.java
@@ -10,17 +10,25 @@ import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumC
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.UserDetailsProvider;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplication;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.NotificationType;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.Subscriber;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.SubscriberType;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.UserDetails;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.RecipientsFinder;
@@ -50,9 +58,10 @@ public class AppellantMakeAnApplicationPersonalisationSmsTest {
 
     private String mockedAppealReferenceNumber = "someReferenceNumber";
     private String mockedAppellantMobilePhone = "07123456789";
+    private String applicationType = "someApplicationType";
     private String applicationTypePhrase = "some application type";
-    private String homeOfficeUser = "caseworker-ia-homeofficelart";
-    private String citizenUser = "citizen";
+    private final String homeOfficeUser = "caseworker-ia-homeofficelart";
+    private final String citizenUser = "citizen";
 
     private AppellantMakeAnApplicationPersonalisationSms appellantMakeAnApplicationPersonalisationSms;
 
@@ -117,8 +126,13 @@ public class AppellantMakeAnApplicationPersonalisationSmsTest {
             .hasMessage("asylumCase must not be null");
     }
 
-    @Test
-    public void should_return_personalisation_when_all_information_given() {
+    @ParameterizedTest
+    @ValueSource(strings = { citizenUser, homeOfficeUser })
+    public void should_return_personalisation_when_all_information_given(String user) {
+        when(userDetails.getRoles()).thenReturn(List.of(user));
+        when(makeAnApplicationService.getMakeAnApplication(asylumCase, false))
+            .thenReturn(Optional.of(makeAnApplication));
+        when(makeAnApplication.getType()).thenReturn(applicationType);
         when(makeAnApplicationService.mapApplicationTypeToPhrase(makeAnApplication))
             .thenReturn(applicationTypePhrase);
 
@@ -127,10 +141,11 @@ public class AppellantMakeAnApplicationPersonalisationSmsTest {
 
         assertEquals(mockedAppealReferenceNumber, personalisation.get("Appeal Ref Number"));
         assertEquals(iaAipFrontendUrl, personalisation.get("Hyperlink to service"));
-        assertEquals(applicationTypePhrase, personalisation.get("applicationType"));
+
+        assertEquals(user.equals(citizenUser) ? applicationType : applicationTypePhrase,
+            personalisation.get("applicationType"));
 
         verify(makeAnApplicationService).getMakeAnApplication(asylumCase, false);
-
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/sms/AppellantMakeAnApplicationPersonalisationSmsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/sms/AppellantMakeAnApplicationPersonalisationSmsTest.java
@@ -50,7 +50,7 @@ public class AppellantMakeAnApplicationPersonalisationSmsTest {
 
     private String mockedAppealReferenceNumber = "someReferenceNumber";
     private String mockedAppellantMobilePhone = "07123456789";
-    private String applicationType = "someApplicationType";
+    private String applicationTypePhrase = "some application type";
     private String homeOfficeUser = "caseworker-ia-homeofficelart";
     private String citizenUser = "citizen";
 
@@ -70,7 +70,6 @@ public class AppellantMakeAnApplicationPersonalisationSmsTest {
                 makeAnApplicationService,
                 userDetailsProvider);
         when(makeAnApplicationService.getMakeAnApplication(asylumCase, false)).thenReturn(Optional.of(makeAnApplication));
-        when(makeAnApplication.getType()).thenReturn(applicationType);
         when(userDetailsProvider.getUserDetails()).thenReturn(userDetails);
     }
 
@@ -120,13 +119,15 @@ public class AppellantMakeAnApplicationPersonalisationSmsTest {
 
     @Test
     public void should_return_personalisation_when_all_information_given() {
+        when(makeAnApplicationService.mapApplicationTypeToPhrase(makeAnApplication))
+            .thenReturn(applicationTypePhrase);
 
         Map<String, String> personalisation =
             appellantMakeAnApplicationPersonalisationSms.getPersonalisation(asylumCase);
 
         assertEquals(mockedAppealReferenceNumber, personalisation.get("Appeal Ref Number"));
         assertEquals(iaAipFrontendUrl, personalisation.get("Hyperlink to service"));
-        assertEquals(applicationType, personalisation.get("applicationType"));
+        assertEquals(applicationTypePhrase, personalisation.get("applicationType"));
 
         verify(makeAnApplicationService).getMakeAnApplication(asylumCase, false);
 

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/MakeAnApplicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/MakeAnApplicationServiceTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.DECIDE_AN_APPLICATION_ID;
@@ -13,12 +14,15 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplication;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.MakeAnApplicationTypes;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
 
@@ -29,6 +33,8 @@ public class MakeAnApplicationServiceTest {
     private AsylumCase asylumCase;
     @Mock
     private List<IdValue<MakeAnApplication>> applications;
+    @Mock
+    private MakeAnApplication makeAnApplication;
 
     private MakeAnApplicationService makeAnApplicationService;
     private String decideAnApplicationId = "2";
@@ -90,5 +96,60 @@ public class MakeAnApplicationServiceTest {
 
         state = State.ADJOURNED;
         assertTrue(makeAnApplicationService.isApplicationListed(state));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = MakeAnApplicationTypes.class)
+    public void shouldMapApplicationTypeToPhrase(MakeAnApplicationTypes makeAnApplicationTypes) {
+        when(makeAnApplication.getType()).thenReturn(makeAnApplicationTypes.name());
+
+        String expectedPhrase = makeAnApplicationService.mapApplicationTypeToPhrase(makeAnApplication);
+
+        switch (makeAnApplicationTypes) {
+            case ADJOURN:
+                assertEquals(expectedPhrase, "change the hearing date");
+                break;
+            case EXPEDITE:
+                assertEquals(expectedPhrase, "have the hearing sooner");
+                break;
+            case JUDGE_REVIEW:
+                assertEquals(expectedPhrase, "ask a judge to review the decision");
+                break;
+            case LINK_OR_UNLINK:
+                assertEquals(expectedPhrase, "link or unlink the appeal");
+                break;
+            case TIME_EXTENSION:
+                assertEquals(expectedPhrase, "ask for more time");
+                break;
+            case TRANSFER:
+                assertEquals(expectedPhrase, "move the hearing to a different location");
+                break;
+            case WITHDRAW:
+                assertEquals(expectedPhrase, "withdraw from the appeal");
+                break;
+            case UPDATE_HEARING_REQUIREMENTS:
+                assertEquals(expectedPhrase, "change some of the hearing requirements");
+                break;
+            case UPDATE_APPEAL_DETAILS:
+                assertEquals(expectedPhrase, "change some of the appeal details");
+                break;
+            case REINSTATE:
+                assertEquals(expectedPhrase, "reinstate the appeal");
+                break;
+            case OTHER:
+                assertEquals(expectedPhrase, "change something about the appeal");
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Test
+    public void should_throw_exception_if_make_an_application_type_is_invalid() {
+        when(makeAnApplication.getType()).thenReturn("unsupportedApplicationType");
+
+        assertThrowsExactly(IllegalArgumentException.class,
+            () -> makeAnApplicationService.mapApplicationTypeToPhrase(makeAnApplication),
+            "applicationType not mappable to a phrase");
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/MakeAnApplicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/MakeAnApplicationServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.DECIDE_AN_APPLICATION_ID;
@@ -142,14 +141,5 @@ public class MakeAnApplicationServiceTest {
             default:
                 break;
         }
-    }
-
-    @Test
-    public void should_throw_exception_if_make_an_application_type_is_invalid() {
-        when(makeAnApplication.getType()).thenReturn("unsupportedApplicationType");
-
-        assertThrowsExactly(IllegalArgumentException.class,
-            () -> makeAnApplicationService.mapApplicationTypeToPhrase(makeAnApplication),
-            "applicationType not mappable to a phrase");
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/MakeAnApplicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/MakeAnApplicationServiceTest.java
@@ -100,7 +100,7 @@ public class MakeAnApplicationServiceTest {
     @ParameterizedTest
     @EnumSource(value = MakeAnApplicationTypes.class)
     public void shouldMapApplicationTypeToPhrase(MakeAnApplicationTypes makeAnApplicationTypes) {
-        when(makeAnApplication.getType()).thenReturn(makeAnApplicationTypes.name());
+        when(makeAnApplication.getType()).thenReturn(makeAnApplicationTypes.toString());
 
         String expectedPhrase = makeAnApplicationService.mapApplicationTypeToPhrase(makeAnApplication);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6948](https://tools.hmcts.net/jira/browse/RIA-6948)


### Change description ###
- Add verbalization mapping for the `applicationType` variable used in AIP notifications for the `MAKE_AN_APPLICATION` event


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
