### PR TITLE
RIA-7329 internal ADA/detained non-ada notification for residentJudgeFtpaDecision event when granted, partially granted or refused only

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -22,5 +22,6 @@
     </suppress>
     <suppress until="2023-09-30">
         <cve>CVE-2023-35116</cve><!-- 2023-08-03 jackson-databind 2.15.2 (latest version at time of writing) is still vulnerable. Check again once a new version becomes available -->
+        <cve>CVE-2023-41080</cve>
     </suppress>
 </suppressions>

--- a/src/functionalTest/resources/scenarios/RIA-2975-RIA-3003-ftpa-applicant-appeal-decision-not-admitted-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-2975-RIA-3003-ftpa-applicant-appeal-decision-not-admitted-appellant.json
@@ -14,6 +14,7 @@
           "currentCaseStateVisibleToJudge": "ftpaSubmitted",
           "listCaseHearingCentre": "bradford",
           "ftpaAppellantDecisionOutcomeType": "notAdmitted",
+          "ftpaAppellantRjDecisionOutcomeType": "notAdmitted",
           "ftpaApplicantType": "appellant",
           "ariaListingReference": "987654321",
           "notificationsSent": []

--- a/src/functionalTest/resources/scenarios/RIA-2975-RIA-3003-ftpa-applicant-appeal-decision-refused-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-2975-RIA-3003-ftpa-applicant-appeal-decision-refused-appellant.json
@@ -13,6 +13,7 @@
         "replacements": {
           "currentCaseStateVisibleToJudge": "ftpaSubmitted",
           "ftpaAppellantDecisionOutcomeType": "refused",
+          "ftpaAppellantRjDecisionOutcomeType": "refused",
           "ftpaApplicantType": "appellant",
           "ariaListingReference": "987654321",
           "notificationsSent": []

--- a/src/functionalTest/resources/scenarios/RIA-2975-RIA-3003-ftpa-applicant-appeal-decision-reheard-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-2975-RIA-3003-ftpa-applicant-appeal-decision-reheard-appellant.json
@@ -14,6 +14,7 @@
         "replacements": {
           "currentCaseStateVisibleToJudge": "ftpaSubmitted",
           "ftpaAppellantDecisionOutcomeType": "reheardRule32",
+          "ftpaAppellantRjDecisionOutcomeType": "reheardRule32",
           "ftpaApplicantType": "appellant",
           "listCaseHearingCentre": "taylorHouse",
           "ariaListingReference": "987654321",

--- a/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-granted-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-granted-appellant.json
@@ -13,6 +13,7 @@
         "replacements": {
           "currentCaseStateVisibleToJudge": "ftpaDecided",
           "ftpaAppellantDecisionOutcomeType": "granted",
+          "ftpaAppellantRjDecisionOutcomeType": "granted",
           "ftpaApplicantType": "appellant",
           "ariaListingReference": "987654321",
           "notificationsSent": []

--- a/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-2975-RIA-4352-ftpa-applicant-appeal-decision-partially-granted-appellant.json
@@ -13,6 +13,7 @@
         "replacements": {
           "currentCaseStateVisibleToJudge": "ftpaDecided",
           "ftpaAppellantDecisionOutcomeType": "partiallyGranted",
+          "ftpaAppellantRjDecisionOutcomeType": "partiallyGranted",
           "ftpaApplicantType": "appellant",
           "ariaListingReference": "987654321",
           "notificationsSent": []

--- a/src/functionalTest/resources/scenarios/RIA-3651-ftpa-applicant-appeal-decision-reheard-rule-32-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-3651-ftpa-applicant-appeal-decision-reheard-rule-32-appellant.json
@@ -15,6 +15,7 @@
           "isReheardAppealEnabled": "Yes",
           "currentCaseStateVisibleToJudge": "ftpaSubmitted",
           "ftpaAppellantDecisionOutcomeType": "reheardRule32",
+          "ftpaAppellantRjDecisionOutcomeType": "reheardRule32",
           "ftpaApplicantType": "appellant",
           "listCaseHearingCentre": "taylorHouse",
           "ariaListingReference": "987654321",

--- a/src/functionalTest/resources/scenarios/RIA-3651-ftpa-applicant-appeal-decision-reheard-rule-35-appellant.json
+++ b/src/functionalTest/resources/scenarios/RIA-3651-ftpa-applicant-appeal-decision-reheard-rule-35-appellant.json
@@ -15,6 +15,7 @@
           "isReheardAppealEnabled": "Yes",
           "currentCaseStateVisibleToJudge": "ftpaSubmitted",
           "ftpaAppellantDecisionOutcomeType": "reheardRule35",
+          "ftpaAppellantRjDecisionOutcomeType": "reheardRule35",
           "ftpaApplicantType": "appellant",
           "listCaseHearingCentre": "taylorHouse",
           "ariaListingReference": "987654321",

--- a/src/functionalTest/resources/scenarios/RIA-6665-ftpa-appellant-not-admitted-in-country.json
+++ b/src/functionalTest/resources/scenarios/RIA-6665-ftpa-appellant-not-admitted-in-country.json
@@ -13,6 +13,7 @@
         "replacements": {
           "currentCaseStateVisibleToJudge": "ftpaSubmitted",
           "ftpaAppellantDecisionOutcomeType": "notAdmitted",
+          "ftpaAppellantRjDecisionOutcomeType": "notAdmitted",
           "ftpaApplicantType": "appellant",
           "ariaListingReference": "987654321",
           "appellantInUk": "Yes"

--- a/src/functionalTest/resources/scenarios/RIA-6665-ftpa-appellant-partially-granted-out-of-country.json
+++ b/src/functionalTest/resources/scenarios/RIA-6665-ftpa-appellant-partially-granted-out-of-country.json
@@ -13,6 +13,7 @@
         "replacements": {
           "currentCaseStateVisibleToJudge": "ftpaSubmitted",
           "ftpaAppellantDecisionOutcomeType": "partiallyGranted",
+          "ftpaAppellantRjDecisionOutcomeType": "partiallyGranted",
           "ftpaApplicantType": "appellant",
           "ariaListingReference": "987654321",
           "appellantInUk": "No"

--- a/src/functionalTest/resources/scenarios/RIA-6665-ftpa-appellant-refused-ada.json
+++ b/src/functionalTest/resources/scenarios/RIA-6665-ftpa-appellant-refused-ada.json
@@ -13,6 +13,7 @@
         "replacements": {
           "currentCaseStateVisibleToJudge": "ftpaSubmitted",
           "ftpaAppellantDecisionOutcomeType": "refused",
+          "ftpaAppellantRjDecisionOutcomeType": "refused",
           "ftpaApplicantType": "appellant",
           "ariaListingReference": "987654321",
           "isAcceleratedDetainedAppeal": "Yes"

--- a/src/functionalTest/resources/scenarios/RIA-7329-internal-appellant-ftpa-rj-decided-ada-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-7329-internal-appellant-ftpa-rj-decided-ada-granted.json
@@ -1,0 +1,71 @@
+{
+  "description": "RIA-7329 Internal appellant's FTPA decided by RJ as granted for ADA case",
+  "launchDarklyKey": "tcw-application-notifications-feature:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 7329,
+      "eventId": "residentJudgeFtpaDecision",
+      "state": "ftpaSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "detentionFacility": "immigrationRemovalCentre",
+          "ircName": "Brookhouse",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "ftpaApplicantType": "appellant",
+          "ftpaAppellantRjDecisionOutcomeType": "granted",
+          "notificationAttachmentDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "internalAppellantFtpaDecidedLetter",
+                "document": {
+                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                },
+                "suppliedBy": "",
+                "description": "",
+                "dateUploaded": "{$TODAY}"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "detentionFacility": "immigrationRemovalCentre",
+        "ircName": "Brookhouse",
+        "isAcceleratedDetainedAppeal": "Yes",
+        "ftpaApplicantType": "appellant",
+        "ftpaAppellantRjDecisionOutcomeType": "granted",
+        "notificationsSent": [
+          {
+            "id": "7329_INTERNAL_APPELLANT_FTPA_DECIDED_BY_RESIDENT_JUDGE_DET",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7329_INTERNAL_APPELLANT_FTPA_DECIDED_BY_RESIDENT_JUDGE_DET",
+        "recipient": "det-irc-brookhouse@example.com",
+        "subject": "ADA – SERVE IN PERSON: FTPA decided",
+        "body": [
+          "Home Office reference: A1234567",
+          "HMCTS reference: PA/12345/2019",
+          "Appellant name: Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7329-internal-appellant-ftpa-rj-decided-ada-refused.json
+++ b/src/functionalTest/resources/scenarios/RIA-7329-internal-appellant-ftpa-rj-decided-ada-refused.json
@@ -1,0 +1,71 @@
+{
+  "description": "RIA-7329 Internal appellant's FTPA decided by RJ as refused for ADA case",
+  "launchDarklyKey": "tcw-application-notifications-feature:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 7329,
+      "eventId": "residentJudgeFtpaDecision",
+      "state": "ftpaSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "detentionFacility": "immigrationRemovalCentre",
+          "ircName": "Brookhouse",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "ftpaApplicantType": "appellant",
+          "ftpaAppellantRjDecisionOutcomeType": "refused",
+          "notificationAttachmentDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "internalAppellantFtpaDecidedLetter",
+                "document": {
+                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                },
+                "suppliedBy": "",
+                "description": "",
+                "dateUploaded": "{$TODAY}"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "detentionFacility": "immigrationRemovalCentre",
+        "ircName": "Brookhouse",
+        "isAcceleratedDetainedAppeal": "Yes",
+        "ftpaApplicantType": "appellant",
+        "ftpaAppellantRjDecisionOutcomeType": "refused",
+        "notificationsSent": [
+          {
+            "id": "7329_INTERNAL_APPELLANT_FTPA_DECIDED_BY_RESIDENT_JUDGE_DET",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7329_INTERNAL_APPELLANT_FTPA_DECIDED_BY_RESIDENT_JUDGE_DET",
+        "recipient": "det-irc-brookhouse@example.com",
+        "subject": "ADA – SERVE IN PERSON: FTPA decided",
+        "body": [
+          "Home Office reference: A1234567",
+          "HMCTS reference: PA/12345/2019",
+          "Appellant name: Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7329-internal-appellant-ftpa-rj-decided-detained-non-ada-granted.json
+++ b/src/functionalTest/resources/scenarios/RIA-7329-internal-appellant-ftpa-rj-decided-detained-non-ada-granted.json
@@ -1,0 +1,69 @@
+{
+  "description": "RIA-7329 Internal appellant's FTPA decided by RJ as granted for detained non-ADA case",
+  "launchDarklyKey": "tcw-application-notifications-feature:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 7329,
+      "eventId": "residentJudgeFtpaDecision",
+      "state": "ftpaSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "detentionFacility": "immigrationRemovalCentre",
+          "ircName": "Brookhouse",
+          "ftpaApplicantType": "appellant",
+          "ftpaAppellantRjDecisionOutcomeType": "granted",
+          "notificationAttachmentDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "internalAppellantFtpaDecidedLetter",
+                "document": {
+                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                },
+                "suppliedBy": "",
+                "description": "",
+                "dateUploaded": "{$TODAY}"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "detentionFacility": "immigrationRemovalCentre",
+        "ircName": "Brookhouse",
+        "ftpaApplicantType": "appellant",
+        "ftpaAppellantRjDecisionOutcomeType": "granted",
+        "notificationsSent": [
+          {
+            "id": "7329_INTERNAL_APPELLANT_FTPA_DECIDED_BY_RESIDENT_JUDGE_DET",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7329_INTERNAL_APPELLANT_FTPA_DECIDED_BY_RESIDENT_JUDGE_DET",
+        "recipient": "det-irc-brookhouse@example.com",
+        "subject": "ADA – SERVE IN PERSON: FTPA decided",
+        "body": [
+          "Home Office reference: A1234567",
+          "HMCTS reference: PA/12345/2019",
+          "Appellant name: Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7329-internal-appellant-ftpa-rj-decided-detained-non-ada-refused.json
+++ b/src/functionalTest/resources/scenarios/RIA-7329-internal-appellant-ftpa-rj-decided-detained-non-ada-refused.json
@@ -1,0 +1,69 @@
+{
+  "description": "RIA-7329 Internal appellant's FTPA decided by RJ as refused for detained non-ADA case",
+  "launchDarklyKey": "tcw-application-notifications-feature:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 7329,
+      "eventId": "residentJudgeFtpaDecision",
+      "state": "ftpaSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "detentionFacility": "immigrationRemovalCentre",
+          "ircName": "Brookhouse",
+          "ftpaApplicantType": "appellant",
+          "ftpaAppellantRjDecisionOutcomeType": "refused",
+          "notificationAttachmentDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "internalAppellantFtpaDecidedLetter",
+                "document": {
+                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                },
+                "suppliedBy": "",
+                "description": "",
+                "dateUploaded": "{$TODAY}"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "detentionFacility": "immigrationRemovalCentre",
+        "ircName": "Brookhouse",
+        "ftpaApplicantType": "appellant",
+        "ftpaAppellantRjDecisionOutcomeType": "refused",
+        "notificationsSent": [
+          {
+            "id": "7329_INTERNAL_APPELLANT_FTPA_DECIDED_BY_RESIDENT_JUDGE_DET",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7329_INTERNAL_APPELLANT_FTPA_DECIDED_BY_RESIDENT_JUDGE_DET",
+        "recipient": "det-irc-brookhouse@example.com",
+        "subject": "ADA – SERVE IN PERSON: FTPA decided",
+        "body": [
+          "Home Office reference: A1234567",
+          "HMCTS reference: PA/12345/2019",
+          "Appellant name: Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTag.java
@@ -55,6 +55,7 @@ public enum DocumentTag {
     INTERNAL_FTPA_SUBMITTED_APPELLANT_LETTER("internalFtpaSubmittedAppellantLetter"),
     INTERNAL_DETAINED_TRANSFER_OUT_OF_ADA_LETTER("internalDetainedTransferOutOfAdaLetter"),
 
+    INTERNAL_APPELLANT_FTPA_DECIDED_LETTER("internalAppellantFtpaDecidedLetter"),
     @JsonEnumDefaultValue
     NONE("");
 

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation.java
@@ -1,0 +1,109 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.DETENTION_FACILITY;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.FTPA_APPELLANT_RJ_DECISION_OUTCOME_TYPE;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentTag.INTERNAL_APPELLANT_FTPA_DECIDED_LETTER;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.getLetterForNotification;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.isAcceleratedDetainedAppeal;
+
+import java.io.IOException;
+import java.util.*;
+import com.google.common.collect.ImmutableMap;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.RequiredFieldMissingException;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailWithLinkNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DetEmailService;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PersonalisationProvider;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.DocumentDownloadClient;
+import uk.gov.service.notify.NotificationClientException;
+
+
+@Slf4j
+@Service
+public class DetentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation implements EmailWithLinkNotificationPersonalisation {
+    @Value("${linksToForms.iaut1}")
+    private static String iaut1FormUrl;
+    private final String internalAppellantFtpaDecidedByResidentJudgeLetterTemplateId;
+    private final DocumentDownloadClient documentDownloadClient;
+    private final DetEmailService detEmailService;
+    private final PersonalisationProvider personalisationProvider;
+    private String formLinkForTemplateIfRequired = "*[IAUT1: Application for permission to appeal from First-tier Tribunal](" + iaut1FormUrl + ")";
+    private String adaPrefix;
+    private String nonAdaPrefix;
+
+    public DetentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation(
+            @Value("${govnotify.template.ftpaDecidedByResidentJudge.detentionEngagementTeam.email}") String internalAppellantFtpaDecidedByResidentJudgeLetterTemplateId,
+            DetEmailService detEmailService,
+            DocumentDownloadClient documentDownloadClient,
+            @Value("${govnotify.emailPrefix.adaInPerson}") String adaPrefix,
+            @Value("${govnotify.emailPrefix.nonAdaInPerson}") String nonAdaPrefix,
+            PersonalisationProvider personalisationProvider
+    ) {
+        this.internalAppellantFtpaDecidedByResidentJudgeLetterTemplateId = internalAppellantFtpaDecidedByResidentJudgeLetterTemplateId;
+        this.detEmailService = detEmailService;
+        this.documentDownloadClient = documentDownloadClient;
+        this.adaPrefix = adaPrefix;
+        this.nonAdaPrefix = nonAdaPrefix;
+        this.personalisationProvider = personalisationProvider;
+    }
+
+    @Override
+    public String getTemplateId() {
+        return internalAppellantFtpaDecidedByResidentJudgeLetterTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        Optional<String> detentionFacility = asylumCase.read(DETENTION_FACILITY, String.class);
+        if (detentionFacility.isEmpty() || detentionFacility.get().equals("other")) {
+            return Collections.emptySet();
+        }
+
+        return Collections.singleton(detEmailService.getDetEmailAddress(asylumCase));
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_INTERNAL_APPELLANT_FTPA_DECIDED_BY_RESIDENT_JUDGE_DET";
+    }
+
+    @Override
+    public Map<String, Object> getPersonalisationForLink(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        Optional<FtpaDecisionOutcomeType> ftpaAppellantDecisionOutcomeType = asylumCase
+                .read(FTPA_APPELLANT_RJ_DECISION_OUTCOME_TYPE, FtpaDecisionOutcomeType.class);
+
+        if (ftpaAppellantDecisionOutcomeType.isEmpty()) {
+            throw new RequiredFieldMissingException("FTPA decision not found");
+        }
+
+        if (ftpaAppellantDecisionOutcomeType.get().equals(FTPA_GRANTED)) {
+            formLinkForTemplateIfRequired = "";
+        }
+
+        return ImmutableMap
+                .<String, Object>builder()
+                .put("subjectPrefix", isAcceleratedDetainedAppeal(asylumCase) ? adaPrefix : nonAdaPrefix)
+                .putAll(personalisationProvider.getAppellantPersonalisation(asylumCase))
+                .put("documentLink", getInternalDetainedReviewHomeOfficeResponseLetterInJsonObject(asylumCase))
+                .put("formLinkForTemplateIfRequired", formLinkForTemplateIfRequired)
+                .build();
+    }
+
+    private JSONObject getInternalDetainedReviewHomeOfficeResponseLetterInJsonObject(AsylumCase asylumCase) {
+        try {
+            return documentDownloadClient.getJsonObjectFromDocument(getLetterForNotification(asylumCase, INTERNAL_APPELLANT_FTPA_DECIDED_LETTER));
+        } catch (IOException | NotificationClientException e) {
+            log.error("Failed to get FTPA decision letter in compatible format", e);
+            throw new IllegalStateException("Failed to get FTPA decision letter in compatible format");
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -4278,4 +4278,20 @@ public class NotificationGeneratorConfiguration {
                 )
         );
     }
+
+    @Bean("internalAppellantFtpaDecidedByRjNotificationGenerator")
+    public List<NotificationGenerator> internalAppellantFtpaDecidedByRjNotificationGenerator(
+            DetentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation detentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation,
+            GovNotifyNotificationSender notificationSender,
+            NotificationIdAppender notificationIdAppender) {
+
+        return List.of(
+                new EmailWithLinkNotificationGenerator(
+                        newArrayList(Collections.singleton(detentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation)),
+                        notificationSender,
+                        notificationIdAppender
+                )
+        );
+    }
+
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -529,6 +529,9 @@ govnotify:
       homeOffice:
         detentionEngagementTeam:
           email: 25fcdc45-722c-4d8e-a199-42f1387ee339
+    ftpaDecidedByResidentJudge:
+      detentionEngagementTeam:
+        email: e1bf96d6-505f-4fcc-bc90-12ad29065bb9
     respondentReview:
       legalRep:
         email: ed2d12f7-c5d0-40c1-a603-3a9f3dd1a95b
@@ -1725,3 +1728,6 @@ ia:
   config:
     validator:
       secret: ${IA_CONFIG_VALIDATOR_SECRET:}
+
+linksToForms:
+  iaut1: ${IAUT1_FORM_URL:https://www.gov.uk/government/publications/form-iaut1-application-for-permission-to-appeal-from-first-tier-tribunal}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTagTest.java
@@ -52,10 +52,11 @@ public class DocumentTagTest {
         assertEquals("internalApplyForFtpaRespondent", DocumentTag.INTERNAL_APPLY_FOR_FTPA_RESPONDENT.toString());
         assertEquals("internalFtpaSubmittedAppellantLetter", DocumentTag.INTERNAL_FTPA_SUBMITTED_APPELLANT_LETTER.toString());
         assertEquals("internalDetainedTransferOutOfAdaLetter", DocumentTag.INTERNAL_DETAINED_TRANSFER_OUT_OF_ADA_LETTER.toString());
+        assertEquals("internalAppellantFtpaDecidedLetter", DocumentTag.INTERNAL_APPELLANT_FTPA_DECIDED_LETTER.toString());
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(50, DocumentTag.values().length);
+        assertEquals(51, DocumentTag.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisationTest.java
@@ -1,0 +1,211 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.TestUtils.compareStringsAndJsonObjects;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.TestUtils.getDocumentWithMetadata;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.FtpaDecisionOutcomeType.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.utils.SubjectPrefixesInitializer.initializePrefixesForInternalAppeal;
+
+import java.io.IOException;
+import java.util.*;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.RequiredFieldMissingException;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DetEmailService;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PersonalisationProvider;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.DocumentDownloadClient;
+import uk.gov.service.notify.NotificationClientException;
+
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class DetentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisationTest {
+
+    @Mock
+    AsylumCase asylumCase;
+    @Mock
+    DetEmailService detEmailService;
+    @Mock
+    JSONObject jsonDocument;
+    @Mock
+    DocumentDownloadClient documentDownloadClient;
+    @Mock
+    private PersonalisationProvider personalisationProvider;
+
+    private final String appellantFtpaDecidedByResidentJudgeTemplateId = "someTemplateId";
+    private final String detentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisationReferenceId = "_INTERNAL_APPELLANT_FTPA_DECIDED_BY_RESIDENT_JUDGE_DET";
+    private final String detEmailAddress = "some@example.com";
+    private final String appealReferenceNumber = "someReferenceNumber";
+    private final String homeOfficeReferenceNumber = "someReferenceNumber";
+    private final String appellantGivenNames = "someAppellantGivenNames";
+    private final String appellantFamilyName = "someAppellantFamilyName";
+    private final String adaPrefix = "ADA - SERVE IN PERSON";
+    private final String nonAdaPrefix = "IAFT - SERVE IN PERSON";
+    private final String iaut1FormUrl = "https://www.gov.uk/government/publications/form-iaut1-application-for-permission-to-appeal-from-first-tier-tribunal";
+    private final String formLinkForTemplateIfRequired = "*[IAUT1: Application for permission to appeal from First-tier Tribunal](" + iaut1FormUrl + ")";
+    DocumentWithMetadata internalFtpaDecidedByRjLetter = getDocumentWithMetadata(
+            "1", "FTPA decided by resident judge letter", "some other desc", DocumentTag.INTERNAL_APPELLANT_FTPA_DECIDED_LETTER);
+    IdValue<DocumentWithMetadata> internalFtpaDecidedByRjLetterId = new IdValue<>("1", internalFtpaDecidedByRjLetter);
+    private DetentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation detentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation;
+
+    @BeforeEach
+    public void setUp() throws NotificationClientException, IOException {
+        Map<String, String> appelantInfo = new HashMap<>();
+        appelantInfo.put("appellantGivenNames", appellantGivenNames);
+        appelantInfo.put("appellantFamilyName", appellantFamilyName);
+        appelantInfo.put("homeOfficeReferenceNumber", homeOfficeReferenceNumber);
+        appelantInfo.put("appealReferenceNumber", appealReferenceNumber);
+
+        when(personalisationProvider.getAppellantPersonalisation(asylumCase)).thenReturn(appelantInfo);
+
+        when(asylumCase.read(FTPA_APPELLANT_RJ_DECISION_OUTCOME_TYPE, FtpaDecisionOutcomeType.class)).thenReturn(Optional.of(FTPA_GRANTED));
+
+        when(asylumCase.read(NOTIFICATION_ATTACHMENT_DOCUMENTS)).thenReturn(Optional.of(newArrayList(internalFtpaDecidedByRjLetterId)));
+        when(documentDownloadClient.getJsonObjectFromDocument(internalFtpaDecidedByRjLetter)).thenReturn(jsonDocument);
+
+        detentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation =
+                new DetentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation(
+                        appellantFtpaDecidedByResidentJudgeTemplateId,
+                        detEmailService,
+                        documentDownloadClient,
+                        adaPrefix,
+                        nonAdaPrefix,
+                        personalisationProvider
+                );
+
+        initializePrefixesForInternalAppeal(detentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation);
+        ReflectionTestUtils.setField(detentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation, "iaut1FormUrl", iaut1FormUrl);
+
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        assertEquals(appellantFtpaDecidedByResidentJudgeTemplateId, detentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation.getTemplateId());
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        Long caseId = 12345L;
+        assertEquals(caseId + detentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisationReferenceId,
+                detentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address_from_asylum_case() {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.of("immigrationRemovalCentre"));
+        when(detEmailService.getDetEmailAddress(asylumCase)).thenReturn(detEmailAddress);
+
+        assertTrue(
+                detentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation.getRecipientsList(asylumCase).contains(detEmailAddress));
+    }
+
+    @Test
+    public void should_return_empty_set_email_address_from_asylum_case_no_detention_facility() {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.empty());
+        assertEquals(Collections.emptySet(), detentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation.getRecipientsList(asylumCase));
+    }
+
+    @Test
+    public void should_return_empty_set_email_address_from_asylum_case_other_detention_facility() {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.of("other"));
+        assertEquals(Collections.emptySet(), detentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation.getRecipientsList(asylumCase));
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+        assertThatThrownBy(
+                () -> detentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation.getPersonalisationForLink((AsylumCase) null))
+                .isExactlyInstanceOf(NullPointerException.class)
+                .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_internal_ftpa_decided_document_is_missing() {
+        when(asylumCase.read(NOTIFICATION_ATTACHMENT_DOCUMENTS)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(
+                () -> detentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation.getPersonalisationForLink(asylumCase))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("internalAppellantFtpaDecidedLetter document not available");
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_ftpa_decision_is_missing() {
+        when(asylumCase.read(FTPA_APPELLANT_RJ_DECISION_OUTCOME_TYPE, FtpaDecisionOutcomeType.class)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(
+                () -> detentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation.getPersonalisationForLink(asylumCase))
+                .isExactlyInstanceOf(RequiredFieldMissingException.class)
+                .hasMessage("FTPA decision not found");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = FtpaDecisionOutcomeType.class, names = {"FTPA_PARTIALLY_GRANTED", "FTPA_REFUSED", "FTPA_GRANTED"})
+    public void should_return_correct_personalisation_for_detained_non_ada_case(FtpaDecisionOutcomeType ftpaDecisionOutcomeType) {
+
+        final Map<String, Object> expectedPersonalisation = new HashMap<>();
+        expectedPersonalisation.put("subjectPrefix", nonAdaPrefix);
+        expectedPersonalisation.put("appealReferenceNumber", appealReferenceNumber);
+        expectedPersonalisation.put("homeOfficeReferenceNumber", homeOfficeReferenceNumber);
+        expectedPersonalisation.put("appellantGivenNames", appellantGivenNames);
+        expectedPersonalisation.put("appellantFamilyName", appellantFamilyName);
+        expectedPersonalisation.put("documentLink", jsonDocument);
+
+        if (List.of(FTPA_PARTIALLY_GRANTED, FTPA_REFUSED).contains(ftpaDecisionOutcomeType)) {
+            expectedPersonalisation.put("formLinkForTemplateIfRequired", formLinkForTemplateIfRequired);
+        } else {
+            expectedPersonalisation.put("formLinkForTemplateIfRequired", "");
+        }
+
+        when(asylumCase.read(FTPA_APPELLANT_RJ_DECISION_OUTCOME_TYPE, FtpaDecisionOutcomeType.class)).thenReturn(Optional.of(ftpaDecisionOutcomeType));
+
+        Map<String, Object> actualPersonalisation =
+                detentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation.getPersonalisationForLink(asylumCase);
+
+        assertTrue(compareStringsAndJsonObjects(expectedPersonalisation, actualPersonalisation));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = FtpaDecisionOutcomeType.class, names = {"FTPA_PARTIALLY_GRANTED", "FTPA_REFUSED", "FTPA_GRANTED"})
+    public void should_return_correct_personalisation_for_ada_case(FtpaDecisionOutcomeType ftpaDecisionOutcomeType) {
+
+        final Map<String, Object> expectedPersonalisation = new HashMap<>();
+        expectedPersonalisation.put("subjectPrefix", adaPrefix);
+        expectedPersonalisation.put("appealReferenceNumber", appealReferenceNumber);
+        expectedPersonalisation.put("homeOfficeReferenceNumber", homeOfficeReferenceNumber);
+        expectedPersonalisation.put("appellantGivenNames", appellantGivenNames);
+        expectedPersonalisation.put("appellantFamilyName", appellantFamilyName);
+        expectedPersonalisation.put("documentLink", jsonDocument);
+
+        if (List.of(FTPA_PARTIALLY_GRANTED, FTPA_REFUSED).contains(ftpaDecisionOutcomeType)) {
+            expectedPersonalisation.put("formLinkForTemplateIfRequired", formLinkForTemplateIfRequired);
+        } else {
+            expectedPersonalisation.put("formLinkForTemplateIfRequired", "");
+        }
+
+        when(asylumCase.read(FTPA_APPELLANT_RJ_DECISION_OUTCOME_TYPE, FtpaDecisionOutcomeType.class)).thenReturn(Optional.of(ftpaDecisionOutcomeType));
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+        Map<String, Object> actualPersonalisation =
+                detentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation.getPersonalisationForLink(asylumCase);
+
+        assertTrue(compareStringsAndJsonObjects(expectedPersonalisation, actualPersonalisation));
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7329
https://tools.hmcts.net/jira/browse/RIA-7676


### Change description ###
RIA-7329
* Added notification template for residentJudgeFtpaDecision
* Created notification configurations for internal ADA and detained non-ADA cases when residentJudgeFtpaDecision is triggered for an FTPA that has been decided as granted, partially granted and refused only
* Imported doc tag
* Added unit and FTs

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
