### PR TITLE
RIA-7218 Non-ADA notification request respondent review

### DIFF
--- a/charts/ia-case-notifications-api/Chart.yaml
+++ b/charts/ia-case-notifications-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ia-case-notifications-api
 home: https://github.com/hmcts/ia-case-notifications-api
-version: 0.0.42
+version: 0.0.43
 description: Immigration & Asylum Case Notifications Service
 maintainers:
   - name: HMCTS Immigration & Asylum Team

--- a/src/functionalTest/resources/scenarios/RIA-6779-internal-ada-case-request-respondent-evidence.json
+++ b/src/functionalTest/resources/scenarios/RIA-6779-internal-ada-case-request-respondent-evidence.json
@@ -49,7 +49,8 @@
           "appellantGivenNames": "Test",
           "appellantFamilyName": "User",
           "isAdmin": "Yes",
-          "isAcceleratedDetainedAppeal": "Yes"
+          "isAcceleratedDetainedAppeal": "Yes",
+          "appellantInDetention": "Yes"
         }
       }
     }
@@ -84,9 +85,10 @@
         "appellantFamilyName": "User",
         "isAdmin": "Yes",
         "isAcceleratedDetainedAppeal": "Yes",
+        "appellantInDetention": "Yes",
         "notificationsSent":[
           {
-            "id": "68111_DENTENTION_ENGAGEMENT_TEAM_REQUEST_RESPONDENT_REVIEW",
+            "id": "68111_DETENTION_ENGAGEMENT_TEAM_REQUEST_RESPONDENT_REVIEW",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {

--- a/src/functionalTest/resources/scenarios/RIA-7218-internal-non-ada-request-respondent-review-det-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-7218-internal-non-ada-request-respondent-review-det-notification.json
@@ -1,0 +1,100 @@
+{
+  "description": "RIA-7218: internal non-ada request respondent evidence (DET)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 7218,
+      "eventId": "requestRespondentReview",
+      "state": "caseUnderReview",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "detentionFacility": "prison",
+          "prisonName": "The Mount",
+          "directions": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "respondentReview",
+                "parties": "respondent",
+                "uniqueId": "eba53f77-a98e-47ed-af30-f0f4d3372f01",
+                "explanation": "You have until the date indicated below to review the appellant's argument and evidence. You must explain whether the appellant makes a valid case for overturning the original decision.\n\nYou must respond to the Tribunal and tell them:\n\n- whether you oppose all or parts of the appellant's case\n- what your grounds are for opposing the case\n- which of the issues are agreed or not agreed\n- whether there are any further issues you wish to raise\n- whether you are prepared to withdraw to grant\n- whether the appeal can be resolved without a hearing\n\nNext steps\n\nIf you do not respond in time the Tribunal will decide how the case should proceed.",
+                "directionType": "requestRespondentReview",
+                "dateDue": "{$TODAY+13}",
+                "dateSent": "{$TODAY}",
+                "previousDates": []
+              }
+            }
+          ],
+          "notificationAttachmentDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "requestRespondentReview",
+                "document": {
+                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                },
+                "suppliedBy": "",
+                "description": "",
+                "dateUploaded": "{$TODAY}"
+              }
+            }
+          ],
+          "appealReferenceNumber": "Test",
+          "homeOfficeReferenceNumber": "Test",
+          "ariaListingReference": "Test",
+          "appellantGivenNames": "Test",
+          "appellantFamilyName": "User",
+          "isAdmin": "Yes",
+          "appellantInDetention": "Yes"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "detentionFacility": "prison",
+        "prisonName": "The Mount",
+        "directions": [
+          {
+            "id": "1",
+            "value": {
+              "tag": "respondentReview",
+              "parties": "respondent",
+              "uniqueId": "eba53f77-a98e-47ed-af30-f0f4d3372f01",
+              "explanation": "You have until the date indicated below to review the appellant's argument and evidence. You must explain whether the appellant makes a valid case for overturning the original decision.\n\nYou must respond to the Tribunal and tell them:\n\n- whether you oppose all or parts of the appellant's case\n- what your grounds are for opposing the case\n- which of the issues are agreed or not agreed\n- whether there are any further issues you wish to raise\n- whether you are prepared to withdraw to grant\n- whether the appeal can be resolved without a hearing\n\nNext steps\n\nIf you do not respond in time the Tribunal will decide how the case should proceed.",
+              "directionType": "requestRespondentReview",
+              "dateDue": "{$TODAY+13}",
+              "dateSent": "{$TODAY}",
+              "previousDates": []
+            }
+          }
+        ],
+        "appealReferenceNumber": "Test",
+        "homeOfficeReferenceNumber": "Test",
+        "ariaListingReference": "Test",
+        "appellantGivenNames": "Test",
+        "appellantFamilyName": "User",
+        "isAdmin": "Yes",
+        "appellantInDetention": "Yes",
+        "notificationsSent":[
+          {
+            "id": "7218_DETENTION_ENGAGEMENT_TEAM_REQUEST_RESPONDENT_REVIEW",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id":"7218_RESPONDENT_REVIEW_DIRECTION",
+            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamRespondentReviewPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamRespondentReviewPersonalisation.java
@@ -46,7 +46,7 @@ public class DetentionEngagementTeamRespondentReviewPersonalisation implements E
 
     @Override
     public String getReferenceId(Long caseId) {
-        return caseId + "_DENTENTION_ENGAGEMENT_TEAM_REQUEST_RESPONDENT_REVIEW";
+        return caseId + "_DETENTION_ENGAGEMENT_TEAM_REQUEST_RESPONDENT_REVIEW";
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -792,7 +792,7 @@ public class NotificationHandlerConfiguration {
                     return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                             && callback.getEvent() == Event.REQUEST_RESPONDENT_REVIEW
                             && isInternalCase(asylumCase)
-                            && isAcceleratedDetainedAppeal(asylumCase);
+                            && isAppellantInDetention(asylumCase);
                 }, notificationGenerators
         );
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamRespondentReviewPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamRespondentReviewPersonalisationTest.java
@@ -60,7 +60,7 @@ class DetentionEngagementTeamRespondentReviewPersonalisationTest {
 
     @Test
     void should_return_given_reference_id() {
-        assertEquals(caseId + "_DENTENTION_ENGAGEMENT_TEAM_REQUEST_RESPONDENT_REVIEW",
+        assertEquals(caseId + "_DETENTION_ENGAGEMENT_TEAM_REQUEST_RESPONDENT_REVIEW",
                 detentionEngagementTeamRespondentReviewPersonalisation.getReferenceId(caseId));
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-7218

### Change description ###

- Replaced check for ADA with check for in Detention to allow notification to send for both ADA and Detained Non-ADA
- Corrected a typo on notification tag 'DETENTION'
- Unit tests updated
- Functional test updates and new scenario for prison as detention facility

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
