### PR TITLE
RIA-7359 RIA-7678 Fix for notifications using Leadership event

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-6803-ftpa-respondent-granted-internal-ada-case.json
+++ b/src/functionalTest/resources/scenarios/RIA-6803-ftpa-respondent-granted-internal-ada-case.json
@@ -46,22 +46,6 @@
                 "description": "description"
               }
             }
-          ],
-          "notificationAttachmentDocuments": [
-            {
-              "id": "1",
-              "value": {
-                "tag": "internalHoFtpaDecidedLetter",
-                "document": {
-                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
-                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
-                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
-                },
-                "suppliedBy": "",
-                "description": "",
-                "dateUploaded": "{$TODAY}"
-              }
-            }
           ]
         }
       }
@@ -86,10 +70,6 @@
         "notificationsSent": [
           {
             "id": "68031_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
-          },
-          {
-            "id": "68031_INTERNAL_DET_HO_FTPA_DECIDED_EMAIL",
             "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
         ]

--- a/src/functionalTest/resources/scenarios/RIA-6805-ftpa-respondent-not-addmitted-internal-ada-case.json
+++ b/src/functionalTest/resources/scenarios/RIA-6805-ftpa-respondent-not-addmitted-internal-ada-case.json
@@ -46,22 +46,6 @@
                 "description": "description"
               }
             }
-          ],
-          "notificationAttachmentDocuments": [
-            {
-              "id": "1",
-              "value": {
-                "tag": "internalHoFtpaDecidedLetter",
-                "document": {
-                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
-                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
-                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
-                },
-                "suppliedBy": "",
-                "description": "",
-                "dateUploaded": "{$TODAY}"
-              }
-            }
           ]
         }
       }
@@ -86,10 +70,6 @@
         "notificationsSent": [
           {
             "id": "68051_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
-          },
-          {
-            "id": "68051_INTERNAL_DET_HO_FTPA_DECIDED_EMAIL",
             "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
         ]

--- a/src/functionalTest/resources/scenarios/RIA-6805-ftpa-respondent-refused-internal-ada-case.json
+++ b/src/functionalTest/resources/scenarios/RIA-6805-ftpa-respondent-refused-internal-ada-case.json
@@ -46,22 +46,6 @@
                 "description": "description"
               }
             }
-          ],
-          "notificationAttachmentDocuments": [
-            {
-              "id": "1",
-              "value": {
-                "tag": "internalHoFtpaDecidedLetter",
-                "document": {
-                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
-                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
-                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
-                },
-                "suppliedBy": "",
-                "description": "",
-                "dateUploaded": "{$TODAY}"
-              }
-            }
           ]
         }
       }
@@ -86,10 +70,6 @@
         "notificationsSent": [
           {
             "id": "68052_FTPA_APPLICATION_DECISION_HOME_OFFICE_RESPONDENT",
-            "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
-          },
-          {
-            "id": "68052_INTERNAL_DET_HO_FTPA_DECIDED_EMAIL",
             "value":"$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
         ]

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -2487,10 +2487,9 @@ public class NotificationGeneratorConfiguration {
         );
     }
 
-    @Bean("internalRespondentFtpaApplicationNotificationGenerator")
-    public List<NotificationGenerator> internalRespondentFtpaApplicationNotificationGenerator(
+    @Bean("internalRespondentFtpaApplicationHoNotificationGenerator")
+    public List<NotificationGenerator> internalRespondentFtpaApplicationHoNotificationGenerator(
         HomeOfficeFtpaApplicationDecisionRespondentPersonalisation homeOfficeFtpaApplicationDecisionRespondentPersonalisation,
-        DetentionEngagementTeamRespondentFtpaApplicationDecidedPersonalisation detentionEngagementTeamRespondentFtpaApplicationDecidedPersonalisation,
         GovNotifyNotificationSender notificationSender,
         NotificationIdAppender notificationIdAppender) {
 
@@ -2499,7 +2498,17 @@ public class NotificationGeneratorConfiguration {
                 newArrayList(homeOfficeFtpaApplicationDecisionRespondentPersonalisation),
                 notificationSender,
                 notificationIdAppender
-            ),
+            )
+        );
+    }
+
+    @Bean("internalRespondentFtpaApplicationDetNotificationGenerator")
+    public List<NotificationGenerator> internalRespondentFtpaApplicationDetNotificationGenerator(
+        DetentionEngagementTeamRespondentFtpaApplicationDecidedPersonalisation detentionEngagementTeamRespondentFtpaApplicationDecidedPersonalisation,
+        GovNotifyNotificationSender notificationSender,
+        NotificationIdAppender notificationIdAppender) {
+
+        return Arrays.asList(
             new EmailWithLinkNotificationGenerator(
                 newArrayList(detentionEngagementTeamRespondentFtpaApplicationDecidedPersonalisation),
                 notificationSender,

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -2503,8 +2503,8 @@ public class NotificationHandlerConfiguration {
     }
 
     @Bean
-    public PreSubmitCallbackHandler<AsylumCase> internalRespondentFtpaApplicationNotificationHandler(
-        @Qualifier("internalRespondentFtpaApplicationNotificationGenerator")
+    public PreSubmitCallbackHandler<AsylumCase> internalRespondentFtpaApplicationHoNotificationHandler(
+        @Qualifier("internalRespondentFtpaApplicationHoNotificationGenerator")
         List<NotificationGenerator> notificationGenerators) {
 
         return new NotificationHandler(
@@ -2529,6 +2529,36 @@ public class NotificationHandlerConfiguration {
                     && validDecisionOutcomeTypes.contains(decisionOutcomeType)
                     && AsylumCaseUtils.isAppellantInDetention(asylumCase)
                     && AsylumCaseUtils.isInternalCase(asylumCase);
+            },
+            notificationGenerators
+        );
+    }
+
+    @Bean
+    public PreSubmitCallbackHandler<AsylumCase> internalRespondentFtpaApplicationDetNotificationHandler(
+        @Qualifier("internalRespondentFtpaApplicationDetNotificationGenerator")
+        List<NotificationGenerator> notificationGenerators) {
+
+        return new NotificationHandler(
+            (callbackStage, callback) -> {
+
+                AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+                boolean isRespondentApplication = asylumCase.read(FTPA_APPLICANT_TYPE, ApplicantType.class)
+                    .map(applicantType -> RESPONDENT == applicantType).orElse(false);
+                FtpaDecisionOutcomeType decisionOutcomeType = AsylumCaseUtils.getFtpaDecisionOutcomeType(asylumCase)
+                    .orElse(null);
+                Set<FtpaDecisionOutcomeType> validDecisionOutcomeTypes = Set.of(
+                    FTPA_REFUSED,
+                    FTPA_GRANTED,
+                    FTPA_PARTIALLY_GRANTED
+                );
+
+                return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                       && callback.getEvent() == Event.RESIDENT_JUDGE_FTPA_DECISION
+                       && isRespondentApplication
+                       && validDecisionOutcomeTypes.contains(decisionOutcomeType)
+                       && AsylumCaseUtils.isAppellantInDetention(asylumCase)
+                       && AsylumCaseUtils.isInternalCase(asylumCase);
             },
             notificationGenerators
         );


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-7359
https://tools.hmcts.net/jira/browse/RIA-7678

### Change description ###

- Srihari found an issue where Respondent FTPA decisions were throwing an error trying to send a DET notification without document generated when triggering Leadership decision event. I removed the DET notification completely for this event as it is redundant (and this event will eventually be removed later down the line)
- Functional test fixes on which notifications to expect

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
