### PR TITLE
Ria 7109 new email addr for granted part granted ho ftpa decision

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -104,6 +104,7 @@ def secrets = [
         secret('home-office-email-apc', 'HOME_OFFICE_EMAIL_APC'),
         secret('home-office-email-lart', 'HOME_OFFICE_EMAIL_LART'),
         secret('upper-tribunal-notices-email', 'IA_UPPER_TRIBUNAL_NOTICES_EMAIL'),
+        secret('utiac-permission-applications-email', 'IA_UPPER_TRIBUNAL_PERMISSION_APPLICATIONS_EMAIL'),
         secret('nbc-email', 'IA_NBC_EMAIL'),
         secret('ctsc-email', 'IA_CTSC_EMAIL'),
 

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -108,6 +108,7 @@ def secrets = [
         secret('home-office-email-apc', 'HOME_OFFICE_EMAIL_APC'),
         secret('home-office-email-lart', 'HOME_OFFICE_EMAIL_LART'),
         secret('upper-tribunal-notices-email', 'IA_UPPER_TRIBUNAL_NOTICES_EMAIL'),
+        secret('utiac-permission-applications-email', 'IA_UPPER_TRIBUNAL_PERMISSION_APPLICATIONS_EMAIL'),
         secret('nbc-email', 'IA_NBC_EMAIL'),
         secret('ctsc-email', 'IA_CTSC_EMAIL'),
 

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -102,6 +102,7 @@ def secrets = [
     secret('home-office-email-apc', 'HOME_OFFICE_EMAIL_APC'),
     secret('home-office-email-lart', 'HOME_OFFICE_EMAIL_LART'),
     secret('upper-tribunal-notices-email', 'IA_UPPER_TRIBUNAL_NOTICES_EMAIL'),
+    secret('utiac-permission-applications-email', 'IA_UPPER_TRIBUNAL_PERMISSION_APPLICATIONS_EMAIL'),
     secret('nbc-email', 'IA_NBC_EMAIL'),
     secret('ctsc-email', 'IA_CTSC_EMAIL'),
 

--- a/charts/ia-case-notifications-api/Chart.yaml
+++ b/charts/ia-case-notifications-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ia-case-notifications-api
 home: https://github.com/hmcts/ia-case-notifications-api
-version: 0.0.39
+version: 0.0.40
 description: Immigration & Asylum Case Notifications Service
 maintainers:
   - name: HMCTS Immigration & Asylum Team

--- a/charts/ia-case-notifications-api/values.yaml
+++ b/charts/ia-case-notifications-api/values.yaml
@@ -139,6 +139,8 @@ java:
           alias: HOME_OFFICE_EMAIL_LART
         - name: upper-tribunal-notices-email
           alias: IA_UPPER_TRIBUNAL_NOTICES_EMAIL
+        - name: utiac-permission-applications-email
+          alias: IA_UPPER_TRIBUNAL_NOTICES_IAC_EMAIL
         - name: nbc-email
           alias: IA_NBC_EMAIL
         - name: ctsc-email

--- a/charts/ia-case-notifications-api/values.yaml
+++ b/charts/ia-case-notifications-api/values.yaml
@@ -140,7 +140,7 @@ java:
         - name: upper-tribunal-notices-email
           alias: IA_UPPER_TRIBUNAL_NOTICES_EMAIL
         - name: utiac-permission-applications-email
-          alias: IA_UPPER_TRIBUNAL_NOTICES_IAC_EMAIL
+          alias: IA_UPPER_TRIBUNAL_PERMISSION_APPLICATIONS_EMAIL
         - name: nbc-email
           alias: IA_NBC_EMAIL
         - name: ctsc-email

--- a/src/functionalTest/resources/scenarios/RIA-1431-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-granted-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-1431-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-granted-appellant.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "143223754_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-1431-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-granted-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-1431-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-granted-appellant.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "143223754_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-1432-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-granted-respondent.json
+++ b/src/functionalTest/resources/scenarios/RIA-1432-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-granted-respondent.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "1005_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-1432-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-granted-respondent.json
+++ b/src/functionalTest/resources/scenarios/RIA-1432-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-granted-respondent.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "1005_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-1432-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-1432-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-appellant.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "1003_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-1432-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-1432-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-appellant.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "1003_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-1432-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-respondent.json
+++ b/src/functionalTest/resources/scenarios/RIA-1432-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-respondent.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "1007_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-1432-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-respondent.json
+++ b/src/functionalTest/resources/scenarios/RIA-1432-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-respondent.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "1007_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-granted-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-granted-appellant.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "29753754_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-granted-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-granted-appellant.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "29753754_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-granted-respondent.json
+++ b/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-granted-respondent.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "1005_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-granted-respondent.json
+++ b/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-granted-respondent.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "1005_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-appellant.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "1003_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-appellant.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "1003_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-respondent.json
+++ b/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-respondent.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "1007_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-respondent.json
+++ b/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-respondent.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "1007_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-allowed-after-respondent-dismissed-manchester.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-allowed-after-respondent-dismissed-manchester.json
@@ -5,7 +5,7 @@
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "Judge",
     "input": {
-      "id": 1007,
+      "id": 10071,
       "eventId": "residentJudgeFtpaDecision",
       "state": "ftpaSubmitted",
       "caseData": {
@@ -17,11 +17,10 @@
           "ftpaRespondentRjDecisionOutcomeType": "remadeRule32",
           "ftpaAppellantDecisionRemadeRule32": "allowed",
           "ftpaApplicantType": "appellant",
-          "ftpaApplicantType": "respondent",
           "ariaListingReference": "987654321",
           "notificationsSent": [
             {
-              "id": "1007_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
+              "id": "10071_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
               "value": "34e146c9-6050-4894-a64e-acd461a5f934"
             }
           ]
@@ -40,7 +39,7 @@
     },
     "notifications": [
       {
-        "reference": "1007_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
+        "reference": "10071_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
         "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal",
         "body": [
@@ -51,7 +50,7 @@
         ]
       },
       {
-        "reference": "1007_FTPA_APPLICATION_DECISION_LEGAL_REPRESENTATIVE_APPELLANT",
+        "reference": "10071_FTPA_APPLICATION_DECISION_LEGAL_REPRESENTATIVE_APPELLANT",
         "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal",
         "body": [

--- a/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-refused-after-respondent-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-refused-after-respondent-granted.json
@@ -38,7 +38,7 @@
     "notifications": [
       {
         "reference": "9003_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal refused",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-refused-after-respondent-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-refused-after-respondent-granted.json
@@ -38,7 +38,7 @@
     "notifications": [
       {
         "reference": "9003_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal refused",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-refused-after-respondent-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-refused-after-respondent-granted.json
@@ -38,7 +38,7 @@
     "notifications": [
       {
         "reference": "9003_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal refused",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-reheard-after-respondent-granted-bradford.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-reheard-after-respondent-granted-bradford.json
@@ -41,7 +41,7 @@
     "notifications": [
       {
         "reference": "1020_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-reheard-after-respondent-granted-bradford.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-reheard-after-respondent-granted-bradford.json
@@ -41,7 +41,7 @@
     "notifications": [
       {
         "reference": "1020_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-reheard-after-respondent-granted-bradford.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-reheard-after-respondent-granted-bradford.json
@@ -41,7 +41,7 @@
     "notifications": [
       {
         "reference": "1020_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-reheard-after-respondent-granted-taylor-house.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-reheard-after-respondent-granted-taylor-house.json
@@ -40,7 +40,7 @@
     "notifications": [
       {
         "reference": "9009_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-reheard-after-respondent-granted-taylor-house.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-reheard-after-respondent-granted-taylor-house.json
@@ -40,7 +40,7 @@
     "notifications": [
       {
         "reference": "9009_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-reheard-after-respondent-granted-taylor-house.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-appellant-reheard-after-respondent-granted-taylor-house.json
@@ -40,7 +40,7 @@
     "notifications": [
       {
         "reference": "9009_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-respondent-granted-after-appellant-refused.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-respondent-granted-after-appellant-refused.json
@@ -38,7 +38,7 @@
     "notifications": [
       {
         "reference": "9004_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-respondent-granted-after-appellant-refused.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-respondent-granted-after-appellant-refused.json
@@ -38,7 +38,7 @@
     "notifications": [
       {
         "reference": "9004_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-ftpa-appellant-granted-after-respondent-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-ftpa-appellant-granted-after-respondent-granted.json
@@ -38,7 +38,7 @@
     "notifications": [
       {
         "reference": "9001_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-ftpa-appellant-granted-after-respondent-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-ftpa-appellant-granted-after-respondent-granted.json
@@ -38,7 +38,7 @@
     "notifications": [
       {
         "reference": "9001_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-ftpa-appellant-partially-granted-after-respondent-not-addmitted.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-ftpa-appellant-partially-granted-after-respondent-not-addmitted.json
@@ -38,7 +38,7 @@
     "notifications": [
       {
         "reference": "9005_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-ftpa-appellant-partially-granted-after-respondent-not-addmitted.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-ftpa-appellant-partially-granted-after-respondent-not-addmitted.json
@@ -38,7 +38,7 @@
     "notifications": [
       {
         "reference": "9005_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-ftpa-respondent-granted-after-appellant-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-ftpa-respondent-granted-after-appellant-granted.json
@@ -38,7 +38,7 @@
     "notifications": [
       {
         "reference": "9002_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-ftpa-respondent-granted-after-appellant-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-ftpa-respondent-granted-after-appellant-granted.json
@@ -38,7 +38,7 @@
     "notifications": [
       {
         "reference": "9002_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-3855-ftpa-decided-appellant-granted-after-appellant-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-3855-ftpa-decided-appellant-granted-after-appellant-granted.json
@@ -40,7 +40,7 @@
     "notifications": [
       {
         "reference": "3855_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-3855-ftpa-decided-appellant-granted-after-appellant-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-3855-ftpa-decided-appellant-granted-after-appellant-granted.json
@@ -40,7 +40,7 @@
     "notifications": [
       {
         "reference": "3855_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-3855-ftpa-submitted-appellant-granted-after-appellant-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-3855-ftpa-submitted-appellant-granted-after-appellant-granted.json
@@ -40,7 +40,7 @@
     "notifications": [
       {
         "reference": "3855_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-3855-ftpa-submitted-appellant-granted-after-appellant-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-3855-ftpa-submitted-appellant-granted-after-appellant-granted.json
@@ -40,7 +40,7 @@
     "notifications": [
       {
         "reference": "3855_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-3855-ftpa-submitted-respondent-granted-after-appellant-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-3855-ftpa-submitted-respondent-granted-after-appellant-granted.json
@@ -40,7 +40,7 @@
     "notifications": [
       {
         "reference": "3855_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-3855-ftpa-submitted-respondent-granted-after-appellant-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-3855-ftpa-submitted-respondent-granted-after-appellant-granted.json
@@ -40,7 +40,7 @@
     "notifications": [
       {
         "reference": "3855_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-granted-aip-journey-leadership-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-granted-aip-journey-leadership-judge.json
@@ -63,7 +63,7 @@
     "notifications": [
       {
         "reference": "61131_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-granted-aip-journey-leadership-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-granted-aip-journey-leadership-judge.json
@@ -63,7 +63,7 @@
     "notifications": [
       {
         "reference": "61131_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-granted-aip-journey-resident-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-granted-aip-journey-resident-judge.json
@@ -63,7 +63,7 @@
     "notifications": [
       {
         "reference": "61135_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-granted-aip-journey-resident-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-granted-aip-journey-resident-judge.json
@@ -63,7 +63,7 @@
     "notifications": [
       {
         "reference": "61135_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-partially-granted-aip-journey-leadership-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-partially-granted-aip-journey-leadership-judge.json
@@ -63,7 +63,7 @@
     "notifications": [
       {
         "reference": "61132_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-partially-granted-aip-journey-leadership-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-partially-granted-aip-journey-leadership-judge.json
@@ -63,7 +63,7 @@
     "notifications": [
       {
         "reference": "61132_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-partially-granted-aip-journey-resident-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-partially-granted-aip-journey-resident-judge.json
@@ -63,7 +63,7 @@
     "notifications": [
       {
         "reference": "61134_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-partially-granted-aip-journey-resident-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-partially-granted-aip-journey-resident-judge.json
@@ -63,7 +63,7 @@
     "notifications": [
       {
         "reference": "61134_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-granted-aip-journey-leadership-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-granted-aip-journey-leadership-judge.json
@@ -62,7 +62,7 @@
     "notifications": [
       {
         "reference": "61161_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-granted-aip-journey-leadership-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-granted-aip-journey-leadership-judge.json
@@ -62,7 +62,7 @@
     "notifications": [
       {
         "reference": "61161_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-granted-aip-journey-resident-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-granted-aip-journey-resident-judge.json
@@ -62,7 +62,7 @@
     "notifications": [
       {
         "reference": "61162_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-granted-aip-journey-resident-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-granted-aip-journey-resident-judge.json
@@ -62,7 +62,7 @@
     "notifications": [
       {
         "reference": "61162_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-partially-granted-aip-journey-leadership-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-partially-granted-aip-journey-leadership-judge.json
@@ -62,7 +62,7 @@
     "notifications": [
       {
         "reference": "61163_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-partially-granted-aip-journey-leadership-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-partially-granted-aip-journey-leadership-judge.json
@@ -62,7 +62,7 @@
     "notifications": [
       {
         "reference": "61163_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-partially-granted-aip-journey-resident-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-partially-granted-aip-journey-resident-judge.json
@@ -62,7 +62,7 @@
     "notifications": [
       {
         "reference": "61164_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-partially-granted-aip-journey-resident-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-partially-granted-aip-journey-resident-judge.json
@@ -62,7 +62,7 @@
     "notifications": [
       {
         "reference": "61164_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesIacEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/integrationTest/resources/application-integration.yaml
+++ b/src/integrationTest/resources/application-integration.yaml
@@ -11,6 +11,7 @@ feesAdminOfficerEmailAddress: not-used-in-integration
 apcHomeOfficeEmailAddress: not-used-in-integration
 lartHomeOfficeEmailAddress: not-used-in-integration
 upperTribunalNoticesEmailAddress: not-used-in-integration
+upperTribunalPermissionApplicationsEmailAddress: not-used-in-integration
 nbcEmailAddress: not-used-in-integration
 ctscEmailAddress: not-used-in-integration
 

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionAppellantPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionAppellantPersonalisation.java
@@ -18,7 +18,7 @@ public class HomeOfficeFtpaApplicationDecisionAppellantPersonalisation implement
 
     private final PersonalisationProvider personalisationProvider;
     private final String upperTribunalNoticesEmailAddress;
-    private final String upperTribunalNoticesIacEmailAddress;
+    private final String upperTribunalPermissionApplicationsEmailAddress;
     private final String applicationGrantedOtherPartyHomeOfficeTemplateId;
     private final String applicationPartiallyGrantedOtherPartyHomeOfficeTemplateId;
     private final String applicationNotAdmittedOtherPartyHomeOfficeTemplateId;
@@ -37,7 +37,7 @@ public class HomeOfficeFtpaApplicationDecisionAppellantPersonalisation implement
         @Value("${govnotify.template.applicationDismissed.homeOffice.email}") String applicationDismissedHomeOfficeTemplateId,
         PersonalisationProvider personalisationProvider,
         @Value("${upperTribunalNoticesEmailAddress}") String upperTribunalNoticesEmailAddress,
-        @Value("${upperTribunalNoticesIacEmailAddress}") String upperTribunalNoticesIacEmailAddress
+        @Value("${upperTribunalPermissionApplicationsEmailAddress}") String upperTribunalPermissionApplicationsEmailAddress
     ) {
         this.applicationGrantedOtherPartyHomeOfficeTemplateId = applicationGrantedOtherPartyHomeOfficeTemplateId;
         this.applicationPartiallyGrantedOtherPartyHomeOfficeTemplateId = applicationPartiallyGrantedOtherPartyHomeOfficeTemplateId;
@@ -48,7 +48,7 @@ public class HomeOfficeFtpaApplicationDecisionAppellantPersonalisation implement
         this.applicationDismissedHomeOfficeTemplateId = applicationDismissedHomeOfficeTemplateId;
         this.personalisationProvider = personalisationProvider;
         this.upperTribunalNoticesEmailAddress = upperTribunalNoticesEmailAddress;
-        this.upperTribunalNoticesIacEmailAddress = upperTribunalNoticesIacEmailAddress;
+        this.upperTribunalPermissionApplicationsEmailAddress = upperTribunalPermissionApplicationsEmailAddress;
     }
 
     @Override
@@ -95,7 +95,7 @@ public class HomeOfficeFtpaApplicationDecisionAppellantPersonalisation implement
                     ) {
                     String recipient = ftpaAppellantLjRjDecision(asylumCase)
                         .map(decision -> List.of(FTPA_GRANTED,FTPA_PARTIALLY_GRANTED).contains(decision)
-                            ? upperTribunalNoticesIacEmailAddress
+                            ? upperTribunalPermissionApplicationsEmailAddress
                             : upperTribunalNoticesEmailAddress)
                         .orElseThrow(() -> new IllegalStateException("Appellant decision not present"));
 

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionRespondentPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionRespondentPersonalisation.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.homeoffice;
 
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_GRANTED;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_PARTIALLY_GRANTED;
 
 import java.util.*;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,13 +11,15 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.utils.FtpaNotificationPersonalisationUtil;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PersonalisationProvider;
 
 @Service
-public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisation implements EmailNotificationPersonalisation {
+public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisation implements EmailNotificationPersonalisation, FtpaNotificationPersonalisationUtil {
 
     private final PersonalisationProvider personalisationProvider;
     private final String upperTribunalNoticesEmailAddress;
+    private final String upperTribunalNoticesIacEmailAddress;
     private final String applicationGrantedApplicantHomeOfficeTemplateId;
     private final String applicationPartiallyGrantedApplicantHomeOfficeTemplateId;
     private final String applicationNotAdmittedApplicantHomeOfficeTemplateId;
@@ -33,7 +37,8 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisation implemen
         @Value("${govnotify.template.applicationAllowed.homeOffice.email}") String applicationAllowedHomeOfficeTemplateId,
         @Value("${govnotify.template.applicationDismissed.homeOffice.email}") String applicationDismissedHomeOfficeTemplateId,
         PersonalisationProvider personalisationProvider,
-        @Value("${upperTribunalNoticesEmailAddress}") String upperTribunalNoticesEmailAddress
+        @Value("${upperTribunalNoticesEmailAddress}") String upperTribunalNoticesEmailAddress,
+        @Value("${upperTribunalNoticesIacEmailAddress}") String upperTribunalNoticesIacEmailAddress
     ) {
         this.applicationGrantedApplicantHomeOfficeTemplateId = applicationGrantedApplicantHomeOfficeTemplateId;
         this.applicationPartiallyGrantedApplicantHomeOfficeTemplateId = applicationPartiallyGrantedApplicantHomeOfficeTemplateId;
@@ -44,6 +49,7 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisation implemen
         this.applicationDismissedHomeOfficeTemplateId = applicationDismissedHomeOfficeTemplateId;
         this.personalisationProvider = personalisationProvider;
         this.upperTribunalNoticesEmailAddress = upperTribunalNoticesEmailAddress;
+        this.upperTribunalNoticesIacEmailAddress = upperTribunalNoticesIacEmailAddress;
     }
 
     @Override
@@ -87,7 +93,13 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisation implemen
                     State.FTPA_SUBMITTED,
                     State.FTPA_DECIDED).contains(currentState)
                 ) {
-                    return Collections.singleton(upperTribunalNoticesEmailAddress);
+                    String recipient = ftpaRespondentLjRjDecision(asylumCase)
+                        .map(decision -> List.of(FTPA_GRANTED,FTPA_PARTIALLY_GRANTED).contains(decision)
+                            ? upperTribunalNoticesIacEmailAddress
+                            : upperTribunalNoticesEmailAddress)
+                        .orElseThrow(() -> new IllegalStateException("Appellant decision not present"));
+
+                    return Collections.singleton(recipient);
                 } else {
                     throw new IllegalStateException("homeOffice email Address cannot be found");
                 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionRespondentPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionRespondentPersonalisation.java
@@ -19,7 +19,7 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisation implemen
 
     private final PersonalisationProvider personalisationProvider;
     private final String upperTribunalNoticesEmailAddress;
-    private final String upperTribunalNoticesIacEmailAddress;
+    private final String upperTribunalPermissionApplicationsEmailAddress;
     private final String applicationGrantedApplicantHomeOfficeTemplateId;
     private final String applicationPartiallyGrantedApplicantHomeOfficeTemplateId;
     private final String applicationNotAdmittedApplicantHomeOfficeTemplateId;
@@ -38,7 +38,7 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisation implemen
         @Value("${govnotify.template.applicationDismissed.homeOffice.email}") String applicationDismissedHomeOfficeTemplateId,
         PersonalisationProvider personalisationProvider,
         @Value("${upperTribunalNoticesEmailAddress}") String upperTribunalNoticesEmailAddress,
-        @Value("${upperTribunalNoticesIacEmailAddress}") String upperTribunalNoticesIacEmailAddress
+        @Value("${upperTribunalPermissionApplicationsEmailAddress}") String upperTribunalPermissionApplicationsEmailAddress
     ) {
         this.applicationGrantedApplicantHomeOfficeTemplateId = applicationGrantedApplicantHomeOfficeTemplateId;
         this.applicationPartiallyGrantedApplicantHomeOfficeTemplateId = applicationPartiallyGrantedApplicantHomeOfficeTemplateId;
@@ -49,7 +49,7 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisation implemen
         this.applicationDismissedHomeOfficeTemplateId = applicationDismissedHomeOfficeTemplateId;
         this.personalisationProvider = personalisationProvider;
         this.upperTribunalNoticesEmailAddress = upperTribunalNoticesEmailAddress;
-        this.upperTribunalNoticesIacEmailAddress = upperTribunalNoticesIacEmailAddress;
+        this.upperTribunalPermissionApplicationsEmailAddress = upperTribunalPermissionApplicationsEmailAddress;
     }
 
     @Override
@@ -95,7 +95,7 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisation implemen
                 ) {
                     String recipient = ftpaRespondentLjRjDecision(asylumCase)
                         .map(decision -> List.of(FTPA_GRANTED,FTPA_PARTIALLY_GRANTED).contains(decision)
-                            ? upperTribunalNoticesIacEmailAddress
+                            ? upperTribunalPermissionApplicationsEmailAddress
                             : upperTribunalNoticesEmailAddress)
                         .orElseThrow(() -> new IllegalStateException("Appellant decision not present"));
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1247,7 +1247,7 @@ paymentExceptionsAdminOfficerEmailAddress: ${PAYMENT_EXCEPTIONS_ADMIN_OFFICER_EM
 apcHomeOfficeEmailAddress: ${HOME_OFFICE_EMAIL_APC}
 lartHomeOfficeEmailAddress: ${HOME_OFFICE_EMAIL_LART}
 upperTribunalNoticesEmailAddress: ${IA_UPPER_TRIBUNAL_NOTICES_EMAIL}
-upperTribunalPermissionApplicationsEmailAddress: ${IA_UPPER_TRIBUNAL_PERMISSION_APPLICATIONS_EMAIL}
+upperTribunalPermissionApplicationsEmailAddress: ${IA_UPPER_TRIBUNAL_PERMISSION_APPLICATIONS_EMAIL:UTIACpermissionapplications@grantedpartgranted.fake.com}
 
 nbcEmailAddress: ${IA_NBC_EMAIL}
 ctscEmailAddress: ${IA_CTSC_EMAIL}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1247,6 +1247,8 @@ paymentExceptionsAdminOfficerEmailAddress: ${PAYMENT_EXCEPTIONS_ADMIN_OFFICER_EM
 apcHomeOfficeEmailAddress: ${HOME_OFFICE_EMAIL_APC}
 lartHomeOfficeEmailAddress: ${HOME_OFFICE_EMAIL_LART}
 upperTribunalNoticesEmailAddress: ${IA_UPPER_TRIBUNAL_NOTICES_EMAIL}
+upperTribunalNoticesIacEmailAddress: ${IA_UPPER_TRIBUNAL_NOTICES_IAC_EMAIL}
+
 nbcEmailAddress: ${IA_NBC_EMAIL}
 ctscEmailAddress: ${IA_CTSC_EMAIL}
 ctscAdminPendingPaymentEmailAddress: ${IA_CTSC_ADMIN_PENDING_PAYMENT_EMAIL:pendingPayment@example.com}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1247,7 +1247,7 @@ paymentExceptionsAdminOfficerEmailAddress: ${PAYMENT_EXCEPTIONS_ADMIN_OFFICER_EM
 apcHomeOfficeEmailAddress: ${HOME_OFFICE_EMAIL_APC}
 lartHomeOfficeEmailAddress: ${HOME_OFFICE_EMAIL_LART}
 upperTribunalNoticesEmailAddress: ${IA_UPPER_TRIBUNAL_NOTICES_EMAIL}
-upperTribunalNoticesIacEmailAddress: ${IA_UPPER_TRIBUNAL_NOTICES_IAC_EMAIL}
+upperTribunalPermissionApplicationsEmailAddress: ${IA_UPPER_TRIBUNAL_PERMISSION_APPLICATIONS_EMAIL}
 
 nbcEmailAddress: ${IA_NBC_EMAIL}
 ctscEmailAddress: ${IA_CTSC_EMAIL}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionAppellantPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionAppellantPersonalisationTest.java
@@ -4,15 +4,21 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.CURRENT_CASE_STATE_VISIBLE_TO_JUDGE;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_APPELLANT_DECISION_OUTCOME_TYPE;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_APPELLANT_DECISION_REMADE_RULE_32;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.*;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -33,6 +39,7 @@ public class HomeOfficeFtpaApplicationDecisionAppellantPersonalisationTest {
 
     private Long caseId = 12345L;
     private String upperTribunalNoticesEmailAddress = "homeoffice-granted@example.com";
+    private String upperTribunalNoticesIacEmailAddress = "homeoffice-granted-iac@example.com";
     private String appealReferenceNumber = "someReferenceNumber";
     private String homeOfficeRefNumber = "someHomeOfficeRefNumber";
     private String ariaListingReference = "ariaListingReference";
@@ -47,14 +54,14 @@ public class HomeOfficeFtpaApplicationDecisionAppellantPersonalisationTest {
     private String allowedTemplateId = "allowedTemplateId";
     private String dismissedTemplateId = "dismissedTemplateId";
 
-    private FtpaDecisionOutcomeType granted = FtpaDecisionOutcomeType.FTPA_GRANTED;
-    private FtpaDecisionOutcomeType partiallyGranted = FtpaDecisionOutcomeType.FTPA_PARTIALLY_GRANTED;
-    private FtpaDecisionOutcomeType notAdmitted = FtpaDecisionOutcomeType.FTPA_NOT_ADMITTED;
-    private FtpaDecisionOutcomeType refused = FtpaDecisionOutcomeType.FTPA_REFUSED;
-    private FtpaDecisionOutcomeType reheard = FtpaDecisionOutcomeType.FTPA_REHEARD35;
-    private FtpaDecisionOutcomeType remade = FtpaDecisionOutcomeType.FTPA_REMADE32;
-    private FtpaDecisionOutcomeType allowed = FtpaDecisionOutcomeType.FTPA_ALLOWED;
-    private FtpaDecisionOutcomeType dismissed = FtpaDecisionOutcomeType.FTPA_DISMISSED;
+    private FtpaDecisionOutcomeType granted = FTPA_GRANTED;
+    private FtpaDecisionOutcomeType partiallyGranted = FTPA_PARTIALLY_GRANTED;
+    private FtpaDecisionOutcomeType notAdmitted = FTPA_NOT_ADMITTED;
+    private FtpaDecisionOutcomeType refused = FTPA_REFUSED;
+    private FtpaDecisionOutcomeType reheard = FTPA_REHEARD35;
+    private FtpaDecisionOutcomeType remade = FTPA_REMADE32;
+    private FtpaDecisionOutcomeType allowed = FTPA_ALLOWED;
+    private FtpaDecisionOutcomeType dismissed = FTPA_DISMISSED;
 
     private HomeOfficeFtpaApplicationDecisionAppellantPersonalisation
         homeOfficeFtpaApplicationDecisionAppellantPersonalisation;
@@ -72,7 +79,8 @@ public class HomeOfficeFtpaApplicationDecisionAppellantPersonalisationTest {
                 allowedTemplateId,
                 dismissedTemplateId,
                 personalisationProvider,
-                upperTribunalNoticesEmailAddress
+                upperTribunalNoticesEmailAddress,
+                upperTribunalNoticesIacEmailAddress
 
             );
     }
@@ -135,13 +143,31 @@ public class HomeOfficeFtpaApplicationDecisionAppellantPersonalisationTest {
             homeOfficeFtpaApplicationDecisionAppellantPersonalisation.getReferenceId(caseId));
     }
 
-    @Test
-    void should_return_given_email_address_for_correct_states() {
+    @ParameterizedTest
+    @EnumSource(value = FtpaDecisionOutcomeType.class, names = {
+        "FTPA_GRANTED",
+        "FTPA_PARTIALLY_GRANTED",
+        "FTPA_REFUSED",
+        "FTPA_NOT_ADMITTED",
+        "FTPA_REHEARD35",
+        "FTPA_REHEARD32",
+        "FTPA_REMADE32",
+        "FTPA_ALLOWED",
+        "FTPA_DISMISSED"
+    })
+    void should_return_given_email_address_for_correct_states(FtpaDecisionOutcomeType decision) {
+        when(asylumCase.read(FTPA_APPELLANT_DECISION_OUTCOME_TYPE, FtpaDecisionOutcomeType.class))
+            .thenReturn(Optional.of(decision));
         Arrays.asList(State.FTPA_SUBMITTED,State.FTPA_DECIDED).stream().forEach(state -> {
             when(asylumCase.read(CURRENT_CASE_STATE_VISIBLE_TO_JUDGE, State.class))
                 .thenReturn(Optional.of(state));
+
+            String expectedEmailAddress = Set.of(FTPA_GRANTED, FTPA_PARTIALLY_GRANTED).contains(decision)
+                ? upperTribunalNoticesIacEmailAddress
+                : upperTribunalNoticesEmailAddress;
+
             assertTrue(homeOfficeFtpaApplicationDecisionAppellantPersonalisation.getRecipientsList(asylumCase)
-                .contains(upperTribunalNoticesEmailAddress));
+                .contains(expectedEmailAddress));
         });
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionAppellantPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionAppellantPersonalisationTest.java
@@ -39,7 +39,7 @@ public class HomeOfficeFtpaApplicationDecisionAppellantPersonalisationTest {
 
     private Long caseId = 12345L;
     private String upperTribunalNoticesEmailAddress = "homeoffice-granted@example.com";
-    private String upperTribunalNoticesIacEmailAddress = "homeoffice-granted-iac@example.com";
+    private String upperTribunalPermissionApplicationsEmailAddress = "homeoffice-granted-iac@example.com";
     private String appealReferenceNumber = "someReferenceNumber";
     private String homeOfficeRefNumber = "someHomeOfficeRefNumber";
     private String ariaListingReference = "ariaListingReference";
@@ -80,7 +80,7 @@ public class HomeOfficeFtpaApplicationDecisionAppellantPersonalisationTest {
                 dismissedTemplateId,
                 personalisationProvider,
                 upperTribunalNoticesEmailAddress,
-                upperTribunalNoticesIacEmailAddress
+                upperTribunalPermissionApplicationsEmailAddress
 
             );
     }
@@ -163,7 +163,7 @@ public class HomeOfficeFtpaApplicationDecisionAppellantPersonalisationTest {
                 .thenReturn(Optional.of(state));
 
             String expectedEmailAddress = Set.of(FTPA_GRANTED, FTPA_PARTIALLY_GRANTED).contains(decision)
-                ? upperTribunalNoticesIacEmailAddress
+                ? upperTribunalPermissionApplicationsEmailAddress
                 : upperTribunalNoticesEmailAddress;
 
             assertTrue(homeOfficeFtpaApplicationDecisionAppellantPersonalisation.getRecipientsList(asylumCase)

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionRespondentPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionRespondentPersonalisationTest.java
@@ -5,14 +5,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_GRANTED;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_PARTIALLY_GRANTED;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -33,6 +38,7 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisationTest {
 
     private Long caseId = 12345L;
     private String homeOfficeEmailAddress = "homeoffice-allowed@example.com";
+    private String upperTribunalNoticesIacEmailAddress = "homeoffice-allowed-iac@example.com";
     private String appealReferenceNumber = "someReferenceNumber";
     private String homeOfficeRefNumber = "someHomeOfficeRefNumber";
     private String ariaListingReference = "ariaListingReference";
@@ -72,7 +78,8 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisationTest {
                 allowedTemplateId,
                 dismissedTemplateId,
                 personalisationProvider,
-                homeOfficeEmailAddress
+                homeOfficeEmailAddress,
+                upperTribunalNoticesIacEmailAddress
             );
     }
 
@@ -134,15 +141,34 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisationTest {
             homeOfficeFtpaApplicationDecisionRespondentPersonalisation.getReferenceId(caseId));
     }
 
-    @Test
-    void should_return_given_email_address_for_correct_states() {
+    @ParameterizedTest
+    @EnumSource(value = FtpaDecisionOutcomeType.class, names = {
+        "FTPA_GRANTED",
+        "FTPA_PARTIALLY_GRANTED",
+        "FTPA_REFUSED",
+        "FTPA_NOT_ADMITTED",
+        "FTPA_REHEARD35",
+        "FTPA_REHEARD32",
+        "FTPA_REMADE32",
+        "FTPA_ALLOWED",
+        "FTPA_DISMISSED"
+    })
+    void should_return_given_email_address_for_correct_states(FtpaDecisionOutcomeType decision) {
+        when(asylumCase.read(FTPA_RESPONDENT_DECISION_OUTCOME_TYPE, FtpaDecisionOutcomeType.class))
+            .thenReturn(Optional.of(decision));
+
         Arrays.asList(State.FTPA_SUBMITTED,State.FTPA_DECIDED)
             .stream()
             .forEach(state -> {
                 when(asylumCase.read(CURRENT_CASE_STATE_VISIBLE_TO_JUDGE, State.class))
                     .thenReturn(Optional.of(state));
+
+                String expectedEmailAddress = Set.of(FTPA_GRANTED, FTPA_PARTIALLY_GRANTED).contains(decision)
+                    ? upperTribunalNoticesIacEmailAddress
+                    : homeOfficeEmailAddress;
+
                 assertTrue(homeOfficeFtpaApplicationDecisionRespondentPersonalisation.getRecipientsList(asylumCase)
-                    .contains(homeOfficeEmailAddress));
+                    .contains(expectedEmailAddress));
             });
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionRespondentPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionRespondentPersonalisationTest.java
@@ -38,7 +38,7 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisationTest {
 
     private Long caseId = 12345L;
     private String homeOfficeEmailAddress = "homeoffice-allowed@example.com";
-    private String upperTribunalNoticesIacEmailAddress = "homeoffice-allowed-iac@example.com";
+    private String upperTribunalPermissionApplicationsEmailAddress = "homeoffice-allowed-iac@example.com";
     private String appealReferenceNumber = "someReferenceNumber";
     private String homeOfficeRefNumber = "someHomeOfficeRefNumber";
     private String ariaListingReference = "ariaListingReference";
@@ -79,7 +79,7 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisationTest {
                 dismissedTemplateId,
                 personalisationProvider,
                 homeOfficeEmailAddress,
-                upperTribunalNoticesIacEmailAddress
+                upperTribunalPermissionApplicationsEmailAddress
             );
     }
 
@@ -164,7 +164,7 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisationTest {
                     .thenReturn(Optional.of(state));
 
                 String expectedEmailAddress = Set.of(FTPA_GRANTED, FTPA_PARTIALLY_GRANTED).contains(decision)
-                    ? upperTribunalNoticesIacEmailAddress
+                    ? upperTribunalPermissionApplicationsEmailAddress
                     : homeOfficeEmailAddress;
 
                 assertTrue(homeOfficeFtpaApplicationDecisionRespondentPersonalisation.getRecipientsList(asylumCase)


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-7109](https://tools.hmcts.net/jira/browse/RIA-7109)


### Change description ###
- Made personalization classes for emails to HO related to FTPA decisions pick between the old and the new email address based on whether the decision is `granted` or `partiallyGranted`. This affects resident judge decisions, leadership judge decisions, as well as cases in both LR and AIP journeys.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
