### PR TITLE
RIA-7551_appeal_can_proceed: Add notification personalisation, config…

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -25,5 +25,6 @@
         <cve>CVE-2023-20883</cve>
         <cve>CVE-2023-2976</cve>
         <cve>CVE-2023-35116</cve>
+        <cve>CVE-2023-34034</cve>
     </suppress>
 </suppressions>

--- a/src/functionalTest/resources/scenarios/RIA-2774-force-case-progression-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-2774-force-case-progression-notification.json
@@ -62,7 +62,7 @@
     "notifications": [
       {
         "reference": "2774_RESPONDENT_FORCE_CASE_PROGRESSION",
-        "recipient": "{$respondentEmailAddresses.nonStandardDirectionUntilListing}",
+        "recipient": "{$IA_RESPONDENT_EVIDENCE_DIRECTION_EMAIL}",
         "subject": "Immigration and Asylum appeal: Case progressed without respondent evidence",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-2774-force-case-progression-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-2774-force-case-progression-notification.json
@@ -62,7 +62,7 @@
     "notifications": [
       {
         "reference": "2774_RESPONDENT_FORCE_CASE_PROGRESSION",
-        "recipient": "{$IA_RESPONDENT_EVIDENCE_DIRECTION_EMAIL}",
+        "recipient": "{$respondentEmailAddresses.nonStandardDirectionUntilListing}",
         "subject": "Immigration and Asylum appeal: Case progressed without respondent evidence",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-7551-internal-non-ada-detention-appeal-can-proceed.json
+++ b/src/functionalTest/resources/scenarios/RIA-7551-internal-non-ada-detention-appeal-can-proceed.json
@@ -1,0 +1,65 @@
+{
+  "description": "RIA-7551 internal non-ada Appeal can proceed notification",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7551,
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "detentionFacility": "prison",
+          "prisonName": "The Mount",
+          "isAcceleratedDetainedAppeal": "No",
+          "appellantInDetention": "Yes",
+          "submissionOutOfTime": "No",
+          "notificationAttachmentDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "recordOutOfTimeDecisionDocument",
+                "document": {
+                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                },
+                "suppliedBy": "",
+                "description": "",
+                "dateUploaded": "{$TODAY}"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "notificationsSent": [
+          {
+            "id": "7551_INTERNAL_NON_ADA_RECORD_OUT_OF_TIME_DECISION_CAN_PROCEED",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7551_INTERNAL_NON_ADA_RECORD_OUT_OF_TIME_DECISION_CAN_PROCEED",
+        "recipient": "det-prison-the-mount@example.com",
+        "subject": "IAFT – SERVE IN PERSON: Appeal details have been sent",
+        "body": [
+          "Home Office reference: A1234567",
+          "HMCTS reference: PA/12345/2019",
+          "Appellant name: Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7551-internal-non-ada-detention-appeal-can-proceed.json
+++ b/src/functionalTest/resources/scenarios/RIA-7551-internal-non-ada-detention-appeal-can-proceed.json
@@ -1,20 +1,21 @@
 {
-  "description": "RIA-7551 internal non-ada Appeal can proceed notification",
+  "description": "RIA-7551 CaseOfficer record out of time decision and appeal can proceed",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
-    "credentials": "AdminOfficer",
+    "credentials": "CaseOfficer",
     "input": {
       "id": 7551,
-      "eventId": "submitAppeal",
+      "eventId": "recordOutOfTimeDecision",
       "state": "appealSubmitted",
       "caseData": {
         "template": "minimal-internal-appeal-submitted.json",
         "replacements": {
+          "appealType":"protection",
+          "outOfTimeDecisionType": "approved",
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "No",
           "detentionFacility": "prison",
           "prisonName": "The Mount",
-          "isAcceleratedDetainedAppeal": "No",
-          "appellantInDetention": "Yes",
-          "submissionOutOfTime": "No",
           "notificationAttachmentDocuments": [
             {
               "id": "1",
@@ -41,6 +42,8 @@
     "caseData": {
       "template": "minimal-internal-appeal-submitted.json",
       "replacements": {
+        "appealType": "protection",
+        "outOfTimeDecisionType": "approved",
         "notificationsSent": [
           {
             "id": "7551_INTERNAL_NON_ADA_RECORD_OUT_OF_TIME_DECISION_CAN_PROCEED",
@@ -53,7 +56,7 @@
       {
         "reference": "7551_INTERNAL_NON_ADA_RECORD_OUT_OF_TIME_DECISION_CAN_PROCEED",
         "recipient": "det-prison-the-mount@example.com",
-        "subject": "IAFT – SERVE IN PERSON: Appeal details have been sent",
+        "subject": "IAFT – SERVE IN PERSON: Appeal can proceed",
         "body": [
           "Home Office reference: A1234567",
           "HMCTS reference: PA/12345/2019",

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation.java
@@ -1,0 +1,87 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.DETENTION_FACILITY;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentTag.RECORD_OUT_OF_TIME_DECISION_DOCUMENT;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.getLetterForNotification;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailWithLinkNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DetEmailService;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.DocumentDownloadClient;
+import uk.gov.service.notify.NotificationClientException;
+
+@Slf4j
+@Service
+public class AdminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation implements EmailWithLinkNotificationPersonalisation {
+
+    private final String recordOutOfTimeDecisionCanProceedTemplateId;
+    private final String nonAdaPrefix;
+    private final DetEmailService detEmailService;
+    private final DocumentDownloadClient documentDownloadClient;
+
+    public AdminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation(
+            @Value("${govnotify.template.recordOutOfTimeDecision.adminOfficer.canProceed.email}") String recordOutOfTimeDecisionCanProceedTemplateId,
+            @Value("${govnotify.emailPrefix.nonAdaInPerson}") String nonAdaPrefix, DetEmailService detEmailService,
+            DocumentDownloadClient documentDownloadClient
+    ) {
+        this.recordOutOfTimeDecisionCanProceedTemplateId = recordOutOfTimeDecisionCanProceedTemplateId;
+        this.nonAdaPrefix = nonAdaPrefix;
+        this.detEmailService = detEmailService;
+        this.documentDownloadClient = documentDownloadClient;
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_INTERNAL_NON_ADA_RECORD_OUT_OF_TIME_DECISION_CAN_PROCEED";
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        Optional<String> detentionFacility = asylumCase.read(DETENTION_FACILITY, String.class);
+        if (detentionFacility.isEmpty() || detentionFacility.get().equals("other")) {
+            return Collections.emptySet();
+        }
+        return Collections.singleton(detEmailService.getDetEmailAddress(asylumCase));
+    }
+
+    @Override
+    public String getTemplateId() {
+        return recordOutOfTimeDecisionCanProceedTemplateId;
+    }
+
+    @Override
+    public Map<String, Object> getPersonalisationForLink(AsylumCase asylumCase) throws IOException, NotificationClientException {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        return ImmutableMap
+                .<String, Object>builder()
+                .put("subjectPrefix", nonAdaPrefix)
+                .put("appealReferenceNumber", asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+                .put("homeOfficeReferenceNumber", asylumCase.read(AsylumCaseDefinition.HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""))
+                .put("appellantGivenNames", asylumCase.read(AsylumCaseDefinition.APPELLANT_GIVEN_NAMES, String.class).orElse(""))
+                .put("appellantFamilyName", asylumCase.read(AsylumCaseDefinition.APPELLANT_FAMILY_NAME, String.class).orElse(""))
+                .put("documentLink", getAppealCanProceedLetterJsonObject(asylumCase))
+                .build();
+    }
+
+    private JSONObject getAppealCanProceedLetterJsonObject(AsylumCase asylumCase) {
+        try {
+            return documentDownloadClient.getJsonObjectFromDocument(getLetterForNotification(asylumCase, RECORD_OUT_OF_TIME_DECISION_DOCUMENT));
+        } catch (IOException | NotificationClientException e) {
+            log.error("Failed to get Internal 'Appeal can proceed' Letter in compatible format", e);
+            throw new IllegalStateException("Failed to get Internal 'Appeal can proceed' Letter in compatible format");
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -3316,6 +3316,21 @@ public class NotificationGeneratorConfiguration {
         );
     }
 
+    @Bean("recordOfTimeDecisionCanProceedEmailInternalNotificationGenerator")
+    public List<NotificationGenerator> recordOfTimeDecisionCanProceedEmailInternalNotificationHandler(
+            AdminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation adminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation,
+            GovNotifyNotificationSender notificationSender,
+            NotificationIdAppender notificationIdAppender) {
+
+        return Arrays.asList(
+                new EmailWithLinkNotificationGenerator(
+                        newArrayList(Collections.singleton(adminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation)),
+                        notificationSender,
+                        notificationIdAppender
+                )
+        );
+    }
+
     @Bean("recordOfTimeDecisionCannotProceedEmailNotificationGenerator")
     public List<NotificationGenerator> recordOfTimeDecisionCannotProceedEmailNotificationHandler(
         LegalRepresentativeRecordOutOfTimeDecisionCannotProceed legalRepresentativeRecordOutOfTimeDecisionCannotProceed,

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -3416,7 +3416,6 @@ public class NotificationHandlerConfiguration {
         );
     }
 
-
     @Bean
     public PreSubmitCallbackHandler<AsylumCase> recordOfTimeDecisionCanProceedEmailNotificationHandler(
         @Qualifier("recordOfTimeDecisionCanProceedEmailNotificationGenerator")
@@ -3434,9 +3433,34 @@ public class NotificationHandlerConfiguration {
                        && callback.getEvent() == Event.RECORD_OUT_OF_TIME_DECISION
                        && Arrays.asList(IN_TIME, OutOfTimeDecisionType.APPROVED)
                            .contains(outOfTimeDecisionType)
-                       && isRepJourney(asylumCase);
+                       && isRepJourney(asylumCase)
+                       && !isInternalCase(asylumCase);
 
             }, notificationGenerators
+        );
+    }
+
+    @Bean
+    public PreSubmitCallbackHandler<AsylumCase> recordOfTimeDecisionCanProceedEmailInternalNotificationHandler(
+            @Qualifier("recordOfTimeDecisionCanProceedEmailInternalNotificationGenerator")
+            List<NotificationGenerator> notificationGenerators) {
+
+        return new NotificationHandler(
+                (callbackStage, callback) -> {
+                    AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+                    OutOfTimeDecisionType outOfTimeDecisionType =
+                            asylumCase.read(OUT_OF_TIME_DECISION_TYPE, OutOfTimeDecisionType.class)
+                                    .orElse(UNKNOWN);
+
+                    return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                            && callback.getEvent() == Event.RECORD_OUT_OF_TIME_DECISION
+                            && outOfTimeDecisionType == OutOfTimeDecisionType.APPROVED
+                            && isInternalCase(asylumCase)
+                            && isAppellantInDetention(asylumCase)
+                            && !isAcceleratedDetainedAppeal(asylumCase);
+
+                }, notificationGenerators
         );
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -911,6 +911,9 @@ govnotify:
         cannotProceed:
           email: 233b7b72-9fcd-421a-bf8d-0e20cf23343c
           sms: c54e3e51-43ba-48f4-ae88-8a269153259c
+      adminOfficer:
+        canProceed:
+          email: 08f27b34-cd85-40c7-953d-eebea17467d1
     upperTribunalBundleFailed:
       adminOfficer:
         email: 04dc7de2-32d6-4a00-a8e6-c3c4ee9bc985

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1283,6 +1283,7 @@ security:
       - "markAppealAsDetained"
       - "markAsReadyForUtTransfer"
       - "updateDetentionLocation"
+      - "recordOutOfTimeDecision"
     caseworker-ia-homeofficeapc:
       - "uploadHomeOfficeBundle"
       - "uploadAdditionalEvidenceHomeOffice"

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerRecordOutOfTimeDecisionCanProceedPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerRecordOutOfTimeDecisionCanProceedPersonalisationTest.java
@@ -1,0 +1,140 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.TestUtils.getDocumentWithMetadata;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo.YES;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentWithMetadata;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DetEmailService;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.DocumentDownloadClient;
+import uk.gov.service.notify.NotificationClientException;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AdminOfficerRecordOutOfTimeDecisionCanProceedPersonalisationTest {
+    @Mock
+    AsylumCase asylumCase;
+    @Mock
+    DetEmailService detEmailService;
+    @Mock
+    DocumentDownloadClient documentDownloadClient;
+    private final Long caseId = 12345L;
+    private final String templateId = "someTemplateId";
+    private final String nonAdaPrefix = "IAFT - SERVE IN PERSON";
+    private final String appealReferenceNumber = "someReferenceNumber";
+    private final String homeOfficeReferenceNumber = "1234-1234-1234-1234";
+    private final String appellantGivenNames = "someAppellantGivenNames";
+    private final String appellantFamilyName = "someAppellantFamilyName";
+
+    DocumentWithMetadata responseLetter = getDocumentWithMetadata(
+            "1", "non-ada-record-out-of-time-can-proceed", "some other desc", DocumentTag.RECORD_OUT_OF_TIME_DECISION_DOCUMENT);
+    IdValue<DocumentWithMetadata> responseLetterId = new IdValue<>("1", responseLetter);
+    private final JSONObject jsonObject = new JSONObject("{\"title\": \"JsonDocument\"}");
+    private AdminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation adminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation;
+
+    AdminOfficerRecordOutOfTimeDecisionCanProceedPersonalisationTest() {
+    }
+
+    @BeforeEach
+    void setup() throws NotificationClientException, IOException {
+        adminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation = new AdminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation(
+                templateId,
+                nonAdaPrefix,
+                detEmailService,
+                documentDownloadClient
+        );
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YES));
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(asylumCase.read(NOTIFICATION_ATTACHMENT_DOCUMENTS)).thenReturn(Optional.of(newArrayList(responseLetterId)));
+        when(documentDownloadClient.getJsonObjectFromDocument(any(DocumentWithMetadata.class))).thenReturn(jsonObject);
+    }
+
+    @Test
+    void should_return_given_reference_id() {
+        assertEquals(caseId + "_INTERNAL_NON_ADA_RECORD_OUT_OF_TIME_DECISION_CAN_PROCEED",
+                adminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    void should_return_given_det_email_address() {
+        String detentionEngagementTeamEmail = "det@email.com";
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.of("immigrationRemovalCentre"));
+        when(detEmailService.getDetEmailAddress(asylumCase)).thenReturn(detentionEngagementTeamEmail);
+
+        assertTrue(
+                adminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation.getRecipientsList(asylumCase).contains(detentionEngagementTeamEmail));
+    }
+
+    @Test
+    public void should_return_empty_set_email_address_from_asylum_case_no_detention_facility() {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.empty());
+        assertEquals(Collections.emptySet(), adminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation.getRecipientsList(asylumCase));
+    }
+
+    @Test
+    public void should_return_empty_set_email_address_from_asylum_case_other_detention_facility() {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.of("other"));
+        assertEquals(Collections.emptySet(), adminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation.getRecipientsList(asylumCase));
+    }
+
+    @Test
+    void should_return_personalisation_of_all_information() throws NotificationClientException, IOException {
+        Map<String, Object> personalisation = adminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation.getPersonalisationForLink(asylumCase);
+
+        assertEquals(nonAdaPrefix, personalisation.get("subjectPrefix"));
+        assertEquals(appealReferenceNumber, personalisation.get("appealReferenceNumber"));
+        assertEquals(homeOfficeReferenceNumber, personalisation.get("homeOfficeReferenceNumber"));
+        assertEquals(appellantGivenNames, personalisation.get("appellantGivenNames"));
+        assertEquals(appellantFamilyName, personalisation.get("appellantFamilyName"));
+        assertEquals(jsonObject, personalisation.get("documentLink"));
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(() -> adminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation.getPersonalisationForLink((AsylumCase) null))
+                .isExactlyInstanceOf(NullPointerException.class)
+                .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_throw_exception_when_hearing_bundle_is_empty() {
+        when(asylumCase.read(NOTIFICATION_ATTACHMENT_DOCUMENTS)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> adminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation.getPersonalisationForLink(asylumCase))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("recordOutOfTimeDecisionDocument document not available");
+    }
+
+    @Test
+    public void should_throw_exception_when_notification_client_throws_Exception() throws NotificationClientException, IOException {
+        when(documentDownloadClient.getJsonObjectFromDocument(responseLetter)).thenThrow(new NotificationClientException("File size is more than 2MB"));
+        assertThatThrownBy(() -> adminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation.getPersonalisationForLink(asylumCase))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("Failed to get Internal 'Appeal can proceed' Letter in compatible format");
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7551


### Change description ###
Added AdminOfficerRecordOutOfTimeDecisionCanProceedPersonalisation, configuration, handler methods and classes, updated application properties with notification link, added tests


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
