### PR TITLE
RIA-7390 Make LR name be composite of first+last name

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-4293-send-home-office-evidence-direction.json
+++ b/src/functionalTest/resources/scenarios/RIA-4293-send-home-office-evidence-direction.json
@@ -12,7 +12,8 @@
         "template": "minimal-appeal-submitted.json",
         "replacements": {
           "legalRepCompany": "Some Updated Company Ltd",
-          "legalRepName": "Bob Smith",
+          "legalRepName": "Bob",
+          "legalRepFamilyName": "Smith",
           "legalRepresentativeEmailAddress": "email@updated.com",
           "legalRepReferenceNumber": "updated-reference",
           "directions": [

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AsylumCaseDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AsylumCaseDefinition.java
@@ -88,6 +88,9 @@ public enum AsylumCaseDefinition {
     LEGAL_REP_NAME(
         "legalRepName", new TypeReference<String>(){}),
 
+    LEGAL_REP_FAMILY_NAME(
+        "legalRepFamilyName", new TypeReference<String>(){}),
+
     LEGAL_REP_COMPANY_NAME(
             "legalRepCompanyName", new TypeReference<String>(){}),
 

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/respondent/RespondentEvidenceDirectionPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/respondent/RespondentEvidenceDirectionPersonalisation.java
@@ -89,6 +89,10 @@ public class RespondentEvidenceDirectionPersonalisation implements EmailNotifica
             .map(it -> it.getCaseRoleId() == null)
             .orElse(false);
 
+        String lrName = asylumCase.read(LEGAL_REP_NAME, String.class).orElse("");
+        String lrLastName = asylumCase.read(LEGAL_REP_FAMILY_NAME, String.class).orElse("");
+        String legalRepName = (lrName + " " + lrLastName).trim();
+
         return ImmutableMap
             .<String, String>builder()
             .putAll(customerServicesProvider.getCustomerServicesPersonalisation())
@@ -99,7 +103,7 @@ public class RespondentEvidenceDirectionPersonalisation implements EmailNotifica
             .put("linkToOnlineService", iaExUiFrontendUrl)
             .put("companyName", hasNoc ? "" : asylumCase.read(LEGAL_REP_COMPANY, String.class).orElse(""))
             .put("companyAddress", hasNoc ? "" : companyAddress)
-            .put("legalRepName", hasNoc ? "" : asylumCase.read(LEGAL_REP_NAME, String.class).orElse(""))
+            .put("legalRepName", hasNoc ? "" : legalRepName)
             .put("legalRepEmail", hasNoc ? "" : asylumCase.read(LEGAL_REPRESENTATIVE_EMAIL_ADDRESS, String.class).orElse(""))
             .put("legalRepReference", hasNoc ? "" : asylumCase.read(LEGAL_REP_REFERENCE_NUMBER, String.class).orElse(""))
             .put("dueDate", directionDueDate)

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/respondent/RespondentEvidenceDirectionPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/respondent/RespondentEvidenceDirectionPersonalisationTest.java
@@ -42,6 +42,7 @@ public class RespondentEvidenceDirectionPersonalisationTest {
     private String companyName = "Legal Rep Company Name";
     private String companyAddress = "45 Lunar House Spa Road London SE1 3HP";
     private String legalRepName = "Legal Rep Name";
+    private String legalRepFamilyName = "Legal Rep Family Name";
     private String legalRepReference = "Legal Rep Reference";
     private String legalRepEmail = "Legal Rep Email";
     private String legalRepCompanyName = "Legal Rep Company Name";
@@ -76,6 +77,7 @@ public class RespondentEvidenceDirectionPersonalisationTest {
         when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeRefNumber));
 
         when(asylumCase.read(LEGAL_REP_NAME, String.class)).thenReturn(Optional.of(legalRepName));
+        when(asylumCase.read(LEGAL_REP_FAMILY_NAME, String.class)).thenReturn(Optional.of(legalRepFamilyName));
         when(asylumCase.read(LEGAL_REPRESENTATIVE_EMAIL_ADDRESS, String.class)).thenReturn(Optional.of(legalRepEmail));
         when(asylumCase.read(LEGAL_REP_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(legalRepReference));
         when(asylumCase.read(LEGAL_REP_COMPANY, String.class)).thenReturn(Optional.of(legalRepCompanyName));
@@ -151,7 +153,7 @@ public class RespondentEvidenceDirectionPersonalisationTest {
         assertEquals("", personalisation.get("appellantFamilyName"));
         assertEquals(companyName, personalisation.get("companyName"));
         assertEquals(companyAddress, personalisation.get("companyAddress"));
-        assertEquals(legalRepName, personalisation.get("legalRepName"));
+        assertEquals(legalRepName + " " + legalRepFamilyName, personalisation.get("legalRepName"));
         assertEquals(legalRepEmail, personalisation.get("legalRepEmail"));
         assertEquals(legalRepReference, personalisation.get("legalRepReference"));
         assertEquals(expectedDirectionDueDate, personalisation.get("dueDate"));
@@ -208,7 +210,7 @@ public class RespondentEvidenceDirectionPersonalisationTest {
         assertEquals(appellantFamilyName, personalisation.get("appellantFamilyName"));
         assertEquals(companyName, personalisation.get("companyName"));
         assertEquals(companyAddress, personalisation.get("companyAddress"));
-        assertEquals(legalRepName, personalisation.get("legalRepName"));
+        assertEquals(legalRepName + " " + legalRepFamilyName, personalisation.get("legalRepName"));
         assertEquals(legalRepEmail, personalisation.get("legalRepEmail"));
         assertEquals(legalRepReference, personalisation.get("legalRepReference"));
         assertEquals(expectedDirectionDueDate, personalisation.get("dueDate"));


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-7390](https://tools.hmcts.net/jira/browse/RIA-7390)


### Change description ###
- Turned the only instance where `legalRepName` is read into a composition of `legalRepName` and `legalRepFamilyName`, which will default to just the value of `legalRepName` in case `legalRepFamilyName` is empty.
- `legalRepresentativeName` doesn't seem to need addressing, as it's created in the backend as a result of first name and last name taken from the `userDetails`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
