### PR TITLE
RIA-7555 review ho response notification (decision maintained + withdrawn)

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7555-internal-detained-home-office-response-review-decision-maintained.json
+++ b/src/functionalTest/resources/scenarios/RIA-7555-internal-detained-home-office-response-review-decision-maintained.json
@@ -1,0 +1,58 @@
+{
+  "description": "RIA-7555 - Internal detained (non-ada) home office response review notification with decision maintained letter attached",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 7555,
+      "eventId": "requestResponseReview",
+      "state": "respondentReview",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "detentionFacility": "immigrationRemovalCentre",
+          "ircName": "Brookhouse",
+          "isAcceleratedDetainedAppeal": "No",
+          "appellantInDetention": "Yes",
+          "appealReviewOutcome": "decisionMaintained",
+          "notificationAttachmentDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "internalDetainedRequestHomeOfficeResponseReview",
+                "document": {
+                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                },
+                "suppliedBy": "",
+                "description": "",
+                "dateUploaded": "{$TODAY}"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "detentionFacility": "immigrationRemovalCentre",
+        "ircName": "Brookhouse",
+        "isAcceleratedDetainedAppeal": "No",
+        "appellantInDetention": "Yes",
+        "appealReviewOutcome": "decisionMaintained",
+        "notificationsSent": [
+          {
+            "id": "7555_INTERNAL_DETAINED_REVIEW_HOME_OFFICE_RESPONSE_DET",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7555-internal-detained-home-office-response-review-decision-withdrawn.json
+++ b/src/functionalTest/resources/scenarios/RIA-7555-internal-detained-home-office-response-review-decision-withdrawn.json
@@ -1,0 +1,58 @@
+{
+  "description": "RIA-7555 - Internal detained (non-ada) home office response review notification with decision withdrawn letter attached",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 7555,
+      "eventId": "requestResponseReview",
+      "state": "respondentReview",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "detentionFacility": "immigrationRemovalCentre",
+          "ircName": "Brookhouse",
+          "isAcceleratedDetainedAppeal": "No",
+          "appellantInDetention": "Yes",
+          "appealReviewOutcome": "decisionWithdrawn",
+          "notificationAttachmentDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "internalDetainedRequestHomeOfficeResponseReview",
+                "document": {
+                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                },
+                "suppliedBy": "",
+                "description": "",
+                "dateUploaded": "{$TODAY}"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "detentionFacility": "immigrationRemovalCentre",
+        "ircName": "Brookhouse",
+        "isAcceleratedDetainedAppeal": "No",
+        "appellantInDetention": "Yes",
+        "appealReviewOutcome": "decisionWithdrawn",
+        "notificationsSent": [
+          {
+            "id": "7555_INTERNAL_DETAINED_REVIEW_HOME_OFFICE_RESPONSE_DET",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamReviewHomeOfficeResponsePersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamReviewHomeOfficeResponsePersonalisation.java
@@ -1,0 +1,102 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPEAL_REVIEW_OUTCOME;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.DETENTION_FACILITY;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentTag.INTERNAL_DETAINED_REQUEST_HO_RESPONSE_REVIEW;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.getLetterForNotification;
+
+import java.io.IOException;
+import java.util.*;
+import com.google.common.collect.ImmutableMap;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AppealReviewOutcome;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailWithLinkNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DetEmailService;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PersonalisationProvider;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.DocumentDownloadClient;
+import uk.gov.service.notify.NotificationClientException;
+
+
+@Slf4j
+@Service
+public class DetentionEngagementTeamReviewHomeOfficeResponsePersonalisation implements EmailWithLinkNotificationPersonalisation {
+
+    private final String homeOfficeAppealReviewMaintainedDocumentName = "Home Office Response";
+    private final String homeOfficeAppealReviewWithdrawnDocumentName = "Withdrawal Letter";
+    private final String internalDetainedReviewHomeOfficeResponseTemplateId;
+    private final DocumentDownloadClient documentDownloadClient;
+    private final DetEmailService detEmailService;
+    private final PersonalisationProvider personalisationProvider;
+
+    private String subjectPrefix;
+
+    public DetentionEngagementTeamReviewHomeOfficeResponsePersonalisation(
+            @Value("${govnotify.template.reviewHomeOfficeResponse.detentionEngagementTeam.email}") String internalDetainedReviewHomeOfficeResponseTemplateId,
+            DetEmailService detEmailService,
+            DocumentDownloadClient documentDownloadClient,
+            @Value("${govnotify.emailPrefix.nonAdaByPost}") String subjectPrefix,
+            PersonalisationProvider personalisationProvider
+    ) {
+        this.internalDetainedReviewHomeOfficeResponseTemplateId = internalDetainedReviewHomeOfficeResponseTemplateId;
+        this.detEmailService = detEmailService;
+        this.documentDownloadClient = documentDownloadClient;
+        this.subjectPrefix = subjectPrefix;
+        this.personalisationProvider = personalisationProvider;
+    }
+
+    @Override
+    public String getTemplateId() {
+        return internalDetainedReviewHomeOfficeResponseTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        Optional<String> detentionFacility = asylumCase.read(DETENTION_FACILITY, String.class);
+        if (detentionFacility.isEmpty() || detentionFacility.get().equals("other")) {
+            return Collections.emptySet();
+        }
+
+        return Collections.singleton(detEmailService.getDetEmailAddress(asylumCase));
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_INTERNAL_DETAINED_REVIEW_HOME_OFFICE_RESPONSE_DET";
+    }
+
+    @Override
+    public Map<String, Object> getPersonalisationForLink(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        return ImmutableMap
+                .<String, Object>builder()
+                .put("subjectPrefix", subjectPrefix)
+                .putAll(personalisationProvider.getAppellantPersonalisation(asylumCase))
+                .put("documentName", getDocumentName(asylumCase))
+                .put("documentLink", getInternalDetainedReviewHomeOfficeResponseLetterInJsonObject(asylumCase))
+                .build();
+    }
+
+    private String getDocumentName(AsylumCase asylumCase) {
+        AppealReviewOutcome appealReviewOutcome =  asylumCase.read(APPEAL_REVIEW_OUTCOME, AppealReviewOutcome.class)
+                .orElseThrow(() -> new IllegalStateException("Appeal review outcome is not present"));
+
+        return appealReviewOutcome.equals(AppealReviewOutcome.DECISION_MAINTAINED)
+                ? homeOfficeAppealReviewMaintainedDocumentName
+                : homeOfficeAppealReviewWithdrawnDocumentName;
+    }
+
+    private JSONObject getInternalDetainedReviewHomeOfficeResponseLetterInJsonObject(AsylumCase asylumCase) {
+        try {
+            return documentDownloadClient.getJsonObjectFromDocument(getLetterForNotification(asylumCase, INTERNAL_DETAINED_REQUEST_HO_RESPONSE_REVIEW));
+        } catch (IOException | NotificationClientException e) {
+            log.error("Failed to get Internal detained review Home Office response letter in compatible format", e);
+            throw new IllegalStateException("Failed to get Internal detained review Home Office response letter in compatible format");
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -4192,4 +4192,19 @@ public class NotificationGeneratorConfiguration {
                 )
         );
     }
+
+    @Bean("internalDetainedReviewHomeOfficeResponseNotificationGenerator")
+    public List<NotificationGenerator> internalDetainedReviewHomeOfficeResponseNotificationGenerator(
+            DetentionEngagementTeamReviewHomeOfficeResponsePersonalisation detentionEngagementTeamReviewHomeOfficeResponsePersonalisation,
+            GovNotifyNotificationSender notificationSender,
+            NotificationIdAppender notificationIdAppender) {
+
+        return List.of(
+                new EmailWithLinkNotificationGenerator(
+                        newArrayList(Collections.singleton(detentionEngagementTeamReviewHomeOfficeResponsePersonalisation)),
+                        notificationSender,
+                        notificationIdAppender
+                )
+        );
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -1420,7 +1420,8 @@ public class NotificationHandlerConfiguration {
 
                 return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                     && callback.getEvent() == Event.REQUEST_RESPONSE_REVIEW
-                    && isRepJourney(asylumCase);
+                    && isRepJourney(asylumCase)
+                    && !isInternalCase(asylumCase);
             },
             notificationGenerators
         );
@@ -4513,6 +4514,24 @@ public class NotificationHandlerConfiguration {
                        && isRemissionPartiallyApprovedOrRejected
                        && isEaHuEuAppeal(asylumCase);
             }, notificationGenerators
+        );
+    }
+
+    @Bean
+    public PreSubmitCallbackHandler<AsylumCase> internalDetainedReviewHomeOfficeResponseNotificationHandler(
+            @Qualifier("internalDetainedReviewHomeOfficeResponseNotificationGenerator") List<NotificationGenerator> notificationGenerators
+    ) {
+
+        return new NotificationHandler(
+                (callbackStage, callback) -> {
+                    final AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+                    return callback.getEvent() == Event.REQUEST_RESPONSE_REVIEW
+                            && callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                            && isInternalCase(asylumCase)
+                            && isAppellantInDetention(asylumCase)
+                            && !isAcceleratedDetainedAppeal(asylumCase);
+                }, notificationGenerators
         );
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -365,6 +365,9 @@ govnotify:
         email: 0df260d7-fd82-430b-86bb-047083a8172a
       detentionEngagementTeam:
         email: c15c1d5d-aa44-4725-b953-14bd506cf7ce
+    reviewHomeOfficeResponse:
+      detentionEngagementTeam:
+        email: 31f172e8-8929-4538-88b0-57d0d89af676
     hearingBundleReady:
       detentionEngagementTeam:
         email: e4c5547d-7cff-49f5-b47c-7861343db513

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTagTest.java
@@ -45,6 +45,7 @@ public class DocumentTagTest {
         assertEquals("internalDetMarkAsPaidLetter", DocumentTag.INTERNAL_DET_MARK_AS_PAID_LETTER.toString());
         assertEquals("internalListCaseLetter", DocumentTag.INTERNAL_LIST_CASE_LETTER.toString());
         assertEquals("internalRequestHearingRequirementsLetter", DocumentTag.INTERNAL_REQUEST_HEARING_REQUIREMENTS_LETTER.toString());
+        assertEquals("internalDetainedRequestHomeOfficeResponseReview", DocumentTag.INTERNAL_DETAINED_REQUEST_HO_RESPONSE_REVIEW.toString());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamReviewHomeOfficeResponsePersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamReviewHomeOfficeResponsePersonalisationTest.java
@@ -1,0 +1,186 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.TestUtils.compareStringsAndJsonObjects;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.TestUtils.getDocumentWithMetadata;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import com.google.common.collect.ImmutableMap;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AppealReviewOutcome;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentWithMetadata;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DetEmailService;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PersonalisationProvider;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.DocumentDownloadClient;
+import uk.gov.service.notify.NotificationClientException;
+
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class DetentionEngagementTeamReviewHomeOfficeResponsePersonalisationTest {
+
+    @Mock
+    AsylumCase asylumCase;
+    @Mock
+    DetEmailService detEmailService;
+    @Mock
+    JSONObject jsonDocument;
+    @Mock
+    DocumentDownloadClient documentDownloadClient;
+    @Mock
+    private PersonalisationProvider personalisationProvider;
+
+    private final String templateId = "someTemplateId";
+    private final String detentionEngagementTeamReviewHomeOfficeResponseersonalisationReferenceId = "_INTERNAL_DETAINED_REVIEW_HOME_OFFICE_RESPONSE_DET";
+    private final String detEmailAddress = "some@example.com";
+    private final String appealReferenceNumber = "someReferenceNumber";
+    private final String homeOfficeReferenceNumber = "someReferenceNumber";
+    private final String appellantGivenNames = "someAppellantGivenNames";
+    private final String appellantFamilyName = "someAppellantFamilyName";
+    private final String subjectPrefix = "IAFT - SERVE BY POST";
+    private final String homeOfficeAppealReviewMaintainedDocumentName = "Home Office Response";
+    private final String homeOfficeAppealReviewWithdrawnDocumentName = "Withdrawal Letter";
+    DocumentWithMetadata internalDetainedReviewHomeOfficeResponseDecisionMaintainedLetter = getDocumentWithMetadata(
+            "1", "Detained appellant letter_HO response when decision maintained", "some other desc", DocumentTag.INTERNAL_DETAINED_REQUEST_HO_RESPONSE_REVIEW);
+    IdValue<DocumentWithMetadata> internalDetainedReviewHomeOfficeResponseDecisionMaintainedLetterId = new IdValue<>("1", internalDetainedReviewHomeOfficeResponseDecisionMaintainedLetter);
+
+    DocumentWithMetadata internalDetainedReviewHomeOfficeResponseDecisionWithdrawnLetter = getDocumentWithMetadata(
+            "1", "Detained appellant letter_HO response when decision withdrawn", "some other desc", DocumentTag.INTERNAL_DETAINED_REQUEST_HO_RESPONSE_REVIEW);
+    IdValue<DocumentWithMetadata> internalDetainedReviewHomeOfficeResponseDecisionWithdrawnLetterId = new IdValue<>("1", internalDetainedReviewHomeOfficeResponseDecisionWithdrawnLetter);
+    private DetentionEngagementTeamReviewHomeOfficeResponsePersonalisation detentionEngagementTeamReviewHomeOfficeResponsePersonalisation;
+
+
+    @BeforeEach
+    public void setUp() throws NotificationClientException, IOException {
+        Map<String, String> appelantInfo = new HashMap<>();
+        appelantInfo.put("appellantGivenNames", appellantGivenNames);
+        appelantInfo.put("appellantFamilyName", appellantFamilyName);
+        appelantInfo.put("homeOfficeReferenceNumber", homeOfficeReferenceNumber);
+        appelantInfo.put("appealReferenceNumber", appealReferenceNumber);
+
+        when(personalisationProvider.getAppellantPersonalisation(asylumCase)).thenReturn(appelantInfo);
+        when(asylumCase.read(APPEAL_REVIEW_OUTCOME, AppealReviewOutcome.class)).thenReturn(Optional.of(AppealReviewOutcome.DECISION_MAINTAINED));
+
+        detentionEngagementTeamReviewHomeOfficeResponsePersonalisation =
+                new DetentionEngagementTeamReviewHomeOfficeResponsePersonalisation(
+                        templateId,
+                        detEmailService,
+                        documentDownloadClient,
+                        subjectPrefix,
+                        personalisationProvider
+                );
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        assertEquals(templateId, detentionEngagementTeamReviewHomeOfficeResponsePersonalisation.getTemplateId());
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        Long caseId = 12345L;
+        assertEquals(caseId + detentionEngagementTeamReviewHomeOfficeResponseersonalisationReferenceId,
+                detentionEngagementTeamReviewHomeOfficeResponsePersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address_from_asylum_case() {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.of("immigrationRemovalCentre"));
+        when(detEmailService.getDetEmailAddress(asylumCase)).thenReturn(detEmailAddress);
+
+        assertTrue(
+                detentionEngagementTeamReviewHomeOfficeResponsePersonalisation.getRecipientsList(asylumCase).contains(detEmailAddress));
+    }
+
+    @Test
+    public void should_return_empty_set_email_address_from_asylum_case_no_detention_facility() {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.empty());
+        assertEquals(Collections.emptySet(), detentionEngagementTeamReviewHomeOfficeResponsePersonalisation.getRecipientsList(asylumCase));
+    }
+
+    @Test
+    public void should_return_empty_set_email_address_from_asylum_case_other_detention_facility() {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.of("other"));
+        assertEquals(Collections.emptySet(), detentionEngagementTeamReviewHomeOfficeResponsePersonalisation.getRecipientsList(asylumCase));
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(
+                () -> detentionEngagementTeamReviewHomeOfficeResponsePersonalisation.getPersonalisationForLink((AsylumCase) null))
+                .isExactlyInstanceOf(NullPointerException.class)
+                .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_internal_detained_request_home_office_response_review_document_is_missing() {
+        when(asylumCase.read(NOTIFICATION_ATTACHMENT_DOCUMENTS)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(
+                () -> detentionEngagementTeamReviewHomeOfficeResponsePersonalisation.getPersonalisationForLink(asylumCase))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("internalDetainedRequestHomeOfficeResponseReview document not available");
+    }
+
+    @ParameterizedTest
+    @EnumSource(AppealReviewOutcome.class)
+    public void should_return_correct_letter_based_on_appeal_review_outcome(AppealReviewOutcome appealReviewOutcome) throws NotificationClientException, IOException {
+        IdValue<DocumentWithMetadata> documentIdValueMetaDataToUpload;
+        documentIdValueMetaDataToUpload = appealReviewOutcome.equals(AppealReviewOutcome.DECISION_MAINTAINED)
+                ? internalDetainedReviewHomeOfficeResponseDecisionMaintainedLetterId
+                : internalDetainedReviewHomeOfficeResponseDecisionWithdrawnLetterId;
+
+        when(asylumCase.read(NOTIFICATION_ATTACHMENT_DOCUMENTS)).thenReturn(Optional.of(newArrayList(documentIdValueMetaDataToUpload)));
+
+        DocumentWithMetadata documentToUpload;
+        documentToUpload = appealReviewOutcome.equals(AppealReviewOutcome.DECISION_MAINTAINED)
+                ? internalDetainedReviewHomeOfficeResponseDecisionMaintainedLetter
+                : internalDetainedReviewHomeOfficeResponseDecisionWithdrawnLetter;
+
+        when(documentDownloadClient.getJsonObjectFromDocument(documentToUpload)).thenReturn(jsonDocument);
+        when(asylumCase.read(APPEAL_REVIEW_OUTCOME, AppealReviewOutcome.class)).thenReturn(Optional.of(appealReviewOutcome));
+
+        String expectedDocumentName = appealReviewOutcome.equals(AppealReviewOutcome.DECISION_MAINTAINED)
+                ? homeOfficeAppealReviewMaintainedDocumentName
+                : homeOfficeAppealReviewWithdrawnDocumentName;
+
+        final Map<String, Object> expectedPersonalisation =
+                ImmutableMap
+                        .<String, Object>builder()
+                        .put("subjectPrefix", subjectPrefix)
+                        .put("appealReferenceNumber", appealReferenceNumber)
+                        .put("homeOfficeReferenceNumber", homeOfficeReferenceNumber)
+                        .put("appellantGivenNames", appellantGivenNames)
+                        .put("appellantFamilyName", appellantFamilyName)
+                        .put("documentName", expectedDocumentName)
+                        .put("documentLink", jsonDocument)
+                        .build();
+
+        Map<String, Object> actualPersonalisation =
+                detentionEngagementTeamReviewHomeOfficeResponsePersonalisation.getPersonalisationForLink(asylumCase);
+
+        assertTrue(compareStringsAndJsonObjects(expectedPersonalisation, actualPersonalisation));
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7555

### Change description ###
* Adding functionality for generating notification when LO requests response review (for both decision maintained and wihdrawn)
* Added unit tests and FTs
* Updated DocumentTag

### Testing ###
Email notification
<img width="282" alt="HomeOfficeReviewResponseNotification" src="https://github.com/hmcts/ia-case-notifications-api/assets/118450580/c70439f8-b751-4bb0-80be-33381dfd93fd">

Decision maintained letter
[maintained_letter.pdf](https://github.com/hmcts/ia-case-notifications-api/files/12359821/maintained_letter.pdf)

Decision withdrawn letter
[withdrawn_letter.pdf](https://github.com/hmcts/ia-case-notifications-api/files/12359839/withdrawn_letter.pdf)





**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
