### PR TITLE
RIA-7385 Remove pedantic checkstyle rules

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -177,21 +177,12 @@
     </module>
     <module name="OverloadMethodsDeclarationOrder"/>
     <module name="VariableDeclarationUsageDistance"/>
-    <module name="CustomImportOrder">
-      <property name="sortImportsInGroupAlphabetically" value="true"/>
-      <property name="separateLineBetweenGroups" value="true"/>
-      <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceBefore">
       <property name="tokens" value="COMMA, SEMI, POST_INC, POST_DEC, DOT, ELLIPSIS, METHOD_REF"/>
       <property name="allowLineBreaks" value="true"/>
     </module>
     <module name="ParenPad"/>
-    <module name="OperatorWrap">
-      <property name="option" value="NL"/>
-      <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF "/>
-    </module>
     <module name="AnnotationLocation">
       <property name="id" value="AnnotationLocationMostCases"/>
       <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -20,9 +20,9 @@
             ]]</notes>
         <cve>CVE-2022-45688</cve>
     </suppress>
-    <suppress>
+    <suppress until="2023-07-27">
         <cve>CVE-2023-28709</cve>
         <cve>CVE-2023-20883</cve>
-
+        <cve>CVE-2023-35116</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
RIA-7385

### Change description ###
IDEs apply their own formatting by default.
The removed roles enforced the formatting of a specific IDE (Eclipse) and get in the way of developers using IntelliJ, while providing little to no benefit.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
