### PR TITLE
RIA-7160 request case building notifications DET non-ADA

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7152-internal-ada-request-case-building-colnbrook-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-7152-internal-ada-request-case-building-colnbrook-notification.json
@@ -12,6 +12,7 @@
         "replacements": {
           "currentCaseStateVisibleToHomeOfficeAll":"awaitingRespondentEvidence",
           "currentCaseStateVisibleToLegalRepresentative": "awaitingRespondentEvidence",
+          "appellantInDetention": "Yes",
           "isAcceleratedDetainedAppeal": "Yes",
           "detentionFacility": "immigrationRemovalCentre",
           "ircName": "Colnbrook",
@@ -43,7 +44,7 @@
       "replacements": {
         "notificationsSent": [
           {
-            "id": "71522_INTERNAL_ADA_REQUEST_CASE_BUILDING_EMAIL",
+            "id": "71522_INTERNAL_DET_REQUEST_CASE_BUILDING_EMAIL",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
         ]
@@ -51,9 +52,9 @@
     },
     "notifications": [
       {
-        "reference": "71522_INTERNAL_ADA_REQUEST_CASE_BUILDING_EMAIL",
+        "reference": "71522_INTERNAL_DET_REQUEST_CASE_BUILDING_EMAIL",
         "recipient": "det-irc-colnbrook@example.com",
-        "subject": "Accelerated detained appeal – SERVE IN PERSON: Appeal reasons form",
+        "subject": "ADA – SERVE IN PERSON: Appeal reasons form",
         "body": [
           "Home Office reference: A1234567",
           "HMCTS reference: PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-7152-internal-ada-request-case-building-tinsley-house-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-7152-internal-ada-request-case-building-tinsley-house-notification.json
@@ -12,6 +12,7 @@
         "replacements": {
           "currentCaseStateVisibleToHomeOfficeAll":"awaitingRespondentEvidence",
           "currentCaseStateVisibleToLegalRepresentative": "awaitingRespondentEvidence",
+          "appellantInDetention": "Yes",
           "isAcceleratedDetainedAppeal": "Yes",
           "detentionFacility": "immigrationRemovalCentre",
           "ircName": "Tinsley House",
@@ -43,7 +44,7 @@
       "replacements": {
         "notificationsSent": [
           {
-            "id": "71521_INTERNAL_ADA_REQUEST_CASE_BUILDING_EMAIL",
+            "id": "71521_INTERNAL_DET_REQUEST_CASE_BUILDING_EMAIL",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
         ]
@@ -51,9 +52,9 @@
     },
     "notifications": [
       {
-        "reference": "71521_INTERNAL_ADA_REQUEST_CASE_BUILDING_EMAIL",
+        "reference": "71521_INTERNAL_DET_REQUEST_CASE_BUILDING_EMAIL",
         "recipient": "det-irc-tinsleyhouse@example.com",
-        "subject": "Accelerated detained appeal – SERVE IN PERSON: Appeal reasons form",
+        "subject": "ADA – SERVE IN PERSON: Appeal reasons form",
         "body": [
           "Home Office reference: A1234567",
           "HMCTS reference: PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-7160-internal-detained-request-case-building-notifications-det-prison.json
+++ b/src/functionalTest/resources/scenarios/RIA-7160-internal-detained-request-case-building-notifications-det-prison.json
@@ -1,0 +1,66 @@
+{
+  "description": "RIA-7160 Send request case building notification (Non-ADA) to DET prison (The Mount)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "caseOfficer",
+    "input": {
+      "id": 7160,
+      "eventId": "requestCaseBuilding",
+      "state": "awaitingRespondentEvidence",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "currentCaseStateVisibleToHomeOfficeAll":"awaitingRespondentEvidence",
+          "currentCaseStateVisibleToLegalRepresentative": "awaitingRespondentEvidence",
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "No",
+          "detentionFacility": "prison",
+          "prisonName": "The Mount",
+          "notificationAttachmentDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "requestCaseBuilding",
+                "document": {
+                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                },
+                "suppliedBy": "",
+                "description": "",
+                "dateUploaded": "{$TODAY}"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "notificationsSent": [
+          {
+            "id": "7160_INTERNAL_DET_REQUEST_CASE_BUILDING_EMAIL",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7160_INTERNAL_DET_REQUEST_CASE_BUILDING_EMAIL",
+        "recipient": "det-prison-the-mount@example.com",
+        "subject": "IAFT – SERVE IN PERSON: Appeal reasons form",
+        "body": [
+          "Home Office reference: A1234567",
+          "HMCTS reference: PA/12345/2019",
+          "Appellant name: Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamRequestCaseBuildingPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamRequestCaseBuildingPersonalisation.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detent
 
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.isAcceleratedDetainedAppeal;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
@@ -30,16 +31,19 @@ public class DetentionEngagementTeamRequestCaseBuildingPersonalisation implement
     private final String internalAdaRequestCaseBuildingTemplateId;
     private final DocumentDownloadClient documentDownloadClient;
     private String adaPrefix;
+    private String detainedPrefix;
     private final DetEmailService detEmailService;
 
     public DetentionEngagementTeamRequestCaseBuildingPersonalisation(
             @Value("${govnotify.template.requestCaseBuilding.detentionEngagementTeam.email}") String templateId,
-            @Value("${govnotify.emailPrefix.ada}") String adaPrefix,
+            @Value("${govnotify.emailPrefix.adaInPerson}") String adaPrefix,
+            @Value("${govnotify.emailPrefix.nonAdaInPerson}") String detainedPrefix,
             DetEmailService detEmailService,
             DocumentDownloadClient documentDownloadClient
     ) {
         this.internalAdaRequestCaseBuildingTemplateId = templateId;
         this.adaPrefix = adaPrefix;
+        this.detainedPrefix = detainedPrefix;
         this.detEmailService = detEmailService;
         this.documentDownloadClient = documentDownloadClient;
     }
@@ -70,7 +74,7 @@ public class DetentionEngagementTeamRequestCaseBuildingPersonalisation implement
 
         return ImmutableMap
                 .<String, Object>builder()
-                .put("subjectPrefix", adaPrefix)
+                .put("subjectPrefix", isAcceleratedDetainedAppeal(asylumCase) ? adaPrefix : detainedPrefix)
                 .put("appealReferenceNumber", asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
                 .put("homeOfficeReferenceNumber", asylumCase.read(AsylumCaseDefinition.HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""))
                 .put("appellantGivenNames", asylumCase.read(AsylumCaseDefinition.APPELLANT_GIVEN_NAMES, String.class).orElse(""))

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamRequestCaseBuildingPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamRequestCaseBuildingPersonalisation.java
@@ -29,19 +29,22 @@ import uk.gov.service.notify.NotificationClientException;
 public class DetentionEngagementTeamRequestCaseBuildingPersonalisation implements EmailWithLinkNotificationPersonalisation {
 
     private final String internalAdaRequestCaseBuildingTemplateId;
+    private final String internalDetainedRequestCaseBuildingTemplateId;
     private final DocumentDownloadClient documentDownloadClient;
-    private String adaPrefix;
-    private String detainedPrefix;
+    private final String adaPrefix;
+    private final String detainedPrefix;
     private final DetEmailService detEmailService;
 
     public DetentionEngagementTeamRequestCaseBuildingPersonalisation(
-            @Value("${govnotify.template.requestCaseBuilding.detentionEngagementTeam.email}") String templateId,
+            @Value("${govnotify.template.requestCaseBuilding.detentionEngagementTeam.ada.email}") String templateIdAda,
+            @Value("${govnotify.template.requestCaseBuilding.detentionEngagementTeam.detained.email}") String templateIdDetained,
             @Value("${govnotify.emailPrefix.adaInPerson}") String adaPrefix,
             @Value("${govnotify.emailPrefix.nonAdaInPerson}") String detainedPrefix,
             DetEmailService detEmailService,
             DocumentDownloadClient documentDownloadClient
     ) {
-        this.internalAdaRequestCaseBuildingTemplateId = templateId;
+        this.internalAdaRequestCaseBuildingTemplateId = templateIdAda;
+        this.internalDetainedRequestCaseBuildingTemplateId = templateIdDetained;
         this.adaPrefix = adaPrefix;
         this.detainedPrefix = detainedPrefix;
         this.detEmailService = detEmailService;
@@ -49,8 +52,8 @@ public class DetentionEngagementTeamRequestCaseBuildingPersonalisation implement
     }
 
     @Override
-    public String getTemplateId() {
-        return internalAdaRequestCaseBuildingTemplateId;
+    public String getTemplateId(AsylumCase asylumCase) {
+        return isAcceleratedDetainedAppeal(asylumCase) ? internalAdaRequestCaseBuildingTemplateId : internalDetainedRequestCaseBuildingTemplateId;
     }
 
     @Override
@@ -65,7 +68,7 @@ public class DetentionEngagementTeamRequestCaseBuildingPersonalisation implement
 
     @Override
     public String getReferenceId(Long caseId) {
-        return caseId + "_INTERNAL_ADA_REQUEST_CASE_BUILDING_EMAIL";
+        return caseId + "_INTERNAL_DET_REQUEST_CASE_BUILDING_EMAIL";
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/utils/AsylumCaseUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/utils/AsylumCaseUtils.java
@@ -30,12 +30,6 @@ public class AsylumCaseUtils {
             .equals(YES);
     }
 
-    public static boolean isDetainedAppeal(AsylumCase asylumCase) {
-        return asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)
-                .orElse(NO)
-                .equals(YES);
-    }
-
     public static boolean isAgeAssessmentAppeal(AsylumCase asylumCase) {
         return (asylumCase.read(APPEAL_TYPE, AppealType.class)).orElse(null) == AppealType.AG;
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/utils/AsylumCaseUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/utils/AsylumCaseUtils.java
@@ -30,6 +30,12 @@ public class AsylumCaseUtils {
             .equals(YES);
     }
 
+    public static boolean isDetainedAppeal(AsylumCase asylumCase) {
+        return asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)
+                .orElse(NO)
+                .equals(YES);
+    }
+
     public static boolean isAgeAssessmentAppeal(AsylumCase asylumCase) {
         return (asylumCase.read(APPEAL_TYPE, AppealType.class)).orElse(null) == AppealType.AG;
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -3989,8 +3989,8 @@ public class NotificationGeneratorConfiguration {
         );
     }
 
-    @Bean("internalAdaRequestCaseBuildingNotificationGenerator")
-    public List<NotificationGenerator> internalAdaRequestCaseBuildingNotificationGenerator(
+    @Bean("internalRequestCaseBuildingNotificationGenerator")
+    public List<NotificationGenerator> internalRequestCaseBuildingNotificationGenerator(
             DetentionEngagementTeamRequestCaseBuildingPersonalisation detentionEngagementTeamRequestCaseBuildingPersonalisation,
             GovNotifyNotificationSender notificationSender,
             NotificationIdAppender notificationIdAppender) {

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -4244,8 +4244,8 @@ public class NotificationHandlerConfiguration {
     }
 
     @Bean
-    public PreSubmitCallbackHandler<AsylumCase> internalAdaRequestCaseBuildingNotificationHandler(
-            @Qualifier("internalAdaRequestCaseBuildingNotificationGenerator") List<NotificationGenerator> notificationGenerators) {
+    public PreSubmitCallbackHandler<AsylumCase> internalRequestCaseBuildingNotificationHandler(
+            @Qualifier("internalRequestCaseBuildingNotificationGenerator") List<NotificationGenerator> notificationGenerators) {
 
         return new NotificationHandler(
                 (callbackStage, callback) ->

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -4252,7 +4252,7 @@ public class NotificationHandlerConfiguration {
                         callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                                 && callback.getEvent().equals(Event.REQUEST_CASE_BUILDING)
                                 && isInternalCase(callback.getCaseDetails().getCaseData())
-                                && isDetainedAppeal(callback.getCaseDetails().getCaseData()),
+                                && isAppellantInDetention(callback.getCaseDetails().getCaseData()),
                 notificationGenerators
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -4252,7 +4252,7 @@ public class NotificationHandlerConfiguration {
                         callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                                 && callback.getEvent().equals(Event.REQUEST_CASE_BUILDING)
                                 && isInternalCase(callback.getCaseDetails().getCaseData())
-                                && isAcceleratedDetainedAppeal(callback.getCaseDetails().getCaseData()),
+                                && isDetainedAppeal(callback.getCaseDetails().getCaseData()),
                 notificationGenerators
         );
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -340,7 +340,10 @@ govnotify:
       legalRep:
         email: c08dc7ff-6a7e-437e-adbd-07e173f6b286
       detentionEngagementTeam:
-        email: 9609ebb3-cb45-4322-ba2c-f3d2a162f7b6
+        ada:
+          email: 9609ebb3-cb45-4322-ba2c-f3d2a162f7b6
+        detained:
+          email: a19170d5-2744-451d-b129-45feac446905
     homeOfficeResponseUploaded:
       caseOfficer:
         email: 0df260d7-fd82-430b-86bb-047083a8172a

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamRequestCaseBuildingPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamRequestCaseBuildingPersonalisationTest.java
@@ -25,6 +25,7 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentTag;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentWithMetadata;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DetEmailService;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.DocumentDownloadClient;
 import uk.gov.service.notify.NotificationClientException;
@@ -42,8 +43,9 @@ public class DetentionEngagementTeamRequestCaseBuildingPersonalisationTest {
     @Mock
     DocumentDownloadClient documentDownloadClient;
 
-    private final String requestcaseBuildingTemplateId = "someTemplateId";
-    private final String requestCaseBuildingPersonalisationReferenceId = "_INTERNAL_ADA_REQUEST_CASE_BUILDING_EMAIL";
+    private final String requestCaseBuildingAdaTemplateId = "someAdaTemplateId";
+    private final String requestCaseBuildingDetainedTemplateId = "someDetainedTemplateId";
+    private final String requestCaseBuildingPersonalisationReferenceId = "_INTERNAL_DET_REQUEST_CASE_BUILDING_EMAIL";
     private final String adaPrefix = "ADA - SERVE IN PERSON";
     private final String detainedPrefix = "IAFT - SERVE IN PERSON";
     private final String ircName = "Tinsley House";
@@ -73,7 +75,8 @@ public class DetentionEngagementTeamRequestCaseBuildingPersonalisationTest {
 
         detentionEngagementTeamRequestCaseBuildingPersonalisation =
                 new DetentionEngagementTeamRequestCaseBuildingPersonalisation(
-                        requestcaseBuildingTemplateId,
+                        requestCaseBuildingAdaTemplateId,
+                        requestCaseBuildingDetainedTemplateId,
                         adaPrefix,
                         detainedPrefix,
                         detEmailService,
@@ -82,10 +85,20 @@ public class DetentionEngagementTeamRequestCaseBuildingPersonalisationTest {
     }
 
     @Test
-    public void should_return_given_template_id() {
+    public void should_return_given_template_id_ada() {
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
         assertEquals(
-                requestcaseBuildingTemplateId,
-                detentionEngagementTeamRequestCaseBuildingPersonalisation.getTemplateId()
+                requestCaseBuildingAdaTemplateId,
+                detentionEngagementTeamRequestCaseBuildingPersonalisation.getTemplateId(asylumCase)
+        );
+    }
+
+    @Test
+    public void should_return_given_template_id_detained() {
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        assertEquals(
+            requestCaseBuildingDetainedTemplateId,
+            detentionEngagementTeamRequestCaseBuildingPersonalisation.getTemplateId(asylumCase)
         );
     }
 
@@ -106,12 +119,15 @@ public class DetentionEngagementTeamRequestCaseBuildingPersonalisationTest {
     }
 
     @Test
-    public void should_return_empty_set_email_address_from_asylum_case() {
-        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.of("immigrationRemovalCentre"));
-        when(detEmailService.getDetEmailAddress(asylumCase)).thenReturn(detEmailAddress);
+    public void should_return_empty_set_email_address_from_asylum_case_no_detention_facility() {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.empty());
+        assertEquals(Collections.emptySet(), detentionEngagementTeamRequestCaseBuildingPersonalisation.getRecipientsList(asylumCase));
+    }
 
-        assertTrue(
-            detentionEngagementTeamRequestCaseBuildingPersonalisation.getRecipientsList(asylumCase).contains(detEmailAddress));
+    @Test
+    public void should_return_empty_set_email_address_from_asylum_case_other_detention_facility() {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.of("other"));
+        assertEquals(Collections.emptySet(), detentionEngagementTeamRequestCaseBuildingPersonalisation.getRecipientsList(asylumCase));
     }
 
     @Test
@@ -135,6 +151,7 @@ public class DetentionEngagementTeamRequestCaseBuildingPersonalisationTest {
 
     @Test
     public void should_return_personalisation_when_all_information_given_refused() {
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
 
         final Map<String, Object> expectedPersonalisation =
                 ImmutableMap

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamRequestCaseBuildingPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamRequestCaseBuildingPersonalisationTest.java
@@ -44,7 +44,8 @@ public class DetentionEngagementTeamRequestCaseBuildingPersonalisationTest {
 
     private final String requestcaseBuildingTemplateId = "someTemplateId";
     private final String requestCaseBuildingPersonalisationReferenceId = "_INTERNAL_ADA_REQUEST_CASE_BUILDING_EMAIL";
-    private final String adaPrefix = "Accelerated detained appeal";
+    private final String adaPrefix = "ADA - SERVE IN PERSON";
+    private final String detainedPrefix = "IAFT - SERVE IN PERSON";
     private final String ircName = "Tinsley House";
     private final String detEmailAddress = "some@example.com";
     private final String appealReferenceNumber = "someReferenceNumber";
@@ -74,6 +75,7 @@ public class DetentionEngagementTeamRequestCaseBuildingPersonalisationTest {
                 new DetentionEngagementTeamRequestCaseBuildingPersonalisation(
                         requestcaseBuildingTemplateId,
                         adaPrefix,
+                        detainedPrefix,
                         detEmailService,
                         documentDownloadClient
                 );


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-7160

### Change description ###

- Rework the notification to DET for Request Case Building event to allow both ADA and Non-ADA templates (each has different number and name/links for forms)
- Fixed Subject prefix in pre-existing ADA notification to match what's in application.yaml and adjusted functional tests accordingly
- Some renaming of generator and handler which is reused for both, so made it more generic

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
