### PR TITLE
RIA-7044 Adding HO Reference number to personalisation for UT notific…

### DIFF
--- a/charts/ia-case-notifications-api/Chart.yaml
+++ b/charts/ia-case-notifications-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ia-case-notifications-api
 home: https://github.com/hmcts/ia-case-notifications-api
-version: 0.0.40
+version: 0.0.41
 description: Immigration & Asylum Case Notifications Service
 maintainers:
   - name: HMCTS Immigration & Asylum Team

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/uppertribunal/UpperTribunalMarkAsReadyForUtTransferPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/uppertribunal/UpperTribunalMarkAsReadyForUtTransferPersonalisation.java
@@ -64,7 +64,6 @@ public class UpperTribunalMarkAsReadyForUtTransferPersonalisation implements Ema
         return ImmutableMap
             .<String, String>builder()
             .putAll(customerServicesProvider.getCustomerServicesPersonalisation())
-            .put("homeOfficeReferenceNumber", asylumCase.read(AsylumCaseDefinition.HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""))
             .put("appealReferenceNumber", asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
             .put("homeOfficeReferenceNumber", asylumCase.read(AsylumCaseDefinition.HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""))
             .put("ariaListingReference", asylumCase.read(AsylumCaseDefinition.ARIA_LISTING_REFERENCE, String.class).orElse(""))

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/uppertribunal/UpperTribunalMarkAsReadyForUtTransferPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/uppertribunal/UpperTribunalMarkAsReadyForUtTransferPersonalisation.java
@@ -65,6 +65,7 @@ public class UpperTribunalMarkAsReadyForUtTransferPersonalisation implements Ema
             .<String, String>builder()
             .putAll(customerServicesProvider.getCustomerServicesPersonalisation())
             .put("appealReferenceNumber", asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+            .put("homeOfficeReferenceNumber", asylumCase.read(AsylumCaseDefinition.HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""))
             .put("ariaListingReference", asylumCase.read(AsylumCaseDefinition.ARIA_LISTING_REFERENCE, String.class).orElse(""))
             .put("appellantGivenNames", asylumCase.read(AsylumCaseDefinition.APPELLANT_GIVEN_NAMES, String.class).orElse(""))
             .put("appellantFamilyName", asylumCase.read(AsylumCaseDefinition.APPELLANT_FAMILY_NAME, String.class).orElse(""))

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/uppertribunal/UpperTribunalMarkAsReadyForUtTransferPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/uppertribunal/UpperTribunalMarkAsReadyForUtTransferPersonalisationTest.java
@@ -27,6 +27,7 @@ public class UpperTribunalMarkAsReadyForUtTransferPersonalisationTest {
     private final String iaExUiFrontendUrl = "http://localhost";
     private final String emailAddress = "upperTribunal@example.com";
     private final String appealReferenceNumber = "someReferenceNumber";
+    private final String homeOfficeReferenceNumber = "someHomeOfficeReferenceNumber";
     private final String ariaListingReference = "someAriaListingReference";
     private final String appellantGivenNames = "someAppellantGivenNames";
     private final String appellantFamilyName = "someAppellantFamilyName";
@@ -44,6 +45,7 @@ public class UpperTribunalMarkAsReadyForUtTransferPersonalisationTest {
     public void setup() {
 
         when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
         when(asylumCase.read(ARIA_LISTING_REFERENCE, String.class)).thenReturn(Optional.of(ariaListingReference));
         when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
         when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
@@ -101,6 +103,7 @@ public class UpperTribunalMarkAsReadyForUtTransferPersonalisationTest {
             upperTribunalMarkAsReadyForUtTransferPersonalisation.getPersonalisation(asylumCase);
 
         assertEquals(appealReferenceNumber, personalisation.get("appealReferenceNumber"));
+        assertEquals(homeOfficeReferenceNumber, personalisation.get("homeOfficeReferenceNumber"));
         assertEquals(ariaListingReference, personalisation.get("ariaListingReference"));
         assertEquals(appellantGivenNames, personalisation.get("appellantGivenNames"));
         assertEquals(appellantFamilyName, personalisation.get("appellantFamilyName"));
@@ -115,6 +118,7 @@ public class UpperTribunalMarkAsReadyForUtTransferPersonalisationTest {
     public void should_return_personalisation_when_all_mandatory_information_given() {
 
         when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.empty());
         when(asylumCase.read(ARIA_LISTING_REFERENCE, String.class)).thenReturn(Optional.empty());
         when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.empty());
         when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.empty());
@@ -124,6 +128,7 @@ public class UpperTribunalMarkAsReadyForUtTransferPersonalisationTest {
             upperTribunalMarkAsReadyForUtTransferPersonalisation.getPersonalisation(asylumCase);
 
         assertEquals("", personalisation.get("appealReferenceNumber"));
+        assertEquals("", personalisation.get("homeOfficeReferenceNumber"));
         assertEquals("", personalisation.get("ariaListingReference"));
         assertEquals("", personalisation.get("appellantGivenNames"));
         assertEquals("", personalisation.get("appellantFamilyName"));


### PR DESCRIPTION
…ation

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-7044

### Change description ###

- Requirement confirmed we need the header to be Respondent/HO header so I added the HO Reference Number field into the before and after listing templates and push that value in personalisation class.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
