### PR TITLE
RIA-7691 RIA-7693 Send notification only when supplied by appellant

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7691-internal-upload-addendum-evidence-admin-officer-det-notification-ada.json
+++ b/src/functionalTest/resources/scenarios/RIA-7691-internal-upload-addendum-evidence-admin-officer-det-notification-ada.json
@@ -14,6 +14,7 @@
           "ircName": "Brookhouse",
           "isAcceleratedDetainedAppeal": "Yes",
           "appellantInDetention": "Yes",
+          "isAppellantRespondent": "The appellant",
           "notificationAttachmentDocuments": [
             {
               "id": "1",

--- a/src/functionalTest/resources/scenarios/RIA-7693-internal-upload-addendum-evidence-admin-officer-det-notification-non-ada.json
+++ b/src/functionalTest/resources/scenarios/RIA-7693-internal-upload-addendum-evidence-admin-officer-det-notification-non-ada.json
@@ -14,6 +14,7 @@
           "ircName": "Brookhouse",
           "isAcceleratedDetainedAppeal": "No",
           "appellantInDetention": "Yes",
+          "isAppellantRespondent": "The appellant",
           "notificationAttachmentDocuments": [
             {
               "id": "1",

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AsylumCaseDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AsylumCaseDefinition.java
@@ -408,6 +408,9 @@ public enum AsylumCaseDefinition {
 
     APPELLANT_IN_DETENTION(
             "appellantInDetention", new TypeReference<YesOrNo>(){}),
+
+    IS_APPELLANT_RESPONDENT(
+            "isAppellantRespondent", new TypeReference<String>(){}),
     ;
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -4882,10 +4882,18 @@ public class NotificationHandlerConfiguration {
             (callbackStage, callback) -> {
                 final AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
 
+                String appellant = "The appellant";
+
+                boolean isAppellantRespondent = asylumCase.read(IS_APPELLANT_RESPONDENT, String.class)
+                    .map(value -> value.equals(appellant))
+                    .orElse(false);
+
                 return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                        && callback.getEvent() == UPLOAD_ADDENDUM_EVIDENCE_ADMIN_OFFICER
                        && isInternalCase(asylumCase)
-                       && isAppellantInDetention(asylumCase);
+                       && isAppellantInDetention(asylumCase)
+                       && isAppellantRespondent;
+
             }, notificationGenerators
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -52,6 +52,8 @@ public class NotificationHandlerConfiguration {
     private static final String ADMIN_OFFICER_ROLE = "caseworker-ia-admofficer";
     private static final String RESPONDENT_APPLICANT = "Respondent";
 
+    private static final String IS_APPELLANT = "The appellant";
+
     @Bean
     public PreSubmitCallbackHandler<AsylumCase> forceCaseProgressionNotificationHandler(
         @Qualifier("forceCaseProgressionNotificationGenerator") List<NotificationGenerator> notificationGenerators) {
@@ -4882,10 +4884,8 @@ public class NotificationHandlerConfiguration {
             (callbackStage, callback) -> {
                 final AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
 
-                String appellant = "The appellant";
-
                 boolean isAppellantRespondent = asylumCase.read(IS_APPELLANT_RESPONDENT, String.class)
-                    .map(value -> value.equals(appellant))
+                    .map(value -> value.equals(IS_APPELLANT))
                     .orElse(false);
 
                 return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -51,7 +51,6 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils;
 public class NotificationHandlerConfiguration {
     private static final String ADMIN_OFFICER_ROLE = "caseworker-ia-admofficer";
     private static final String RESPONDENT_APPLICANT = "Respondent";
-
     private static final String IS_APPELLANT = "The appellant";
 
     @Bean


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/RIA-7691 - ADA
https://tools.hmcts.net/jira/browse/RIA-7693 - Non-ADA

### Change description ###

- Adding additional logic to only send notification when supplied by 'Appellant'. If 'Respondent' is selected then no notification is to be sent.
- Updated functional tests

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
