### PR TITLE
RIA-7329 RIA-7676 unembedded IAUT1 url from iaut1 text in template content

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisation.java
@@ -87,7 +87,7 @@ public class DetentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonali
         String formLinkForTemplateIfRequired = "";
 
         if (List.of(FTPA_PARTIALLY_GRANTED, FTPA_REFUSED).contains(ftpaAppellantDecisionOutcomeType.get())) {
-            formLinkForTemplateIfRequired = "*[IAUT1: Application for permission to appeal from First-tier Tribunal](" + iaut1FormUrl + ")";
+            formLinkForTemplateIfRequired = "*IAUT1: Application for permission to appeal from First-tier Tribunal\n" + iaut1FormUrl;
         }
 
         return ImmutableMap

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonalisationTest.java
@@ -59,7 +59,7 @@ public class DetentionEngagementTeamAppellantFtpaDecidedByResidentJudgePersonali
     private final String adaPrefix = "ADA - SERVE IN PERSON";
     private final String nonAdaPrefix = "IAFT - SERVE IN PERSON";
     private final String iaut1FormUrl = "https://www.gov.uk/government/publications/form-iaut1-application-for-permission-to-appeal-from-first-tier-tribunal";
-    private final String formLinkForTemplateIfRequired = "*[IAUT1: Application for permission to appeal from First-tier Tribunal](" + iaut1FormUrl + ")";
+    private final String formLinkForTemplateIfRequired = "*IAUT1: Application for permission to appeal from First-tier Tribunal\n" + iaut1FormUrl;
     DocumentWithMetadata internalFtpaDecidedByRjLetter = getDocumentWithMetadata(
             "1", "FTPA decided by resident judge letter", "some other desc", DocumentTag.INTERNAL_APPELLANT_FTPA_DECIDED_LETTER);
     IdValue<DocumentWithMetadata> internalFtpaDecidedByRjLetterId = new IdValue<>("1", internalFtpaDecidedByRjLetter);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7329
https://tools.hmcts.net/jira/browse/RIA-7676


### Change description ###
* Refactored IAUT1 form link for template content. Unembedded link and seperated out the URL from the text.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
