### PR TITLE
RIA-7392 Refactor of HO notif. for Mark as UT event AiP Citizen

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -23,5 +23,7 @@
     <suppress>
         <cve>CVE-2023-28709</cve>
         <cve>CVE-2023-20883</cve>
+        <cve>CVE-2023-2976</cve>
+        <cve>CVE-2023-35116</cve>
     </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/utils/AsylumCaseUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/utils/AsylumCaseUtils.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils;
 
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_RESPONDENT_RJ_DECISION_OUTCOME_TYPE;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.JourneyType.AIP;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo.NO;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo.YES;
 
@@ -65,5 +66,12 @@ public class AsylumCaseUtils {
     private static String getFacilityName(AsylumCaseDefinition field, AsylumCase asylumCase) {
         return asylumCase.read(field, String.class)
                 .orElseThrow(() -> new RequiredFieldMissingException(field.name() + " is missing"));
+    }
+
+    public static boolean isAipJourney(AsylumCase asylumCase) {
+
+        return asylumCase
+            .read(JOURNEY_TYPE, JourneyType.class)
+            .map(type -> type == AIP).orElse(false);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeMarkAsReadyForUtTransferPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeMarkAsReadyForUtTransferPersonalisationTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.HearingCentre;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.JourneyType;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.Callback;
@@ -49,6 +50,8 @@ public class HomeOfficeMarkAsReadyForUtTransferPersonalisationTest {
     private String homeOfficeRefNumber = "someRepRefNumber";
     private final String homeOfficeApcEmailAddress = "homeOfficeAPC@example.com";
     private final String homeOfficeLartEmailAddress = "homeOfficeLART@example.com";
+    private final String endAppealEmailAddresses = "HO-end-appeal@example.com";
+
 
     @Mock
     PersonalisationProvider personalisationProvider;
@@ -74,6 +77,7 @@ public class HomeOfficeMarkAsReadyForUtTransferPersonalisationTest {
             afterListingTemplateId,
             homeOfficeApcEmailAddress,
             homeOfficeLartEmailAddress,
+            endAppealEmailAddresses,
             iaExUiFrontendUrl,
             emailAddressFinder,
             personalisationProvider,
@@ -125,6 +129,26 @@ public class HomeOfficeMarkAsReadyForUtTransferPersonalisationTest {
         when(emailAddressFinder.getListCaseHomeOfficeEmailAddress(asylumCase)).thenReturn(homeOfficeBhamEmailAddress);
         when(asylumCase.read(AsylumCaseDefinition.STATE_BEFORE_END_APPEAL, State.class))
                 .thenReturn(Optional.of(State.PRE_HEARING));
+
+        assertEquals(Collections.singleton(homeOfficeBhamEmailAddress), homeOfficeMarkAppealReadyForUtTransferPersonalisation.getRecipientsList(asylumCase));
+    }
+
+    @Test
+    public void should_return_the_ho_end_appeal_email_address_before_listing_aip() {
+        when(asylumCase.read(JOURNEY_TYPE, JourneyType.class))
+            .thenReturn(Optional.of(JourneyType.AIP));
+
+        assertEquals(Collections.singleton(endAppealEmailAddresses), homeOfficeMarkAppealReadyForUtTransferPersonalisation.getRecipientsList(asylumCase));
+    }
+
+    @Test
+    public void should_return_the_ho_hearing_centre_email_address_after_listing_aip() {
+        String homeOfficeBhamEmailAddress = "ho-birmingham@example.com";
+
+        when(asylumCase.read(JOURNEY_TYPE, JourneyType.class))
+            .thenReturn(Optional.of(JourneyType.AIP));
+        when(asylumCase.read(LIST_CASE_HEARING_CENTRE, HearingCentre.class)).thenReturn(Optional.of(HearingCentre.BIRMINGHAM));
+        when(emailAddressFinder.getListCaseHomeOfficeEmailAddress(asylumCase)).thenReturn(homeOfficeBhamEmailAddress);
 
         assertEquals(Collections.singleton(homeOfficeBhamEmailAddress), homeOfficeMarkAppealReadyForUtTransferPersonalisation.getRecipientsList(asylumCase));
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/utils/AsylumCaseUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/utils/AsylumCaseUtilsTest.java
@@ -13,10 +13,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AppealType;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.HearingCentre;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.*;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,6 +44,18 @@ public class AsylumCaseUtilsTest {
     void isAdmin_should_return_false() {
         when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(NO));
         assertFalse(AsylumCaseUtils.isInternalCase(asylumCase));
+    }
+
+    @Test
+    void isAipJourney_should_return_true() {
+        when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.of(JourneyType.AIP));
+        assertTrue(AsylumCaseUtils.isAipJourney(asylumCase));
+    }
+
+    @Test
+    void isAipJourney_should_return_false() {
+        when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.of(JourneyType.REP));
+        assertFalse(AsylumCaseUtils.isAipJourney(asylumCase));
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-7392

### Change description ###

- QA fix: Sending HO notification to same end appeal email address (before listing) or the HO hearing centre email (after listing)
- Existing LR and AiP internal flows remain unchanged

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
