### PR TITLE
Ria 7109 transpose new email changes from ho to admin

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-1431-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-granted-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-1431-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-granted-appellant.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "143223754_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",
@@ -67,7 +67,7 @@
       },
       {
         "reference": "143223754_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_APPELLANT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-1431-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-granted-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-1431-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-granted-appellant.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "143223754_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-1432-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-granted-respondent.json
+++ b/src/functionalTest/resources/scenarios/RIA-1432-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-granted-respondent.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "1005_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",
@@ -67,7 +67,7 @@
       },
       {
         "reference": "1005_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_RESPONDENT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-1432-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-1432-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-appellant.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "1003_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",
@@ -67,7 +67,7 @@
       },
       {
         "reference": "1003_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_APPELLANT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-1432-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-respondent.json
+++ b/src/functionalTest/resources/scenarios/RIA-1432-RIA-2974-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-respondent.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "1007_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",
@@ -67,7 +67,7 @@
       },
       {
         "reference": "1007_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_RESPONDENT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-granted-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-granted-appellant.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "29753754_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",
@@ -67,7 +67,7 @@
       },
       {
         "reference": "29753754_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_APPELLANT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-granted-respondent.json
+++ b/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-granted-respondent.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "1005_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",
@@ -67,7 +67,7 @@
       },
       {
         "reference": "1005_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_RESPONDENT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-appellant.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "1003_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",
@@ -67,7 +67,7 @@
       },
       {
         "reference": "1003_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_APPELLANT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-respondent.json
+++ b/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-respondent.json
@@ -45,7 +45,7 @@
     "notifications": [
       {
         "reference": "1007_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",
@@ -67,7 +67,7 @@
       },
       {
         "reference": "1007_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_RESPONDENT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-respondent-granted-after-appellant-refused.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-RIA-3003-ftpa-respondent-granted-after-appellant-refused.json
@@ -38,7 +38,7 @@
     "notifications": [
       {
         "reference": "9004_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",
@@ -60,7 +60,7 @@
       },
       {
         "reference": "9004_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_RESPONDENT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-ftpa-appellant-granted-after-respondent-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-ftpa-appellant-granted-after-respondent-granted.json
@@ -38,7 +38,7 @@
     "notifications": [
       {
         "reference": "9001_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",
@@ -60,7 +60,7 @@
       },
       {
         "reference": "9001_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_APPELLANT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-ftpa-appellant-partially-granted-after-respondent-not-addmitted.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-ftpa-appellant-partially-granted-after-respondent-not-addmitted.json
@@ -38,7 +38,7 @@
     "notifications": [
       {
         "reference": "9005_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",
@@ -60,7 +60,7 @@
       },
       {
         "reference": "9005_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_APPELLANT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-ftpa-appellant-partially-granted-after-respondent-not-addmitted.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-ftpa-appellant-partially-granted-after-respondent-not-addmitted.json
@@ -38,7 +38,7 @@
     "notifications": [
       {
         "reference": "9005_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{upperTribunalNoticesEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2999-ftpa-respondent-granted-after-appellant-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-2999-ftpa-respondent-granted-after-appellant-granted.json
@@ -38,7 +38,7 @@
     "notifications": [
       {
         "reference": "9002_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",
@@ -60,7 +60,7 @@
       },
       {
         "reference": "9002_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_RESPONDENT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-3855-ftpa-decided-appellant-granted-after-appellant-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-3855-ftpa-decided-appellant-granted-after-appellant-granted.json
@@ -40,7 +40,7 @@
     "notifications": [
       {
         "reference": "3855_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",
@@ -62,7 +62,7 @@
       },
       {
         "reference": "3855_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_RESPONDENT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-3855-ftpa-submitted-appellant-granted-after-appellant-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-3855-ftpa-submitted-appellant-granted-after-appellant-granted.json
@@ -40,7 +40,7 @@
     "notifications": [
       {
         "reference": "3855_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",
@@ -62,7 +62,7 @@
       },
       {
         "reference": "3855_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_RESPONDENT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-3855-ftpa-submitted-respondent-granted-after-appellant-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-3855-ftpa-submitted-respondent-granted-after-appellant-granted.json
@@ -40,7 +40,7 @@
     "notifications": [
       {
         "reference": "3855_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",
@@ -62,7 +62,7 @@
       },
       {
         "reference": "3855_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_RESPONDENT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-granted-aip-journey-leadership-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-granted-aip-journey-leadership-judge.json
@@ -63,7 +63,7 @@
     "notifications": [
       {
         "reference": "61131_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",
@@ -85,7 +85,7 @@
       },
       {
         "reference": "61131_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_APPELLANT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-granted-aip-journey-resident-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-granted-aip-journey-resident-judge.json
@@ -63,7 +63,7 @@
     "notifications": [
       {
         "reference": "61135_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",
@@ -85,7 +85,7 @@
       },
       {
         "reference": "61135_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_APPELLANT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-partially-granted-aip-journey-leadership-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-partially-granted-aip-journey-leadership-judge.json
@@ -63,7 +63,7 @@
     "notifications": [
       {
         "reference": "61132_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",
@@ -85,7 +85,7 @@
       },
       {
         "reference": "61132_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_APPELLANT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-partially-granted-aip-journey-resident-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6113-applicant-ftpa-decision-partially-granted-aip-journey-resident-judge.json
@@ -63,7 +63,7 @@
     "notifications": [
       {
         "reference": "61134_FTPA_APPLICATION_DECISION_HOME_OFFICE_APPELLANT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",
@@ -85,7 +85,7 @@
       },
       {
         "reference": "61134_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_APPELLANT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-granted-aip-journey-leadership-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-granted-aip-journey-leadership-judge.json
@@ -62,7 +62,7 @@
     "notifications": [
       {
         "reference": "61161_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",
@@ -84,7 +84,7 @@
       },
       {
         "reference": "61161_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_RESPONDENT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-granted-aip-journey-resident-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-granted-aip-journey-resident-judge.json
@@ -62,7 +62,7 @@
     "notifications": [
       {
         "reference": "61162_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",
@@ -84,7 +84,7 @@
       },
       {
         "reference": "61162_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_RESPONDENT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-partially-granted-aip-journey-leadership-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-partially-granted-aip-journey-leadership-judge.json
@@ -62,7 +62,7 @@
     "notifications": [
       {
         "reference": "61163_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",
@@ -84,7 +84,7 @@
       },
       {
         "reference": "61163_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_RESPONDENT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-partially-granted-aip-journey-resident-judge.json
+++ b/src/functionalTest/resources/scenarios/RIA-6116-respondent-ftpa-decision-partially-granted-aip-journey-resident-judge.json
@@ -62,7 +62,7 @@
     "notifications": [
       {
         "reference": "61164_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
+        "recipient": "{$upperTribunalNoticesEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",
@@ -84,7 +84,7 @@
       },
       {
         "reference": "61164_FTPA_APPLICATION_DECISION_ADMIN_OFFICER_RESPONDENT",
-        "recipient": "{$ctscAdminFtpaDecisionEmailAddress}",
+        "recipient": "{$upperTribunalPermissionApplicationsEmailAddress}",
         "subject": "Immigration and Asylum appeal: application to appeal to Upper Tribunal partially granted",
         "body": [
           "PA/12345/2019",

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerFtpaDecisionAppellantPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerFtpaDecisionAppellantPersonalisation.java
@@ -2,8 +2,10 @@ package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.admino
 
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_APPELLANT_DECISION_OUTCOME_TYPE;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_APPELLANT_RJ_DECISION_OUTCOME_TYPE;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_GRANTED;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_PARTIALLY_GRANTED;
 
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -12,25 +14,29 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.utils.FtpaNotificationPersonalisationUtil;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PersonalisationProvider;
 
 
 @Service
-public class AdminOfficerFtpaDecisionAppellantPersonalisation implements EmailNotificationPersonalisation {
+public class AdminOfficerFtpaDecisionAppellantPersonalisation implements EmailNotificationPersonalisation, FtpaNotificationPersonalisationUtil {
 
     private final String applicationGrantedAdminTemplateId;
     private final String applicationPartiallyGrantedAdminTemplateId;
     private final String ctscAdminFtpaDecisionEmailAddress;
+    private final String upperTribunalPermissionApplicationsEmailAddress;
     private final PersonalisationProvider personalisationProvider;
 
     public AdminOfficerFtpaDecisionAppellantPersonalisation(
         @Value("${govnotify.template.applicationGranted.admin.email}") String applicationGrantedAdminTemplateId,
         @Value("${govnotify.template.applicationPartiallyGranted.admin.email}") String applicationPartiallyGrantedAdminTemplateId,
         @Value("${ctscAdminFtpaDecisionEmailAddress}") String ctscAdminFtpaDecisionEmailAddress,
+        @Value("${upperTribunalPermissionApplicationsEmailAddress}") String upperTribunalPermissionApplicationsEmailAddress,
         PersonalisationProvider personalisationProvider) {
         this.applicationGrantedAdminTemplateId = applicationGrantedAdminTemplateId;
         this.applicationPartiallyGrantedAdminTemplateId = applicationPartiallyGrantedAdminTemplateId;
         this.ctscAdminFtpaDecisionEmailAddress = ctscAdminFtpaDecisionEmailAddress;
+        this.upperTribunalPermissionApplicationsEmailAddress = upperTribunalPermissionApplicationsEmailAddress;
         this.personalisationProvider = personalisationProvider;
         
     }
@@ -56,7 +62,11 @@ public class AdminOfficerFtpaDecisionAppellantPersonalisation implements EmailNo
 
     @Override
     public Set<String> getRecipientsList(AsylumCase asylumCase) {
-        return Collections.singleton(ctscAdminFtpaDecisionEmailAddress);
+        return ftpaAppellantLjRjDecision(asylumCase)
+            .map(decision -> List.of(FTPA_GRANTED,FTPA_PARTIALLY_GRANTED).contains(decision)
+                ? Set.of(upperTribunalPermissionApplicationsEmailAddress)
+                : Set.of(ctscAdminFtpaDecisionEmailAddress))
+            .orElseThrow(() -> new IllegalStateException("Appellant FTPA decision not present"));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerFtpaDecisionRespondentPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerFtpaDecisionRespondentPersonalisation.java
@@ -2,8 +2,10 @@ package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.admino
 
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_RESPONDENT_DECISION_OUTCOME_TYPE;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_RESPONDENT_RJ_DECISION_OUTCOME_TYPE;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_GRANTED;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_PARTIALLY_GRANTED;
 
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -12,24 +14,28 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.utils.FtpaNotificationPersonalisationUtil;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PersonalisationProvider;
 
 @Service
-public class AdminOfficerFtpaDecisionRespondentPersonalisation implements EmailNotificationPersonalisation {
+public class AdminOfficerFtpaDecisionRespondentPersonalisation implements EmailNotificationPersonalisation, FtpaNotificationPersonalisationUtil {
 
     private final String applicationGrantedAdminTemplateId;
     private final String applicationPartiallyGrantedAdminTemplateId;
     private final String ctscAdminFtpaDecisionEmailAddress;
+    private final String upperTribunalPermissionApplicationsEmailAddress;
     private final PersonalisationProvider personalisationProvider;
 
     public AdminOfficerFtpaDecisionRespondentPersonalisation(
         @Value("${govnotify.template.applicationGranted.admin.email}") String applicationGrantedAdminTemplateId,
         @Value("${govnotify.template.applicationPartiallyGranted.admin.email}") String applicationPartiallyGrantedAdminTemplateId,
         @Value("${ctscAdminFtpaDecisionEmailAddress}") String ctscAdminFtpaDecisionEmailAddress,
+        @Value("${upperTribunalPermissionApplicationsEmailAddress}") String upperTribunalPermissionApplicationsEmailAddress,
         PersonalisationProvider personalisationProvider) {
         this.applicationGrantedAdminTemplateId = applicationGrantedAdminTemplateId;
         this.applicationPartiallyGrantedAdminTemplateId = applicationPartiallyGrantedAdminTemplateId;
         this.ctscAdminFtpaDecisionEmailAddress = ctscAdminFtpaDecisionEmailAddress;
+        this.upperTribunalPermissionApplicationsEmailAddress = upperTribunalPermissionApplicationsEmailAddress;
         this.personalisationProvider = personalisationProvider;
     }
 
@@ -53,7 +59,11 @@ public class AdminOfficerFtpaDecisionRespondentPersonalisation implements EmailN
 
     @Override
     public Set<String> getRecipientsList(AsylumCase asylumCase) {
-        return Collections.singleton(ctscAdminFtpaDecisionEmailAddress);
+        return ftpaRespondentLjRjDecision(asylumCase)
+            .map(decision -> List.of(FTPA_GRANTED,FTPA_PARTIALLY_GRANTED).contains(decision)
+                ? Set.of(upperTribunalPermissionApplicationsEmailAddress)
+                : Set.of(ctscAdminFtpaDecisionEmailAddress))
+            .orElseThrow(() -> new IllegalStateException("Appellant decision not present"));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerFtpaDecisionRespondentPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerFtpaDecisionRespondentPersonalisation.java
@@ -63,7 +63,7 @@ public class AdminOfficerFtpaDecisionRespondentPersonalisation implements EmailN
             .map(decision -> List.of(FTPA_GRANTED,FTPA_PARTIALLY_GRANTED).contains(decision)
                 ? Set.of(upperTribunalPermissionApplicationsEmailAddress)
                 : Set.of(ctscAdminFtpaDecisionEmailAddress))
-            .orElseThrow(() -> new IllegalStateException("Appellant decision not present"));
+            .orElseThrow(() -> new IllegalStateException("Respondent FTPA decision not present"));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionAppellantPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionAppellantPersonalisation.java
@@ -1,24 +1,28 @@
 package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.homeoffice;
 
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.CURRENT_CASE_STATE_VISIBLE_TO_JUDGE;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_APPELLANT_DECISION_OUTCOME_TYPE;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_APPELLANT_DECISION_REMADE_RULE_32;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_APPELLANT_RJ_DECISION_OUTCOME_TYPE;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.utils.FtpaNotificationPersonalisationUtil;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PersonalisationProvider;
 
 @Service
-public class HomeOfficeFtpaApplicationDecisionAppellantPersonalisation implements EmailNotificationPersonalisation, FtpaNotificationPersonalisationUtil {
+public class HomeOfficeFtpaApplicationDecisionAppellantPersonalisation implements EmailNotificationPersonalisation {
 
     private final PersonalisationProvider personalisationProvider;
     private final String upperTribunalNoticesEmailAddress;
-    private final String upperTribunalPermissionApplicationsEmailAddress;
     private final String applicationGrantedOtherPartyHomeOfficeTemplateId;
     private final String applicationPartiallyGrantedOtherPartyHomeOfficeTemplateId;
     private final String applicationNotAdmittedOtherPartyHomeOfficeTemplateId;
@@ -36,8 +40,7 @@ public class HomeOfficeFtpaApplicationDecisionAppellantPersonalisation implement
         @Value("${govnotify.template.applicationAllowed.homeOffice.email}") String applicationAllowedHomeOfficeTemplateId,
         @Value("${govnotify.template.applicationDismissed.homeOffice.email}") String applicationDismissedHomeOfficeTemplateId,
         PersonalisationProvider personalisationProvider,
-        @Value("${upperTribunalNoticesEmailAddress}") String upperTribunalNoticesEmailAddress,
-        @Value("${upperTribunalPermissionApplicationsEmailAddress}") String upperTribunalPermissionApplicationsEmailAddress
+        @Value("${upperTribunalNoticesEmailAddress}") String upperTribunalNoticesEmailAddress
     ) {
         this.applicationGrantedOtherPartyHomeOfficeTemplateId = applicationGrantedOtherPartyHomeOfficeTemplateId;
         this.applicationPartiallyGrantedOtherPartyHomeOfficeTemplateId = applicationPartiallyGrantedOtherPartyHomeOfficeTemplateId;
@@ -48,7 +51,6 @@ public class HomeOfficeFtpaApplicationDecisionAppellantPersonalisation implement
         this.applicationDismissedHomeOfficeTemplateId = applicationDismissedHomeOfficeTemplateId;
         this.personalisationProvider = personalisationProvider;
         this.upperTribunalNoticesEmailAddress = upperTribunalNoticesEmailAddress;
-        this.upperTribunalPermissionApplicationsEmailAddress = upperTribunalPermissionApplicationsEmailAddress;
     }
 
     @Override
@@ -93,13 +95,7 @@ public class HomeOfficeFtpaApplicationDecisionAppellantPersonalisation implement
                     State.FTPA_SUBMITTED,
                     State.FTPA_DECIDED).contains(currentState)
                     ) {
-                    String recipient = ftpaAppellantLjRjDecision(asylumCase)
-                        .map(decision -> List.of(FTPA_GRANTED,FTPA_PARTIALLY_GRANTED).contains(decision)
-                            ? upperTribunalPermissionApplicationsEmailAddress
-                            : upperTribunalNoticesEmailAddress)
-                        .orElseThrow(() -> new IllegalStateException("Appellant decision not present"));
-
-                    return Collections.singleton(recipient);
+                    return Collections.singleton(upperTribunalNoticesEmailAddress);
                 } else {
                     throw new IllegalStateException("homeOffice email Address cannot be found");
                 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionRespondentPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionRespondentPersonalisation.java
@@ -1,10 +1,15 @@
 package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.homeoffice;
 
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_GRANTED;
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_PARTIALLY_GRANTED;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.CURRENT_CASE_STATE_VISIBLE_TO_JUDGE;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_RESPONDENT_DECISION_OUTCOME_TYPE;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_RESPONDENT_DECISION_REMADE_RULE_32;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_RESPONDENT_RJ_DECISION_OUTCOME_TYPE;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
@@ -19,7 +24,6 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisation implemen
 
     private final PersonalisationProvider personalisationProvider;
     private final String upperTribunalNoticesEmailAddress;
-    private final String upperTribunalPermissionApplicationsEmailAddress;
     private final String applicationGrantedApplicantHomeOfficeTemplateId;
     private final String applicationPartiallyGrantedApplicantHomeOfficeTemplateId;
     private final String applicationNotAdmittedApplicantHomeOfficeTemplateId;
@@ -37,8 +41,7 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisation implemen
         @Value("${govnotify.template.applicationAllowed.homeOffice.email}") String applicationAllowedHomeOfficeTemplateId,
         @Value("${govnotify.template.applicationDismissed.homeOffice.email}") String applicationDismissedHomeOfficeTemplateId,
         PersonalisationProvider personalisationProvider,
-        @Value("${upperTribunalNoticesEmailAddress}") String upperTribunalNoticesEmailAddress,
-        @Value("${upperTribunalPermissionApplicationsEmailAddress}") String upperTribunalPermissionApplicationsEmailAddress
+        @Value("${upperTribunalNoticesEmailAddress}") String upperTribunalNoticesEmailAddress
     ) {
         this.applicationGrantedApplicantHomeOfficeTemplateId = applicationGrantedApplicantHomeOfficeTemplateId;
         this.applicationPartiallyGrantedApplicantHomeOfficeTemplateId = applicationPartiallyGrantedApplicantHomeOfficeTemplateId;
@@ -49,7 +52,6 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisation implemen
         this.applicationDismissedHomeOfficeTemplateId = applicationDismissedHomeOfficeTemplateId;
         this.personalisationProvider = personalisationProvider;
         this.upperTribunalNoticesEmailAddress = upperTribunalNoticesEmailAddress;
-        this.upperTribunalPermissionApplicationsEmailAddress = upperTribunalPermissionApplicationsEmailAddress;
     }
 
     @Override
@@ -93,13 +95,7 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisation implemen
                     State.FTPA_SUBMITTED,
                     State.FTPA_DECIDED).contains(currentState)
                 ) {
-                    String recipient = ftpaRespondentLjRjDecision(asylumCase)
-                        .map(decision -> List.of(FTPA_GRANTED,FTPA_PARTIALLY_GRANTED).contains(decision)
-                            ? upperTribunalPermissionApplicationsEmailAddress
-                            : upperTribunalNoticesEmailAddress)
-                        .orElseThrow(() -> new IllegalStateException("Appellant decision not present"));
-
-                    return Collections.singleton(recipient);
+                    return Collections.singleton(upperTribunalNoticesEmailAddress);
                 } else {
                     throw new IllegalStateException("homeOffice email Address cannot be found");
                 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1247,11 +1247,11 @@ paymentExceptionsAdminOfficerEmailAddress: ${PAYMENT_EXCEPTIONS_ADMIN_OFFICER_EM
 apcHomeOfficeEmailAddress: ${HOME_OFFICE_EMAIL_APC}
 lartHomeOfficeEmailAddress: ${HOME_OFFICE_EMAIL_LART}
 upperTribunalNoticesEmailAddress: ${IA_UPPER_TRIBUNAL_NOTICES_EMAIL}
-upperTribunalPermissionApplicationsEmailAddress: ${IA_UPPER_TRIBUNAL_PERMISSION_APPLICATIONS_EMAIL:UTIACpermissionapplications@grantedpartgranted.fake.com}
 
 nbcEmailAddress: ${IA_NBC_EMAIL}
 ctscEmailAddress: ${IA_CTSC_EMAIL}
 ctscAdminPendingPaymentEmailAddress: ${IA_CTSC_ADMIN_PENDING_PAYMENT_EMAIL:pendingPayment@example.com}
+upperTribunalPermissionApplicationsEmailAddress: ${IA_UPPER_TRIBUNAL_PERMISSION_APPLICATIONS_EMAIL:UTIACpermissionapplications@grantedpartgranted.fake.com}
 bailHomeOfficeEmailAddress: ${IA_BAIL_HOME_OFFICE_EMAIL:ho-bail-alar@example.com}
 
 respondentEmailAddresses:

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerFtpaDecisionAppellantPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerFtpaDecisionAppellantPersonalisationTest.java
@@ -2,15 +2,21 @@ package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.admino
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_APPELLANT_DECISION_OUTCOME_TYPE;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_GRANTED;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_PARTIALLY_GRANTED;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
@@ -27,6 +33,7 @@ public class AdminOfficerFtpaDecisionAppellantPersonalisationTest {
 
     private Long caseId = 12345L;
     private String adminOfficeEmailAddress = "some-email@example.com";
+    private String upperTribunalPermissionApplicationsEmailAddress = "upperTribunalPermissionApplicationsEmailAddress";
     private String appealReferenceNumber = "someReferenceNumber";
     private String ariaListingReference = "ariaListingReference";
     private String appellantGivenNames = "someAppellantGivenNames";
@@ -46,8 +53,33 @@ public class AdminOfficerFtpaDecisionAppellantPersonalisationTest {
             grantedTemplateId,
             partiallyGrantedTemplateId,
             adminOfficeEmailAddress,
+            upperTribunalPermissionApplicationsEmailAddress,
             personalisationProvider
         );
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = FtpaDecisionOutcomeType.class, names = {
+        "FTPA_GRANTED",
+        "FTPA_PARTIALLY_GRANTED",
+        "FTPA_REFUSED",
+        "FTPA_NOT_ADMITTED",
+        "FTPA_REHEARD35",
+        "FTPA_REHEARD32",
+        "FTPA_REMADE32",
+        "FTPA_ALLOWED",
+        "FTPA_DISMISSED"
+    })
+    void should_return_correct_recipient_email_address(FtpaDecisionOutcomeType decision) {
+        when(asylumCase.read(FTPA_APPELLANT_DECISION_OUTCOME_TYPE, FtpaDecisionOutcomeType.class))
+            .thenReturn(Optional.of(decision));
+
+        String expectedEmailAddress = Set.of(FTPA_GRANTED, FTPA_PARTIALLY_GRANTED).contains(decision)
+            ? upperTribunalPermissionApplicationsEmailAddress
+            : adminOfficeEmailAddress;
+
+        assertTrue(adminOfficerFtpaDecisionAppellantPersonalisation.getRecipientsList(asylumCase)
+            .contains(expectedEmailAddress));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionAppellantPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionAppellantPersonalisationTest.java
@@ -7,13 +7,19 @@ import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.CURRENT_CASE_STATE_VISIBLE_TO_JUDGE;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_APPELLANT_DECISION_OUTCOME_TYPE;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_APPELLANT_DECISION_REMADE_RULE_32;
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_ALLOWED;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_DISMISSED;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_GRANTED;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_NOT_ADMITTED;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_PARTIALLY_GRANTED;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_REFUSED;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_REHEARD35;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_REMADE32;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,7 +45,6 @@ public class HomeOfficeFtpaApplicationDecisionAppellantPersonalisationTest {
 
     private Long caseId = 12345L;
     private String upperTribunalNoticesEmailAddress = "homeoffice-granted@example.com";
-    private String upperTribunalPermissionApplicationsEmailAddress = "homeoffice-granted-iac@example.com";
     private String appealReferenceNumber = "someReferenceNumber";
     private String homeOfficeRefNumber = "someHomeOfficeRefNumber";
     private String ariaListingReference = "ariaListingReference";
@@ -79,9 +84,7 @@ public class HomeOfficeFtpaApplicationDecisionAppellantPersonalisationTest {
                 allowedTemplateId,
                 dismissedTemplateId,
                 personalisationProvider,
-                upperTribunalNoticesEmailAddress,
-                upperTribunalPermissionApplicationsEmailAddress
-
+                upperTribunalNoticesEmailAddress
             );
     }
 
@@ -162,12 +165,8 @@ public class HomeOfficeFtpaApplicationDecisionAppellantPersonalisationTest {
             when(asylumCase.read(CURRENT_CASE_STATE_VISIBLE_TO_JUDGE, State.class))
                 .thenReturn(Optional.of(state));
 
-            String expectedEmailAddress = Set.of(FTPA_GRANTED, FTPA_PARTIALLY_GRANTED).contains(decision)
-                ? upperTribunalPermissionApplicationsEmailAddress
-                : upperTribunalNoticesEmailAddress;
-
             assertTrue(homeOfficeFtpaApplicationDecisionAppellantPersonalisation.getRecipientsList(asylumCase)
-                .contains(expectedEmailAddress));
+                .contains(upperTribunalNoticesEmailAddress));
         });
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionRespondentPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeFtpaApplicationDecisionRespondentPersonalisationTest.java
@@ -4,15 +4,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_GRANTED;
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.FTPA_PARTIALLY_GRANTED;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.CURRENT_CASE_STATE_VISIBLE_TO_JUDGE;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_RESPONDENT_DECISION_OUTCOME_TYPE;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_RESPONDENT_DECISION_REMADE_RULE_32;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,7 +37,6 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisationTest {
 
     private Long caseId = 12345L;
     private String homeOfficeEmailAddress = "homeoffice-allowed@example.com";
-    private String upperTribunalPermissionApplicationsEmailAddress = "homeoffice-allowed-iac@example.com";
     private String appealReferenceNumber = "someReferenceNumber";
     private String homeOfficeRefNumber = "someHomeOfficeRefNumber";
     private String ariaListingReference = "ariaListingReference";
@@ -78,8 +76,7 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisationTest {
                 allowedTemplateId,
                 dismissedTemplateId,
                 personalisationProvider,
-                homeOfficeEmailAddress,
-                upperTribunalPermissionApplicationsEmailAddress
+                homeOfficeEmailAddress
             );
     }
 
@@ -163,12 +160,8 @@ public class HomeOfficeFtpaApplicationDecisionRespondentPersonalisationTest {
                 when(asylumCase.read(CURRENT_CASE_STATE_VISIBLE_TO_JUDGE, State.class))
                     .thenReturn(Optional.of(state));
 
-                String expectedEmailAddress = Set.of(FTPA_GRANTED, FTPA_PARTIALLY_GRANTED).contains(decision)
-                    ? upperTribunalPermissionApplicationsEmailAddress
-                    : homeOfficeEmailAddress;
-
                 assertTrue(homeOfficeFtpaApplicationDecisionRespondentPersonalisation.getRecipientsList(asylumCase)
-                    .contains(expectedEmailAddress));
+                    .contains(homeOfficeEmailAddress));
             });
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-7109](https://tools.hmcts.net/jira/browse/RIA-7109)


### Change description ###
- Moved previous changes that were made to send notifications to different HO email when FTPA granted/partially granted to Admin


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
