### PR TITLE
RIA-7879 map epims ids to ccd hearing locations

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7879-case-listed-notification-harmondsworth-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7879-case-listed-notification-harmondsworth-hearing-centre.json
@@ -1,0 +1,88 @@
+{
+  "description": "RIA-7879 Send case listed notification to case officer, legal rep and home office (Harmondsworth hearing centre)",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 1015,
+      "eventId": "listCase",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "appealReferenceNumber": "PA/12345/2023",
+          "ariaListingReference": "LP/12345/2023",
+          "listCaseHearingCentre": "harmondsworth",
+          "listCaseHearingDate": "2023-09-03T14:25:15.000",
+          "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "appealReferenceNumber": "PA/12345/2023",
+        "listCaseHearingCentre": "harmondsworth",
+        "listCaseHearingDate": "2023-09-03T14:25:15.000",
+        "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
+        "notificationsSent": [
+          {
+            "id": "1015_CASE_LISTED_LEGAL_REPRESENTATIVE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1015_CASE_LISTED_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1015_CASE_LISTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "1015_CASE_LISTED_LEGAL_REPRESENTATIVE",
+        "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
+        "subject": "Immigration and Asylum appeal: check the details of your hearing",
+        "body": [
+          "PA/12345/2023",
+          "LP/12345/2023",
+          "3 Sept 2023",
+          "14:25",
+          "Harmondsworth Tribunal Hearing Centre, Colnbrook Bypass, UB7 0HB"
+        ]
+      },
+      {
+        "reference": "1015_CASE_LISTED_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.harmondsworth}",
+        "subject": "Immigration and Asylum appeal: case listed",
+        "body": [
+          "PA/12345/2023",
+          "LP/12345/2023",
+          "3 Sept 2023",
+          "14:25",
+          "Harmondsworth Tribunal Hearing Centre, Colnbrook Bypass, UB7 0HB"
+        ]
+      },
+      {
+        "reference": "1015_CASE_LISTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.harmondsworth}",
+        "subject": "Immigration and Asylum appeal: case listed",
+        "body": [
+          "PA/12345/2023",
+          "LP/12345/2023",
+          "3 Sept 2023",
+          "14:25",
+          "Harmondsworth Tribunal Hearing Centre, Colnbrook Bypass, UB7 0HB"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7879-case-listed-notification-harmondsworth-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7879-case-listed-notification-harmondsworth-hearing-centre.json
@@ -54,7 +54,7 @@
         "body": [
           "PA/12345/2023",
           "LP/12345/2023",
-          "3 Sept 2023",
+          "3 Sep 2023",
           "14:25",
           "Harmondsworth Tribunal Hearing Centre, Colnbrook Bypass, UB7 0HB"
         ]
@@ -66,7 +66,7 @@
         "body": [
           "PA/12345/2023",
           "LP/12345/2023",
-          "3 Sept 2023",
+          "3 Sep 2023",
           "14:25",
           "Harmondsworth Tribunal Hearing Centre, Colnbrook Bypass, UB7 0HB"
         ]
@@ -78,7 +78,7 @@
         "body": [
           "PA/12345/2023",
           "LP/12345/2023",
-          "3 Sept 2023",
+          "3 Sep 2023",
           "14:25",
           "Harmondsworth Tribunal Hearing Centre, Colnbrook Bypass, UB7 0HB"
         ]

--- a/src/integrationTest/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/TsvStringProviderTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/TsvStringProviderTest.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Optional;
+
+import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -144,6 +146,56 @@ class TsvStringProviderTest {
             tsvStringProvider.get("hearingCentreName", "taylorHouse")
         );
 
+        Assert.assertEquals(
+                Optional.of("Harmondsworth"),
+                tsvStringProvider.get("hearingCentreName", "harmondsworth")
+        );
+
+        Assert.assertEquals(
+                Optional.of("Hendon"),
+                tsvStringProvider.get("hearingCentreName", "hendon")
+        );
+
+        Assert.assertEquals(
+                Optional.of("Yarl's Wood"),
+                tsvStringProvider.get("hearingCentreName", "yarlsWood")
+        );
+
+        Assert.assertEquals(
+                Optional.of("Bradford & Keighley"),
+                tsvStringProvider.get("hearingCentreName", "bradfordKeighley")
+        );
+
+        Assert.assertEquals(
+                Optional.of("MCC Minshull st"),
+                tsvStringProvider.get("hearingCentreName", "mccMinshull")
+        );
+
+        Assert.assertEquals(
+                Optional.of("MCC Crown Square"),
+                tsvStringProvider.get("hearingCentreName", "mccCrownSquare")
+        );
+
+        Assert.assertEquals(
+                Optional.of("Manchester Mags"),
+                tsvStringProvider.get("hearingCentreName", "manchesterMags")
+        );
+
+        Assert.assertEquals(
+                Optional.of("NTH Tyne Mags"),
+                tsvStringProvider.get("hearingCentreName", "nthTyneMags")
+        );
+
+        Assert.assertEquals(
+                Optional.of("Leeds Mags"),
+                tsvStringProvider.get("hearingCentreName", "leedsMags")
+        );
+
+        Assert.assertEquals(
+                Optional.of("Alloa Sherrif Court"),
+                tsvStringProvider.get("hearingCentreName", "alloaSherrif")
+        );
+
         assertEquals(
             Optional.of("Remote hearing"),
             tsvStringProvider.get("hearingCentreName", "remoteHearing")
@@ -211,6 +263,57 @@ class TsvStringProviderTest {
             Optional.of("IAC Taylor House, 88 Rosebery Avenue, London, EC1R 4QU"),
             tsvStringProvider.get("hearingCentreAddress", "taylorHouse")
         );
+
+        Assert.assertEquals(
+                Optional.of("Harmondsworth Tribunal Hearing Centre, Colnbrook Bypass, UB7 0HB"),
+                tsvStringProvider.get("hearingCentreAddress", "harmondsworth")
+        );
+
+        Assert.assertEquals(
+                Optional.of("Hendon Magistrates' Court, The Court House, The Hyde, NW9 7BY"),
+                tsvStringProvider.get("hearingCentreAddress", "hendon")
+        );
+
+        Assert.assertEquals(
+                Optional.of("Yarl's Wood Immigration and Asylum Hearing Centre, Twinwood Road, MK44 1FD"),
+                tsvStringProvider.get("hearingCentreAddress", "yarlsWood")
+        );
+
+        Assert.assertEquals(
+                Optional.of("Bradford and Keighley Magistrates' Court and Family Court, The Tyrls, PO Box 187, BD1 1JL"),
+                tsvStringProvider.get("hearingCentreAddress", "bradfordKeighley")
+        );
+
+        Assert.assertEquals(
+                Optional.of("Manchester Crown Court (Minshull St), The Court House, Minshull Street, M1 3FS"),
+                tsvStringProvider.get("hearingCentreAddress", "mccMinshull")
+        );
+
+        Assert.assertEquals(
+                Optional.of("Manchester Crown Court (Crown Square), Courts of Justice, Crown Square, M3 3FL"),
+                tsvStringProvider.get("hearingCentreAddress", "mccCrownSquare")
+        );
+
+        Assert.assertEquals(
+                Optional.of("Manchester Magistrates' Court, Crown Square, Manchester, Greater Manchester M60 1PR"),
+                tsvStringProvider.get("hearingCentreAddress", "manchesterMags")
+        );
+
+        Assert.assertEquals(
+                Optional.of("North Tyneside Magistrates' Court, Tynemouth Road, The Court House, NE30 1AG"),
+                tsvStringProvider.get("hearingCentreAddress", "nthTyneMags")
+        );
+
+        Assert.assertEquals(
+                Optional.of("Leeds Magistrates' Court and Family Court, Westgate, LS1 3BY"),
+                tsvStringProvider.get("hearingCentreAddress", "leedsMags")
+        );
+
+        Assert.assertEquals(
+                Optional.of("Alloa Sheriff Court, 47 Drysdale Street, Alloa, FK10 1JA"),
+                tsvStringProvider.get("hearingCentreAddress", "alloaSherrif")
+        );
+
         assertEquals(
             Optional.of("Remote hearing"),
             tsvStringProvider.get("hearingCentreAddress", "remoteHearing")

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/HearingCentre.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/HearingCentre.java
@@ -20,6 +20,16 @@ public enum HearingCentre {
     NOTTINGHAM("nottingham"),
     TAYLOR_HOUSE("taylorHouse"),
     NEWCASTLE("newcastle"),
+    HARMONDSWORTH("harmondsworth"),
+    HENDON("hendon"),
+    YARLS_WOOD("yarlsWood"),
+    BRADFORD_KEIGHLEY("bradfordKeighley"),
+    MCC_MINSHULL("mccMinshull"),
+    MCC_CROWN_SQUARE("mccCrownSquare"),
+    MANCHESTER_MAGS("manchesterMags"),
+    NTH_TYNE_MAGS("nthTyneMags"),
+    LEEDS_MAGS("leedsMags"),
+    ALLOA_SHERRIF("alloaSherrif"),
     REMOTE_HEARING("remoteHearing"),
     DECISION_WITHOUT_HEARING("decisionWithoutHearing");
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1218,6 +1218,16 @@ hearingCentreEmailAddresses:
   hattonCross: ${IA_HEARING_CENTRE_HATTON_CROSS_EMAIL:hc-hatton-cross@example.com}
   glasgow: ${IA_HEARING_CENTRE_GLASGOW_EMAIL:hc-glasgow@example.com}
   belfast: ${IA_HEARING_CENTRE_GLASGOW_EMAIL:hc-glasgow@example.com}
+  harmondsworth: ${IA_HOME_OFFICE_HARMONDSWORTH_EMAIL:hc-harmondsworth@example.com}
+  hendon: ${IA_HOME_OFFICE_HENDON_EMAIL:hc-hendon@example.com}
+  yarlsWood: ${IA_HOME_OFFICE_YARLS_WOOD_EMAIL:hc-yarls-wood@example.com}
+  bradfordKeighley: ${IA_HOME_OFFICE_BRADFORD_KEIGHLEY_EMAIL:hc-bradford-keighley@example.com}
+  mccMinshull: ${IA_HOME_OFFICE_MCC_MINSHULL_EMAIL:hc-mcc-minshull@example.com}
+  mccCrownSquare: ${IA_HOME_OFFICE_MCC_CROWN_SQUARE_EMAIL:hc-mcc-crown-square@example.com}
+  manchesterMags: ${IA_HOME_OFFICE_MANCHESTER_MAGS_EMAIL:hc-manchester-mags@example.com}
+  nthTyneMags: ${IA_HOME_OFFICE_NTH_TYNE_MAGS_EMAIL:hc-nth-tyne-mags@example.com}
+  leedsMags: ${IA_HOME_OFFICE_LEEDS_MAGS_EMAIL:hc-leeds-mags@example.com}
+  alloaSherrif: ${IA_HOME_OFFICE_ALLOA_SHERRIF_EMAIL:hc-alloa-sherrif@example.com}
 
 ### Bail Hearing Email addresses
 bailHearingCentreEmailAddresses:
@@ -1242,6 +1252,16 @@ homeOfficeEmailAddresses:
   hattonCross: ${IA_HOME_OFFICE_HATTON_CROSS_EMAIL:ho-hatton-cross@example.com}
   glasgow: ${IA_HOME_OFFICE_GLASGOW_EMAIL:ho-glasgow@example.com}
   belfast: ${IA_HOME_OFFICE_GLASGOW_EMAIL:ho-glasgow@example.com}
+  harmondsworth: ${IA_HOME_OFFICE_HARMONDSWORTH_EMAIL:ho-harmondsworth@example.com}
+  hendon: ${IA_HOME_OFFICE_HENDON_EMAIL:ho-hendon@example.com}
+  yarlsWood: ${IA_HOME_OFFICE_YARLS_WOOD_EMAIL:ho-yarls-wood@example.com}
+  bradfordKeighley: ${IA_HOME_OFFICE_BRADFORD_KEIGHLEY_EMAIL:ho-bradford-keighley@example.com}
+  mccMinshull: ${IA_HOME_OFFICE_MCC_MINSHULL_EMAIL:ho-mcc-minshull@example.com}
+  mccCrownSquare: ${IA_HOME_OFFICE_MCC_CROWN_SQUARE_EMAIL:ho-mcc-crown-square@example.com}
+  manchesterMags: ${IA_HOME_OFFICE_MANCHESTER_MAGS_EMAIL:ho-manchester-mags@example.com}
+  nthTyneMags: ${IA_HOME_OFFICE_NTH_TYNE_MAGS_EMAIL:ho-nth-tyne-mags@example.com}
+  leedsMags: ${IA_HOME_OFFICE_LEEDS_MAGS_EMAIL:ho-leeds-mags@example.com}
+  alloaSherrif: ${IA_HOME_OFFICE_ALLOA_SHERRIF_EMAIL:ho-alloa-sherrif@example.com}
 
 homeOfficeFtpaEmailAddresses:
   bradford: ${IA_FTPA_HOME_OFFICE_BRADFORD_EMAIL:ho-ftpa-bradford@example.com}

--- a/src/main/resources/strings.tsv
+++ b/src/main/resources/strings.tsv
@@ -26,6 +26,16 @@ hearingCentreName	nottingham	Nottingham Justice Centre
 hearingCentreName	taylorHouse	Taylor House
 hearingCentreName	decisionWithoutHearing	Decision Without Hearing
 hearingCentreName	belfast	Belfast
+hearingCentreName	harmondsworth	Harmondsworth
+hearingCentreName	hendon	Hendon
+hearingCentreName	yarlsWood	Yarl's Wood
+hearingCentreName	bradfordKeighley	Bradford & Keighley
+hearingCentreName	mccMinshull	MCC Minshull st
+hearingCentreName	mccCrownSquare	MCC Crown Square
+hearingCentreName	manchesterMags	Manchester Mags
+hearingCentreName	nthTyneMags	NTH Tyne Mags
+hearingCentreName	leedsMags	Leeds Mags
+hearingCentreName	alloaSherrif	Alloa Sherrif Court
 hearingCentreName	remoteHearing	Remote hearing
 hearingCentreAddress	birmingham	IAC Birmingham, Birmingham Justice Centre, 33 Bull Street, Birmingham, B4 6DS
 hearingCentreAddress	bradford	IAC Bradford, Phoenix House, Rushton Avenue, Thornbury, Bradford, BD3 7BH
@@ -40,5 +50,15 @@ hearingCentreAddress	northShields	IAC North Shields, Kings Court, Royal Quays, E
 hearingCentreAddress	nottingham	Nottingham Justice Centre, Carrington Street, Nottingham, NG2 1EE
 hearingCentreAddress	taylorHouse	IAC Taylor House, 88 Rosebery Avenue, London, EC1R 4QU
 hearingCentreAddress	belfast	Belfast Laganside Court, Oxford Street, Belfast, BT1 3LL
+hearingCentreAddress	harmondsworth	Harmondsworth Tribunal Hearing Centre, Colnbrook Bypass, UB7 0HB
+hearingCentreAddress	hendon	Hendon Magistrates' Court, The Court House, The Hyde, NW9 7BY
+hearingCentreAddress	yarlsWood	Yarl's Wood Immigration and Asylum Hearing Centre, Twinwood Road, MK44 1FD
+hearingCentreAddress	bradfordKeighley	Bradford and Keighley Magistrates' Court and Family Court, The Tyrls, PO Box 187, BD1 1JL
+hearingCentreAddress	mccMinshull	Manchester Crown Court (Minshull St), The Court House, Minshull Street, M1 3FS
+hearingCentreAddress	mccCrownSquare	Manchester Crown Court (Crown Square), Courts of Justice, Crown Square, M3 3FL
+hearingCentreAddress	manchesterMags	Manchester Magistrates' Court, Crown Square, Manchester, Greater Manchester M60 1PR
+hearingCentreAddress	nthTyneMags	North Tyneside Magistrates' Court, Tynemouth Road, The Court House, NE30 1AG
+hearingCentreAddress	leedsMags	Leeds Magistrates' Court and Family Court, Westgate, LS1 3BY
+hearingCentreAddress	alloaSherrif	Alloa Sheriff Court, 47 Drysdale Street, Alloa, FK10 1JA
 hearingCentreAddress	remoteHearing	Remote hearing
 hearingCentreAddress	decisionWithoutHearing	No hearing centre

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/HearingCentreTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/HearingCentreTest.java
@@ -21,6 +21,16 @@ class HearingCentreTest {
         assertEquals("taylorHouse", HearingCentre.TAYLOR_HOUSE.toString());
         assertEquals("newcastle", HearingCentre.NEWCASTLE.toString());
         assertEquals("belfast", HearingCentre.BELFAST.toString());
+        assertEquals("harmondsworth", HearingCentre.HARMONDSWORTH.toString());
+        assertEquals("hendon", HearingCentre.HENDON.toString());
+        assertEquals("yarlsWood", HearingCentre.YARLS_WOOD.toString());
+        assertEquals("bradfordKeighley", HearingCentre.BRADFORD_KEIGHLEY.toString());
+        assertEquals("mccMinshull", HearingCentre.MCC_MINSHULL.toString());
+        assertEquals("mccCrownSquare", HearingCentre.MCC_CROWN_SQUARE.toString());
+        assertEquals("manchesterMags", HearingCentre.MANCHESTER_MAGS.toString());
+        assertEquals("nthTyneMags", HearingCentre.NTH_TYNE_MAGS.toString());
+        assertEquals("leedsMags", HearingCentre.LEEDS_MAGS.toString());
+        assertEquals("alloaSherrif", HearingCentre.ALLOA_SHERRIF.toString());
         assertEquals("remoteHearing", HearingCentre.REMOTE_HEARING.toString());
         assertEquals("decisionWithoutHearing", HearingCentre.DECISION_WITHOUT_HEARING.toString());
 
@@ -41,6 +51,16 @@ class HearingCentreTest {
         assertEquals(HearingCentre.TAYLOR_HOUSE, HearingCentre.from("taylorHouse").get());
         assertEquals(HearingCentre.NEWCASTLE, HearingCentre.from("newcastle").get());
         assertEquals(HearingCentre.BELFAST, HearingCentre.from("belfast").get());
+        assertEquals(HearingCentre.HARMONDSWORTH, HearingCentre.from("harmondsworth").get());
+        assertEquals(HearingCentre.HENDON, HearingCentre.from("hendon").get());
+        assertEquals(HearingCentre.YARLS_WOOD, HearingCentre.from("yarlsWood").get());
+        assertEquals(HearingCentre.BRADFORD_KEIGHLEY, HearingCentre.from("bradfordKeighley").get());
+        assertEquals(HearingCentre.MCC_MINSHULL, HearingCentre.from("mccMinshull").get());
+        assertEquals(HearingCentre.MCC_CROWN_SQUARE, HearingCentre.from("mccCrownSquare").get());
+        assertEquals(HearingCentre.MANCHESTER_MAGS, HearingCentre.from("manchesterMags").get());
+        assertEquals(HearingCentre.NTH_TYNE_MAGS, HearingCentre.from("nthTyneMags").get());
+        assertEquals(HearingCentre.LEEDS_MAGS, HearingCentre.from("leedsMags").get());
+        assertEquals(HearingCentre.ALLOA_SHERRIF, HearingCentre.from("alloaSherrif").get());
         assertEquals(HearingCentre.REMOTE_HEARING, HearingCentre.from("remoteHearing").get());
         assertEquals(HearingCentre.DECISION_WITHOUT_HEARING, HearingCentre.from("decisionWithoutHearing").get());
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/HearingCentreTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/HearingCentreTest.java
@@ -47,6 +47,6 @@ class HearingCentreTest {
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(15, HearingCentre.values().length);
+        assertEquals(25, HearingCentre.values().length);
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7879

### Change description ###
- Added the new hearing venue to location list
- Set the name and address for the new hearing venue
- Temporarily set the email address of home office and hearing centre for new hearing venue


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
