### PR TITLE
RIA-7486 update detention location notification - incorrect subject on email

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeUpdateDetentionLocationPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeUpdateDetentionLocationPersonalisation.java
@@ -1,8 +1,7 @@
 package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.legalrepresentative;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.getDetentionFacilityName;
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.isAppealListed;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.*;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
@@ -15,10 +14,6 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefi
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.CustomerServicesProvider;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PersonalisationProvider;
 
-
-
-
-
 @Service
 public class LegalRepresentativeUpdateDetentionLocationPersonalisation implements LegalRepresentativeEmailNotificationPersonalisation {
 
@@ -28,6 +23,10 @@ public class LegalRepresentativeUpdateDetentionLocationPersonalisation implement
     private final CustomerServicesProvider customerServicesProvider;
     private final PersonalisationProvider personalisationProvider;
 
+    @Value("${govnotify.emailPrefix.ada}")
+    private String adaPrefix;
+    @Value("${govnotify.emailPrefix.nonAda}")
+    private String nonAdaPrefix;
 
     public LegalRepresentativeUpdateDetentionLocationPersonalisation(
             @NotNull(message = "updateDetentionLocationBeforeListingAppellantTemplateId cannot be null")
@@ -64,6 +63,7 @@ public class LegalRepresentativeUpdateDetentionLocationPersonalisation implement
                 .<String, String>builder()
                 .putAll(customerServicesProvider.getCustomerServicesPersonalisation())
                 .putAll(personalisationProvider.getLegalRepHeaderPersonalisation(asylumCase))
+                .put("subjectPrefix", isAcceleratedDetainedAppeal(asylumCase) ? adaPrefix : nonAdaPrefix)
                 .put("oldDetentionLocation", asylumCase.read(AsylumCaseDefinition.PREVIOUS_DETENTION_LOCATION, String.class)
                         .orElseThrow(() -> new RequiredFieldMissingException("Previous Detention location is missing")))
                 .put("newDetentionLocation", getDetentionFacilityName(asylumCase))


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7486


### Change description ###
* Added subject prefix in personalisation
* Updated unit test
* Updated notification templates (acf67e1c-ec14-48f5-aed9-61a703831a5c and 59bbd0ed-2b2f-432b-8111-0cb4b9ea9a7d)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
