### PR TITLE
RIA-7543 DET notification internal detained EA/HU/EU appeals no remission

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7543-internal-detained-ea-hu-eu-no-remission-appeal-fee-due-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-7543-internal-detained-ea-hu-eu-no-remission-appeal-fee-due-notification.json
@@ -1,0 +1,62 @@
+{
+  "description": "RIA-7543 - Internal detained (non-ada) HU/EU/EA no remission appeal fee is due notification with letter attached",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7543,
+      "eventId": "submitAppeal",
+      "state": "pendingPayment",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "detentionFacility": "immigrationRemovalCentre",
+          "ircName": "Brookhouse",
+          "isAcceleratedDetainedAppeal": "No",
+          "appellantInDetention": "Yes",
+          "remissionType": "noRemission",
+          "appealType": "refusalOfHumanRights",
+          "appealSubmissionDate": "{$TODAY}",
+          "notificationAttachmentDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "internalAppealFeeDueLetter",
+                "document": {
+                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                },
+                "suppliedBy": "",
+                "description": "",
+                "dateUploaded": "{$TODAY}"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "detentionFacility": "immigrationRemovalCentre",
+        "ircName": "Brookhouse",
+        "isAcceleratedDetainedAppeal": "No",
+        "appellantInDetention": "Yes",
+        "remissionType": "noRemission",
+        "appealType": "refusalOfHumanRights",
+        "appealSubmissionDate": "{$TODAY}",
+        "notificationsSent": [
+          {
+            "id": "7543_INTERNAL_DETAINED_APPEAL_FEE_DUE_DET",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTag.java
@@ -43,6 +43,7 @@ public enum DocumentTag {
     INTERNAL_APPEAL_SUBMISSION("internalAppealSubmission"),
     INTERNAL_REQUEST_RESPONDENT_EVIDENCE_LETTER("internalRequestRespondentEvidenceLetter"),
     INTERNAL_END_APPEAL_AUTOMATICALLY("internalEndAppealAutomatically"),
+    INTERNAL_APPEAL_FEE_DUE_LETTER("internalAppealFeeDueLetter"),
 
     @JsonEnumDefaultValue
     NONE("");

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisation.java
@@ -1,0 +1,87 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.DETENTION_FACILITY;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentTag.INTERNAL_APPEAL_FEE_DUE_LETTER;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.getLetterForNotification;
+
+import java.io.IOException;
+import java.util.*;
+import com.google.common.collect.ImmutableMap;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailWithLinkNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DetEmailService;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.DocumentDownloadClient;
+import uk.gov.service.notify.NotificationClientException;
+
+
+@Slf4j
+@Service
+public class DetentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisation implements EmailWithLinkNotificationPersonalisation {
+
+    private final String internalDetainedAppealFeeDueTemplateId;
+    private final DocumentDownloadClient documentDownloadClient;
+    private final DetEmailService detEmailService;
+    private String subjectPrefix;
+
+    public DetentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisation(
+            @Value("${govnotify.template.pendingPaymentEaHuEu.detentionEngagementTeam.email}") String internalDetainedAppealFeeDueTemplateId,
+            DetEmailService detEmailService,
+            DocumentDownloadClient documentDownloadClient,
+            @Value("${govnotify.emailPrefix.nonAdaInPerson}") String subjectPrefix
+    ) {
+        this.internalDetainedAppealFeeDueTemplateId = internalDetainedAppealFeeDueTemplateId;
+        this.detEmailService = detEmailService;
+        this.documentDownloadClient = documentDownloadClient;
+        this.subjectPrefix = subjectPrefix;
+    }
+
+    @Override
+    public String getTemplateId() {
+        return internalDetainedAppealFeeDueTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        Optional<String> detentionFacility = asylumCase.read(DETENTION_FACILITY, String.class);
+        if (detentionFacility.isEmpty() || detentionFacility.get().equals("other")) {
+            return Collections.emptySet();
+        }
+
+        return Collections.singleton(detEmailService.getDetEmailAddress(asylumCase));
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_INTERNAL_DETAINED_APPEAL_FEE_DUE_DET";
+    }
+
+    @Override
+    public Map<String, Object> getPersonalisationForLink(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        return ImmutableMap
+                .<String, Object>builder()
+                .put("subjectPrefix", subjectPrefix)
+                .put("appealReferenceNumber", asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+                .put("homeOfficeReferenceNumber", asylumCase.read(AsylumCaseDefinition.HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""))
+                .put("appellantGivenNames", asylumCase.read(AsylumCaseDefinition.APPELLANT_GIVEN_NAMES, String.class).orElse(""))
+                .put("appellantFamilyName", asylumCase.read(AsylumCaseDefinition.APPELLANT_FAMILY_NAME, String.class).orElse(""))
+                .put("documentLink", getInternalDetainedAppealFeeDueLetterInJsonObject(asylumCase))
+                .build();
+    }
+
+    private JSONObject getInternalDetainedAppealFeeDueLetterInJsonObject(AsylumCase asylumCase) {
+        try {
+            return documentDownloadClient.getJsonObjectFromDocument(getLetterForNotification(asylumCase, INTERNAL_APPEAL_FEE_DUE_LETTER));
+        } catch (IOException | NotificationClientException e) {
+            log.error("Failed to get Internal detained appeal fee due letter in compatible format", e);
+            throw new IllegalStateException("Failed to get Internal detained appeal fee due letter in compatible format");
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -4114,4 +4114,19 @@ public class NotificationGeneratorConfiguration {
                 )
         );
     }
+
+    @Bean("internalDetainedAppealFeeDueNotificationGenerator")
+    public List<NotificationGenerator> internalDetainedAppealFeeDueNotificationGenerator(
+            DetentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisation detentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisation,
+            GovNotifyNotificationSender notificationSender,
+            NotificationIdAppender notificationIdAppender) {
+
+        return Arrays.asList(
+                new EmailWithLinkNotificationGenerator(
+                        newArrayList(Collections.singleton(detentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisation)),
+                        notificationSender,
+                        notificationIdAppender
+                )
+        );
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -157,6 +157,9 @@ govnotify:
           email: cf8eeb5d-f80c-47d9-97e2-48cf3b76b832
       caseOfficer:
         email: 759e7336-11ac-437c-be03-a2da44da49ba
+    pendingPaymentEaHuEu:
+      detentionEngagementTeam:
+        email: 5f3cdec9-42a5-4e5d-8b07-39f5fbddb72a
     requestRespondentEvidenceDirection:
       appellant:
         email: 9c8ab848-b1f7-4dbe-9854-4922e94ece67

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTagTest.java
@@ -41,10 +41,11 @@ public class DocumentTagTest {
         assertEquals("internalAppealSubmission", DocumentTag.INTERNAL_APPEAL_SUBMISSION.toString());
         assertEquals("internalRequestRespondentEvidenceLetter", DocumentTag.INTERNAL_REQUEST_RESPONDENT_EVIDENCE_LETTER.toString());
         assertEquals("internalEndAppealAutomatically", DocumentTag.INTERNAL_END_APPEAL_AUTOMATICALLY.toString());
+        assertEquals("internalAppealFeeDueLetter", DocumentTag.INTERNAL_APPEAL_FEE_DUE_LETTER.toString());
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(39, DocumentTag.values().length);
+        assertEquals(40, DocumentTag.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisationTest.java
@@ -1,0 +1,152 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.TestUtils.compareStringsAndJsonObjects;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.TestUtils.getDocumentWithMetadata;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import com.google.common.collect.ImmutableMap;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentWithMetadata;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DetEmailService;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.DocumentDownloadClient;
+import uk.gov.service.notify.NotificationClientException;
+
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class DetentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisationTest {
+    @Mock
+    AsylumCase asylumCase;
+    @Mock
+    DetEmailService detEmailService;
+    @Mock
+    JSONObject jsonDocument;
+    @Mock
+    DocumentDownloadClient documentDownloadClient;
+
+    private final String templateId = "someTemplateId";
+    private final String detentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisationReferenceId = "_INTERNAL_DETAINED_APPEAL_FEE_DUE_DET";
+    private final String detEmailAddress = "some@example.com";
+    private final String appealReferenceNumber = "someReferenceNumber";
+    private final String homeOfficeReferenceNumber = "1234-1234-1234-1234";
+    private final String appellantGivenNames = "someAppellantGivenNames";
+    private final String appellantFamilyName = "someAppellantFamilyName";
+    private final String subjectPrefix = "IAFT - SERVE IN PERSON";
+    DocumentWithMetadata internalDetainedAppealFeeDueLetter = getDocumentWithMetadata(
+            "1", "internal-detained-payment-due-no-remission-letter", "some other desc", DocumentTag.INTERNAL_APPEAL_FEE_DUE_LETTER);
+    IdValue<DocumentWithMetadata> internalDetainedAppealFeeDueLetterId = new IdValue<>("1", internalDetainedAppealFeeDueLetter);
+
+    private DetentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisation detentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisation;
+
+
+    @BeforeEach
+    public void setUp() throws NotificationClientException, IOException {
+
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
+
+        when(asylumCase.read(NOTIFICATION_ATTACHMENT_DOCUMENTS)).thenReturn(Optional.of(newArrayList(internalDetainedAppealFeeDueLetterId)));
+        when(documentDownloadClient.getJsonObjectFromDocument(internalDetainedAppealFeeDueLetter)).thenReturn(jsonDocument);
+
+        detentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisation =
+                new DetentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisation(
+                        templateId,
+                        detEmailService,
+                        documentDownloadClient,
+                        subjectPrefix
+                );
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        assertEquals(templateId, detentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisation.getTemplateId());
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        Long caseId = 12345L;
+        assertEquals(caseId + detentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisationReferenceId,
+                detentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address_from_asylum_case() {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.of("immigrationRemovalCentre"));
+        when(detEmailService.getDetEmailAddress(asylumCase)).thenReturn(detEmailAddress);
+
+        assertTrue(
+                detentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisation.getRecipientsList(asylumCase).contains(detEmailAddress));
+    }
+
+    @Test
+    public void should_return_empty_set_email_address_from_asylum_case_no_detention_facility() {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.empty());
+        assertEquals(Collections.emptySet(), detentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisation.getRecipientsList(asylumCase));
+    }
+
+    @Test
+    public void should_return_empty_set_email_address_from_asylum_case_other_detention_facility() {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.of("other"));
+        assertEquals(Collections.emptySet(), detentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisation.getRecipientsList(asylumCase));
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(
+                () -> detentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisation.getPersonalisationForLink((AsylumCase) null))
+                .isExactlyInstanceOf(NullPointerException.class)
+                .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_internal_detained_appeal_fee_due_document_is_missing() {
+        when(asylumCase.read(NOTIFICATION_ATTACHMENT_DOCUMENTS)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(
+                () -> detentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisation.getPersonalisationForLink(asylumCase))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("internalAppealFeeDueLetter document not available");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given_refused() {
+
+        final Map<String, Object> expectedPersonalisation =
+                ImmutableMap
+                        .<String, Object>builder()
+                        .put("subjectPrefix", subjectPrefix)
+                        .put("appealReferenceNumber", appealReferenceNumber)
+                        .put("homeOfficeReferenceNumber", homeOfficeReferenceNumber)
+                        .put("appellantGivenNames", appellantGivenNames)
+                        .put("appellantFamilyName", appellantFamilyName)
+                        .put("documentLink", jsonDocument)
+                        .build();
+
+        Map<String, Object> actualPersonalisation =
+                detentionEngagementTeamAppealFeeDueNoRemissionHuEaEuPersonalisation.getPersonalisationForLink(asylumCase);
+
+        assertTrue(compareStringsAndJsonObjects(expectedPersonalisation, actualPersonalisation));
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7543


### Change description ###
* Added new handler, template and bean config for internal detained non-ada appeal fee letter with no remissions
* Imported AppealType class from case-api
* Updated existing unit tests (State, BundleOrder & DocumentTag)
* Added unit tests and FT


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
