### PR TITLE
RIA-7033 decideAnApplication internal notifications + HO/LR application refused content change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ ARG APP_INSIGHTS_AGENT_VERSION=2.5.1-BETA
 # Application image
 
 FROM hmctspublic.azurecr.io/base/java:11-distroless
-
 # Mandatory!
 ENV APP ia-case-notifications-api.jar
 ENV APPLICATION_TOTAL_MEMORY 1024M

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-admin-officer-granted-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-admin-officer-granted-after-listing.json
@@ -1,0 +1,68 @@
+{
+  "description": "RIA-7033 - Internal case - send decide an (admofficer) application (granted) notification after listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 70331,
+      "eventId": "decideAnApplication",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "ariaListingReference": "PA/12345/2019",
+          "listCaseHearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Granted",
+                "state":"prepareForHearing",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "ariaListingReference": "PA/12345/2019",
+        "listCaseHearingCentre": "taylorHouse",
+        "notificationsSent": [
+          {
+            "id": "70331_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "70331_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: An appellant application has been granted",
+        "body": [
+          "PA/12345/2019",
+          "A1234567",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-admin-officer-granted-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-admin-officer-granted-before-listing.json
@@ -1,0 +1,64 @@
+{
+  "description": "RIA-7033 - Internal case - Send decide an (admofficer) application (granted) notification before listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 70332,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"",
+                "decision":"Granted",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "notificationsSent": [
+          {
+            "id": "70332_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "70332_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$apcHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: An appellant application has been granted",
+        "body": [
+          "PA/12345/2019",
+          "A123456",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-admin-officer-refused-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-admin-officer-refused-after-listing.json
@@ -1,0 +1,68 @@
+{
+  "description": "RIA-7033 Internal case Send decide an (admofficer) application refused notification after listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 70333,
+      "eventId": "decideAnApplication",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "ariaListingReference": "PA/12345/2019",
+          "listCaseHearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Refused",
+                "state":"prepareForHearing",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "ariaListingReference": "PA/12345/2019",
+        "listCaseHearingCentre": "taylorHouse",
+        "notificationsSent": [
+          {
+            "id": "70333_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "70333_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: An appellant application has been refused",
+        "body": [
+          "PA/12345/2019",
+          "A1234567",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-admin-officer-refused-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-admin-officer-refused-before-listing.json
@@ -1,0 +1,64 @@
+{
+  "description": "RIA-7033 Internal case Send decide an (admofficer) application refused notification before listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 70334,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"",
+                "decision":"Refused",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "notificationsSent": [
+          {
+            "id": "70334_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "70334_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$apcHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: An appellant application has been refused",
+        "body": [
+          "PA/12345/2019",
+          "A123456",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-apc-granted-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-apc-granted-after-listing.json
@@ -1,0 +1,68 @@
+{
+  "description": "RIA-7033 Internal case Send decide an application notification home office APC granted after listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 70335,
+      "eventId": "decideAnApplication",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "ariaListingReference": "PA/12345/2019",
+          "listCaseHearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Granted",
+                "state":"prepareForHearing",
+                "applicantRole":"caseworker-ia-homeofficeapc",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "ariaListingReference": "PA/12345/2019",
+        "listCaseHearingCentre": "taylorHouse",
+        "notificationsSent": [
+          {
+            "id": "70335_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "70335_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$apcHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: Your application has been granted",
+        "body": [
+          "PA/12345/2019",
+          "A1234567",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-apc-granted-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-apc-granted-before-listing.json
@@ -1,0 +1,64 @@
+{
+  "description": "RIA-7033 Internal case Send decide an application notification home office APC granted before listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 70336,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"",
+                "decision":"Granted",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-homeofficeapc",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "notificationsSent": [
+          {
+            "id": "70336_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "70336_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$apcHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: Your application has been granted",
+        "body": [
+          "PA/12345/2019",
+          "A123456",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-apc-refused-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-apc-refused-after-listing.json
@@ -1,0 +1,68 @@
+{
+  "description": "RIA-7033 Internal case Send make an application notification home office APC refused after listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 70337,
+      "eventId": "decideAnApplication",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "ariaListingReference": "PA/12345/2019",
+          "listCaseHearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Refused",
+                "state":"prepareForHearing",
+                "applicantRole":"caseworker-ia-homeofficeapc",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "ariaListingReference": "PA/12345/2019",
+        "listCaseHearingCentre": "taylorHouse",
+        "notificationsSent": [
+          {
+            "id": "70337_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "70337_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$apcHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: application for Other refused",
+        "body": [
+          "PA/12345/2019",
+          "A1234567",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-apc-granted-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-apc-granted-after-listing.json
@@ -1,0 +1,68 @@
+{
+  "description": "RIA-7033 Internal case Send decide an application notification home office Generic APC granted after listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 70338,
+      "eventId": "decideAnApplication",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "ariaListingReference": "PA/12345/2019",
+          "listCaseHearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Granted",
+                "state":"prepareForHearing",
+                "applicantRole":"caseworker-ia-respondentofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "ariaListingReference": "PA/12345/2019",
+        "listCaseHearingCentre": "taylorHouse",
+        "notificationsSent": [
+          {
+            "id": "70338_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "70338_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: Your application has been granted",
+        "body": [
+          "PA/12345/2019",
+          "A1234567",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-apc-granted-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-apc-granted-before-listing.json
@@ -1,0 +1,64 @@
+{
+  "description": "RIA-7033 Internal case Send decide an application notification home office Generic APC granted before listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 70339,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"",
+                "decision":"Granted",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-respondentofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "notificationsSent": [
+          {
+            "id": "70339_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "70339_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$apcHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: Your application has been granted",
+        "body": [
+          "PA/12345/2019",
+          "A123456",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-apc-refuse-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-apc-refuse-before-listing.json
@@ -1,0 +1,64 @@
+{
+  "description": "RIA-7033 Internal case Send decide an application notification home office Generic APC refused before listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703310,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"",
+                "decision":"Refused",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-respondentofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "notificationsSent": [
+          {
+            "id": "703310_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703310_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$apcHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: application for Other refused",
+        "body": [
+          "PA/12345/2019",
+          "A123456",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-apc-refused-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-apc-refused-after-listing.json
@@ -1,0 +1,68 @@
+{
+  "description": "RIA-7033 Internal case Send make an application notification home office Generic APC refused after listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703311,
+      "eventId": "decideAnApplication",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "ariaListingReference": "PA/12345/2019",
+          "listCaseHearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Refused",
+                "state":"prepareForHearing",
+                "applicantRole":"caseworker-ia-respondentofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "ariaListingReference": "PA/12345/2019",
+        "listCaseHearingCentre": "taylorHouse",
+        "notificationsSent": [
+          {
+            "id": "703311_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703311_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: application for Other refused",
+        "body": [
+          "PA/12345/2019",
+          "A1234567",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-lart-granted-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-lart-granted-after-listing.json
@@ -1,0 +1,68 @@
+{
+  "description": "RIA-7033 Internal case Send decide an application notification home office Generic LART granted after listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703312,
+      "eventId": "decideAnApplication",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "ariaListingReference": "PA/12345/2019",
+          "listCaseHearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Granted",
+                "state":"respondentReview",
+                "applicantRole":"caseworker-ia-respondentofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "ariaListingReference": "PA/12345/2019",
+        "listCaseHearingCentre": "taylorHouse",
+        "notificationsSent": [
+          {
+            "id": "703312_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703312_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$lartHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: Your application has been granted",
+        "body": [
+          "PA/12345/2019",
+          "A1234567",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-lart-granted-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-lart-granted-before-listing.json
@@ -1,0 +1,65 @@
+{
+  "description": "RIA-7033 Internal case Send decide an application notification home office Generic LART granted before listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703313,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "decideAnApplicationId": "1",
+          "listCaseHearingCentre": "taylorHouse",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"",
+                "decision":"Granted",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-respondentofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "notificationsSent": [
+          {
+            "id": "703313_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703313_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$apcHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: Your application has been granted",
+        "body": [
+          "PA/12345/2019",
+          "A123456",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-lart-refuse-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-lart-refuse-before-listing.json
@@ -1,0 +1,65 @@
+{
+  "description": "RIA-7033 Internal case Send decide an application notification home office Generic LART refused before listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703314,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "decideAnApplicationId": "1",
+          "listCaseHearingCentre": "taylorHouse",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"",
+                "decision":"Refused",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-respondentofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "notificationsSent": [
+          {
+            "id": "703314_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703314_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$apcHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: application for Other refused",
+        "body": [
+          "PA/12345/2019",
+          "A123456",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-lart-refused-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-lart-refused-after-listing.json
@@ -1,0 +1,68 @@
+{
+  "description": "RIA-7033 Internal case Send make an application notification home office Generic LART refused after listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703315,
+      "eventId": "decideAnApplication",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "ariaListingReference": "PA/12345/2019",
+          "listCaseHearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Refused",
+                "state":"prepareForHearing",
+                "applicantRole":"caseworker-ia-respondentofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "ariaListingReference": "PA/12345/2019",
+        "listCaseHearingCentre": "taylorHouse",
+        "notificationsSent": [
+          {
+            "id": "703315_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703315_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: application for Other refused",
+        "body": [
+          "PA/12345/2019",
+          "A1234567",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-pou-granted-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-pou-granted-after-listing.json
@@ -1,0 +1,68 @@
+{
+  "description": "RIA-7033 Internal case Send decide an application notification home office Generic POU granted after listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703316,
+      "eventId": "decideAnApplication",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "ariaListingReference": "PA/12345/2019",
+          "listCaseHearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Granted",
+                "state":"prepareForHearing",
+                "applicantRole":"caseworker-ia-respondentofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "ariaListingReference": "PA/12345/2019",
+        "listCaseHearingCentre": "taylorHouse",
+        "notificationsSent": [
+          {
+            "id": "703316_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703316_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: Your application has been granted",
+        "body": [
+          "PA/12345/2019",
+          "A1234567",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-pou-granted-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-pou-granted-before-listing.json
@@ -1,0 +1,65 @@
+{
+  "description": "RIA-7033 Internal case Send decide an application notification home office Generic POU granted before listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703317,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "listCaseHearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"",
+                "decision":"Granted",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-respondentofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "notificationsSent": [
+          {
+            "id": "703317_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703317_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$apcHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: Your application has been granted",
+        "body": [
+          "PA/12345/2019",
+          "A123456",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-pou-granted-hc-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-pou-granted-hc-before-listing.json
@@ -1,0 +1,65 @@
+{
+  "description": "RIA-7033 Internal case Send decide an application notification home office Generic Hearing Centre POU granted before listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703318,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"",
+                "decision":"Granted",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-homeofficepou",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "notificationsSent": [
+          {
+            "id": "703318_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703318_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: Your application has been granted",
+        "body": [
+          "PA/12345/2019",
+          "A123456",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-pou-refuse-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-pou-refuse-before-listing.json
@@ -1,0 +1,65 @@
+{
+  "description": "RIA-7033 Internal case Send decide an application notification home office POU refused before listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703319,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "listCaseHearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"",
+                "decision":"Refused",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-respondentofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "notificationsSent": [
+          {
+            "id": "703319_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703319_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$apcHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: application for Other refused",
+        "body": [
+          "PA/12345/2019",
+          "A123456",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-pou-refused-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-generic-pou-refused-after-listing.json
@@ -1,0 +1,68 @@
+{
+  "description": "RIA-7033 Internal case Send make an application notification home office LART refused after listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703320,
+      "eventId": "decideAnApplication",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "ariaListingReference": "PA/12345/2019",
+          "listCaseHearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Refused",
+                "state":"prepareForHearing",
+                "applicantRole":"caseworker-ia-respondentofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "ariaListingReference": "PA/12345/2019",
+        "listCaseHearingCentre": "taylorHouse",
+        "notificationsSent": [
+          {
+            "id": "703320_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703320_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: application for Other refused",
+        "body": [
+          "PA/12345/2019",
+          "A1234567",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-lart-granted-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-lart-granted-after-listing.json
@@ -1,0 +1,68 @@
+{
+  "description": "RIA-7033 Internal case Send decide an application notification home office LART granted after listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703321,
+      "eventId": "decideAnApplication",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "ariaListingReference": "PA/12345/2019",
+          "listCaseHearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Granted",
+                "state":"respondentReview",
+                "applicantRole":"caseworker-ia-homeofficelart",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "ariaListingReference": "PA/12345/2019",
+        "listCaseHearingCentre": "taylorHouse",
+        "notificationsSent": [
+          {
+            "id": "703321_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703321_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$lartHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: Your application has been granted",
+        "body": [
+          "PA/12345/2019",
+          "A1234567",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-lart-granted-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-lart-granted-before-listing.json
@@ -1,0 +1,64 @@
+{
+  "description": "RIA-7033 Internal case Send decide an application notification home office LART granted before listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703322,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"",
+                "decision":"Granted",
+                "state":"prepareForHearing",
+                "applicantRole":"caseworker-ia-homeofficelart",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "notificationsSent": [
+          {
+            "id": "703322_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703322_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$lartHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: Your application has been granted",
+        "body": [
+          "PA/12345/2019",
+          "A123456",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-lart-refused-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-lart-refused-after-listing.json
@@ -1,0 +1,68 @@
+{
+  "description": "RIA-7033 Internal case Send make an application notification home office LART refused after listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703323,
+      "eventId": "decideAnApplication",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "ariaListingReference": "PA/12345/2019",
+          "listCaseHearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Refused",
+                "state":"prepareForHearing",
+                "applicantRole":"caseworker-ia-homeofficelart",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "ariaListingReference": "PA/12345/2019",
+        "listCaseHearingCentre": "taylorHouse",
+        "notificationsSent": [
+          {
+            "id": "703323_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703323_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$lartHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: application for Other refused",
+        "body": [
+          "PA/12345/2019",
+          "A1234567",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-lart-refused-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-lart-refused-before-listing.json
@@ -1,0 +1,64 @@
+{
+  "description": "RIA-7033 Internal case Send decide an application notification home office LART refused before listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703324,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"",
+                "decision":"Refused",
+                "state":"prepareForHearing",
+                "applicantRole":"caseworker-ia-homeofficelart",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "notificationsSent": [
+          {
+            "id": "703324_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703324_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$lartHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: application for Other refused",
+        "body": [
+          "PA/12345/2019",
+          "A123456",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-pou-granted-after-listing-remote-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-pou-granted-after-listing-remote-hearing.json
@@ -1,0 +1,71 @@
+{
+  "description": "RIA-7033 Internal case Send decide an application notification home office POU granted after listing in remote hearing",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703326,
+      "eventId": "decideAnApplication",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "ariaListingReference": "PA/12345/2019",
+          "listCaseHearingCentre": "remoteHearing",
+          "hearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Granted",
+                "state":"listing",
+                "applicantRole":"caseworker-ia-homeofficepou",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "ariaListingReference": "PA/12345/2019",
+        "listCaseHearingCentre": "remoteHearing",
+        "hearingCentre": "taylorHouse",
+        "notificationsSent": [
+          {
+            "id": "703326_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703326_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: Your application has been granted",
+        "body": [
+          "PA/12345/2019",
+          "A1234567",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-pou-granted-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-pou-granted-after-listing.json
@@ -1,0 +1,68 @@
+{
+  "description": "RIA-7033 Internal case Send decide an application notification home office POU granted after listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703325,
+      "eventId": "decideAnApplication",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "ariaListingReference": "PA/12345/2019",
+          "listCaseHearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Granted",
+                "state":"listing",
+                "applicantRole":"caseworker-ia-homeofficepou",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "ariaListingReference": "PA/12345/2019",
+        "listCaseHearingCentre": "taylorHouse",
+        "notificationsSent": [
+          {
+            "id": "703325_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703325_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: Your application has been granted",
+        "body": [
+          "PA/12345/2019",
+          "A1234567",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-pou-granted-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-pou-granted-before-listing.json
@@ -1,0 +1,65 @@
+{
+  "description": "RIA-7033 Internal case Send decide an application notification home office POU granted before listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703327,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "listCaseHearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"",
+                "decision":"Granted",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-homeofficepou",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "notificationsSent": [
+          {
+            "id": "703327_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703327_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: Your application has been granted",
+        "body": [
+          "PA/12345/2019",
+          "A123456",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-pou-refused-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-pou-refused-after-listing.json
@@ -1,0 +1,68 @@
+{
+  "description": "RIA-7033 Internal case Send make an application notification home office LART refused after listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703328,
+      "eventId": "decideAnApplication",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "ariaListingReference": "PA/12345/2019",
+          "listCaseHearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Refused",
+                "state":"prepareForHearing",
+                "applicantRole":"caseworker-ia-homeofficepou",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "ariaListingReference": "PA/12345/2019",
+        "listCaseHearingCentre": "taylorHouse",
+        "notificationsSent": [
+          {
+            "id": "703328_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703328_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: application for Other refused",
+        "body": [
+          "PA/12345/2019",
+          "A1234567",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-pou-refused-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7033-internal-decide-an-application-notification-home-office-pou-refused-before-listing.json
@@ -1,0 +1,65 @@
+{
+  "description": "RIA-7033 Internal case Send decide an application notification home office POU refused before listing",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 703329,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "listCaseHearingCentre": "taylorHouse",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+              {
+              "id": "1",
+              "value": {
+                "type":"Other",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"",
+                "decision":"Refused",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-homeofficepou",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Judge"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "notificationsSent": [
+          {
+            "id": "703329_DECIDE_AN_APPLICATION_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "703329_DECIDE_AN_APPLICATION_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: application for Other refused",
+        "body": [
+          "PA/12345/2019",
+          "A123456",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -2573,6 +2573,25 @@ public class NotificationGeneratorConfiguration {
         );
     }
 
+
+    @Bean("decideAnApplicationInternalNotificationGenerator")
+    public List<NotificationGenerator> decideAnApplicationInternalNotificationGenerator(
+            HomeOfficeDecideAnApplicationPersonalisation homeOfficeDecideAnApplicationPersonalisation,
+            GovNotifyNotificationSender notificationSender,
+            NotificationIdAppender notificationIdAppender
+    ) {
+
+        return Collections.singletonList(
+                new EmailNotificationGenerator(
+                        newArrayList(
+                                homeOfficeDecideAnApplicationPersonalisation
+                        ),
+                        notificationSender,
+                        notificationIdAppender
+                )
+        );
+    }
+
     @Bean("decideAnApplicationDetNotificationGenerator")
     public List<NotificationGenerator> decideAnApplicationDetNotificationGenerator(
         DetentionEngagementTeamDecideAnApplicationPersonalisation detentionEngagementTeamDecideAnApplicationPersonalisation,

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -2631,6 +2631,21 @@ public class NotificationHandlerConfiguration {
         );
     }
 
+
+    @Bean
+    public PreSubmitCallbackHandler<AsylumCase> decideAnApplicationInternalNotificationHandler(
+            @Qualifier("decideAnApplicationInternalNotificationGenerator") List<NotificationGenerator> notificationGenerators) {
+
+        return new NotificationHandler(
+                (callbackStage, callback) ->
+                        callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                                && callback.getEvent() == Event.DECIDE_AN_APPLICATION
+                                && isInternalCase(callback.getCaseDetails().getCaseData())
+                                && !isAcceleratedDetainedAppeal(callback.getCaseDetails().getCaseData()),
+                notificationGenerators
+        );
+    }
+
     @Bean
     public PreSubmitCallbackHandler<AsylumCase> decideAnApplicationDetNotificationHandler(
         @Qualifier("decideAnApplicationDetNotificationGenerator") List<NotificationGenerator> notificationGenerators) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -752,14 +752,14 @@ govnotify:
           applicant:
             legalRep:
               beforeListing:
-                email: 6575dd7d-2730-4438-a128-c28655473b4c
+                email: a85bd34b-de31-4547-b0e3-04772c039c0e
               afterListing:
-                email: 348469d6-c3a9-43c1-bb00-51d175b809dc
+                email: c92f888d-8391-45d5-91a5-11af22331200
             homeOffice:
               beforeListing:
-                email: 1c35344a-a252-4603-9132-4ee2f5efffc1
+                email: 045cf651-7572-463f-8521-73d27fb24d47
               afterListing:
-                email: ef9638cf-cb40-44d3-b17a-9b87b1a6a986
+                email: af7c1851-e2c3-4105-88d1-efa4127f810a
             appellant:
               beforeListing:
                 email: c341e03f-b008-4981-87ae-3db70c533d63


### PR DESCRIPTION
JIRA link (if applicable)

https://tools.hmcts.net/jira/browse/RIA-7033
Change description

    Created new Gov Notify templates for LR/HO refused application with updated content
    Added handler/generator for internal decideAnApplication notifications
    Updated yaml values for decideAnApplication refused notifications to LR/HO to use the new templates
    Added FTs to cover all the scenarios applicable to decideAnApplication event for internal appeals

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
