### PR TITLE
RIA-7443 RIA-7711 internal LO upload addendum evidence supplied by respondent DET notification

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7443-internal-ada-legal-officer-upload-addendum-evidence-supplied-by-respondent-det-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-7443-internal-ada-legal-officer-upload-addendum-evidence-supplied-by-respondent-det-notification.json
@@ -1,0 +1,106 @@
+{
+  "description": "RIA-7443 Internal Legal Officer upload addendum evidence DET notification - ADA",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 7443,
+      "eventId": "uploadAddendumEvidence",
+      "state": "decided",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "detentionFacility": "immigrationRemovalCentre",
+          "ircName": "Brookhouse",
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "addendumEvidenceDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "addendumEvidence",
+                "document": {
+                  "document_url": "http://dm-store:8080/documents/bcc86de8-daca-4c16-b610-28bad91ba313",
+                  "document_filename": "fake-doc.pdf",
+                  "document_binary_url": "http://dm-store:8080/documents/bcc86de8-daca-4c16-b610-28bad91ba313/binary"
+                },
+                "suppliedBy": "The respondent",
+                "uploadedBy": "TCW",
+                "description": "k",
+                "dateUploaded": "2023-09-26"
+              }
+            }
+          ],
+          "notificationAttachmentDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "legalOfficerUploadAdditionalEvidenceLetter",
+                "document": {
+                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                },
+                "suppliedBy": "",
+                "description": "",
+                "dateUploaded": "{$TODAY}"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "detentionFacility": "immigrationRemovalCentre",
+        "ircName": "Brookhouse",
+        "appellantInDetention": "Yes",
+        "isAcceleratedDetainedAppeal": "Yes",
+        "addendumEvidenceDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "tag": "addendumEvidence",
+              "document": {
+                "document_url": "http://dm-store:8080/documents/bcc86de8-daca-4c16-b610-28bad91ba313",
+                "document_filename": "fake-doc.pdf",
+                "document_binary_url": "http://dm-store:8080/documents/bcc86de8-daca-4c16-b610-28bad91ba313/binary"
+              },
+              "suppliedBy": "The respondent",
+              "uploadedBy": "TCW",
+              "description": "k",
+              "dateUploaded": "2023-09-26"
+            }
+          }
+        ],
+        "notificationsSent":[
+          {
+            "id": "7443_INTERNAL_DETAINED_LEGAL_OFFICER_UPLOAD_ADDITIONAL_EVIDENCE_DET_EMAIL",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ],
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "tag": "legalOfficerUploadAdditionalEvidenceLetter",
+              "document": {
+                "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+              },
+              "suppliedBy": "",
+              "description": "",
+              "dateUploaded": "{$TODAY}"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7711-internal-detained-legal-officer-upload-addendum-evidence-supplied-by-respondent-det-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-7711-internal-detained-legal-officer-upload-addendum-evidence-supplied-by-respondent-det-notification.json
@@ -1,0 +1,106 @@
+{
+  "description": "RIA-7711 Internal Legal Officer upload addendum evidence DET notification - Detained non-ada",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 7711,
+      "eventId": "uploadAddendumEvidence",
+      "state": "decided",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "detentionFacility": "immigrationRemovalCentre",
+          "ircName": "Brookhouse",
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "No",
+          "addendumEvidenceDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "addendumEvidence",
+                "document": {
+                  "document_url": "http://dm-store:8080/documents/bcc86de8-daca-4c16-b610-28bad91ba313",
+                  "document_filename": "fake-doc.pdf",
+                  "document_binary_url": "http://dm-store:8080/documents/bcc86de8-daca-4c16-b610-28bad91ba313/binary"
+                },
+                "suppliedBy": "The respondent",
+                "uploadedBy": "TCW",
+                "description": "k",
+                "dateUploaded": "2023-09-26"
+              }
+            }
+          ],
+          "notificationAttachmentDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "legalOfficerUploadAdditionalEvidenceLetter",
+                "document": {
+                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                },
+                "suppliedBy": "",
+                "description": "",
+                "dateUploaded": "{$TODAY}"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "detentionFacility": "immigrationRemovalCentre",
+        "ircName": "Brookhouse",
+        "appellantInDetention": "Yes",
+        "addendumEvidenceDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "tag": "addendumEvidence",
+              "document": {
+                "document_url": "http://dm-store:8080/documents/bcc86de8-daca-4c16-b610-28bad91ba313",
+                "document_filename": "fake-doc.pdf",
+                "document_binary_url": "http://dm-store:8080/documents/bcc86de8-daca-4c16-b610-28bad91ba313/binary"
+              },
+              "suppliedBy": "The respondent",
+              "uploadedBy": "TCW",
+              "description": "k",
+              "dateUploaded": "2023-09-26"
+            }
+          }
+        ],
+        "isAcceleratedDetainedAppeal": "No",
+        "notificationsSent":[
+          {
+            "id": "7711_INTERNAL_DETAINED_LEGAL_OFFICER_UPLOAD_ADDITIONAL_EVIDENCE_DET_EMAIL",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ],
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "tag": "legalOfficerUploadAdditionalEvidenceLetter",
+              "document": {
+                "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+              },
+              "suppliedBy": "",
+              "description": "",
+              "dateUploaded": "{$TODAY}"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTag.java
@@ -68,6 +68,7 @@ public enum DocumentTag {
     INTERNAL_CHANGE_DIRECTION_DUE_DATE_LETTER("internalChangeDirectionDueDateLetter"),
     INTERNAL_EDIT_APPEAL_LETTER("internalEditAppealLetter"),
     HOME_OFFICE_UPLOAD_ADDITIONAL_ADDENDUM_EVIDENCE_LETTER("homeOfficeUploadAdditionalAddendumEvidenceLetter"),
+    LEGAL_OFFICER_UPLOAD_ADDITIONAL_EVIDENCE_LETTER("legalOfficerUploadAdditionalEvidenceLetter"),
 
     @JsonEnumDefaultValue
     NONE("");

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentWithMetadata.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentWithMetadata.java
@@ -15,6 +15,7 @@ public class DocumentWithMetadata implements HasDocument {
     private String dateUploaded;
     private DocumentTag tag;
     private String suppliedBy;
+    private String uploadedBy;
 
     private DocumentWithMetadata() {
         // noop -- for deserializer
@@ -43,6 +44,22 @@ public class DocumentWithMetadata implements HasDocument {
         this.suppliedBy = suppliedBy;
     }
 
+    public DocumentWithMetadata(
+            Document document,
+            String description,
+            String dateUploaded,
+            DocumentTag tag,
+            String suppliedBy,
+            String uploadedBy
+    ) {
+        this.document = document;
+        this.description = description;
+        this.dateUploaded = dateUploaded;
+        this.tag = tag;
+        this.suppliedBy = suppliedBy;
+        this.uploadedBy = uploadedBy;
+    }
+
     @Override
     public Document getDocument() {
         requireNonNull(document);
@@ -66,5 +83,9 @@ public class DocumentWithMetadata implements HasDocument {
 
     public String getSuppliedBy() {
         return suppliedBy;
+    }
+
+    public String getUploadedBy() {
+        return uploadedBy;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamLegalOfficerUploadAddendumEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamLegalOfficerUploadAddendumEvidence.java
@@ -1,0 +1,83 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentTag.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.getLetterForNotification;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.isAcceleratedDetainedAppeal;
+
+import java.io.IOException;
+import java.util.*;
+import com.google.common.collect.ImmutableMap;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailWithLinkNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DetEmailService;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PersonalisationProvider;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.DocumentDownloadClient;
+import uk.gov.service.notify.NotificationClientException;
+
+@Slf4j
+@Service
+public class DetentionEngagementTeamLegalOfficerUploadAddendumEvidence implements EmailWithLinkNotificationPersonalisation {
+
+    @Value("${govnotify.emailPrefix.adaInPerson}")
+    private String adaPrefix;
+    @Value("${govnotify.emailPrefix.nonAdaInPerson}")
+    private String nonAdaPrefix;
+    private final String legalOfficerUploadAddendumEvidenceTemplateId;
+    private final PersonalisationProvider personalisationProvider;
+    private final DocumentDownloadClient documentDownloadClient;
+    private final DetEmailService detEmailService;
+
+    public DetentionEngagementTeamLegalOfficerUploadAddendumEvidence(
+            @Value("${govnotify.template.hoOrTcwUploadedAddendumEvidence.detentionEngagementTeam.email}") String legalOfficerUploadAddendumEvidenceTemplateId,
+            PersonalisationProvider personalisationProvider,
+            DetEmailService detEmailService,
+            DocumentDownloadClient documentDownloadClient
+    ) {
+        this.legalOfficerUploadAddendumEvidenceTemplateId = legalOfficerUploadAddendumEvidenceTemplateId;
+        this.personalisationProvider = personalisationProvider;
+        this.detEmailService = detEmailService;
+        this.documentDownloadClient = documentDownloadClient;
+    }
+
+    @Override
+    public String getTemplateId(AsylumCase asylumCase) {
+        return legalOfficerUploadAddendumEvidenceTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        return detEmailService.getRecipientsList(asylumCase);
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_INTERNAL_DETAINED_LEGAL_OFFICER_UPLOAD_ADDITIONAL_EVIDENCE_DET_EMAIL";
+    }
+
+    @Override
+    public Map<String, Object> getPersonalisationForLink(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        return ImmutableMap
+                .<String, Object>builder()
+                .putAll(personalisationProvider.getAppellantPersonalisation(asylumCase))
+                .put("subjectPrefix", isAcceleratedDetainedAppeal(asylumCase) ? adaPrefix : nonAdaPrefix)
+                .put("documentLink", getLegalOfficerUploadAddendumEvidenceDocumentInJsonObject(asylumCase))
+                .build();
+    }
+
+    private JSONObject getLegalOfficerUploadAddendumEvidenceDocumentInJsonObject(AsylumCase asylumCase) {
+        try {
+            return documentDownloadClient.getJsonObjectFromDocument(getLetterForNotification(asylumCase, LEGAL_OFFICER_UPLOAD_ADDITIONAL_EVIDENCE_LETTER));
+        } catch (IOException | NotificationClientException e) {
+            log.error("Failed to get Legal Officer upload addendum evidence letter in compatible format", e);
+            throw new IllegalStateException("Failed to get Legal Officer upload addendum evidence letter in compatible format");
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/utils/AsylumCaseUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/utils/AsylumCaseUtils.java
@@ -91,4 +91,26 @@ public class AsylumCaseUtils {
             .map(type -> type == AIP).orElse(false);
     }
 
+    public static List<IdValue<DocumentWithMetadata>> getAddendumEvidenceDocuments(AsylumCase asylumCase) {
+        Optional<List<IdValue<DocumentWithMetadata>>> maybeExistingAdditionalEvidenceDocuments =
+                asylumCase.read(ADDENDUM_EVIDENCE_DOCUMENTS);
+        if (maybeExistingAdditionalEvidenceDocuments.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return maybeExistingAdditionalEvidenceDocuments.get();
+    }
+
+
+    public static Optional<IdValue<DocumentWithMetadata>> getLatestAddendumEvidenceDocument(AsylumCase asylumCase) {
+        List<IdValue<DocumentWithMetadata>> addendums = getAddendumEvidenceDocuments(asylumCase);
+
+        if (addendums.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Optional<IdValue<DocumentWithMetadata>> optionalLatestAddendum = addendums.stream().findFirst();
+        return Optional.of(optionalLatestAddendum.get());
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -4508,4 +4508,19 @@ public class NotificationGeneratorConfiguration {
                 )
         );
     }
+
+    @Bean("internalLegalOfficerUploadAddendumEvidenceNotificationGenerator")
+    public List<NotificationGenerator> internalLegalOfficerUploadAddendumEvidenceNotificationGenerator(
+            DetentionEngagementTeamLegalOfficerUploadAddendumEvidence detentionEngagementTeamLegalOfficerUploadAddendumEvidence,
+            GovNotifyNotificationSender notificationSender,
+            NotificationIdAppender notificationIdAppender) {
+
+        return List.of(
+                new EmailWithLinkNotificationGenerator(
+                        newArrayList(Collections.singleton(detentionEngagementTeamLegalOfficerUploadAddendumEvidence)),
+                        notificationSender,
+                        notificationIdAppender
+                )
+        );
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -456,6 +456,8 @@ govnotify:
       appellant:
         email: a4e7e8fd-d260-45ee-80d4-4fc48aa7c585
         sms: f38ac04a-af21-447c-afe5-8eca0ab39d38
+      detentionEngagementTeam:
+        email: e7bbe8fe-f9b5-493e-a87e-ae812e462460
     changeDirectionDueDate:
       detentionEngagementTeam:
         email: 57af3624-c404-44ed-bc74-326b87014da6

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTagTest.java
@@ -66,10 +66,11 @@ class DocumentTagTest {
         assertEquals("internalChangeDirectionDueDateLetter", DocumentTag.INTERNAL_CHANGE_DIRECTION_DUE_DATE_LETTER.toString());
         assertEquals("internalEditAppealLetter", DocumentTag.INTERNAL_EDIT_APPEAL_LETTER.toString());
         assertEquals("homeOfficeUploadAdditionalAddendumEvidenceLetter", DocumentTag.HOME_OFFICE_UPLOAD_ADDITIONAL_ADDENDUM_EVIDENCE_LETTER.toString());
+        assertEquals("legalOfficerUploadAdditionalEvidenceLetter", DocumentTag.LEGAL_OFFICER_UPLOAD_ADDITIONAL_EVIDENCE_LETTER.toString());
     }
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(64, DocumentTag.values().length);
+        assertEquals(65, DocumentTag.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamLegalOfficerUploadAddendumEvidenceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamLegalOfficerUploadAddendumEvidenceTest.java
@@ -1,0 +1,183 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.TestUtils.getDocumentWithMetadata;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.IS_ACCELERATED_DETAINED_APPEAL;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo.YES;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.utils.SubjectPrefixesInitializer.initializePrefixesForInternalAppeal;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentWithMetadata;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DetEmailService;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PersonalisationProvider;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.DocumentDownloadClient;
+import uk.gov.service.notify.NotificationClientException;
+
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class DetentionEngagementTeamLegalOfficerUploadAddendumEvidenceTest {
+
+    @Mock
+    AsylumCase asylumCase;
+    @Mock
+    DetEmailService detEmailService;
+    @Mock
+    JSONObject jsonDocument;
+    @Mock
+    DocumentDownloadClient documentDownloadClient;
+    @Mock
+    PersonalisationProvider personalisationProvider;
+    private String templateId = "templateId";
+    private final String uploadAdditionalEvidencePersonalisationReferenceId = "_INTERNAL_DETAINED_LEGAL_OFFICER_UPLOAD_ADDITIONAL_EVIDENCE_DET_EMAIL";
+    private final String appealReferenceNumber = "someReferenceNumber";
+    private final String homeOfficeReferenceNumber = "1234-1234-1234-1234";
+    private final String appellantGivenNames = "someAppellantGivenNames";
+    private final String appellantFamilyName = "someAppellantFamilyName";
+    private final String detEmailAddress = "some@example.com";
+    private final String adaPrefix = "ADA - SERVE IN PERSON";
+    private final String nonAdaPrefix = "IAFT - SERVE IN PERSON";
+    private final Long caseId = 12345L;
+    private DetentionEngagementTeamLegalOfficerUploadAddendumEvidence detentionEngagementTeamLegalOfficerUploadAddendumEvidence;
+    DocumentWithMetadata uploadAdditionalEvidenceDoc = getDocumentWithMetadata(
+            "1", "appellant letter_LO-evidence", "some other desc", DocumentTag.LEGAL_OFFICER_UPLOAD_ADDITIONAL_EVIDENCE_LETTER);
+    IdValue<DocumentWithMetadata> uploadAdditionalEvidenceDocId = new IdValue<>("1", uploadAdditionalEvidenceDoc);
+
+    DetentionEngagementTeamLegalOfficerUploadAddendumEvidenceTest() {
+    }
+
+    @BeforeEach
+    void setup() throws NotificationClientException, IOException {
+        detentionEngagementTeamLegalOfficerUploadAddendumEvidence = new DetentionEngagementTeamLegalOfficerUploadAddendumEvidence(
+                templateId,
+                personalisationProvider,
+                detEmailService,
+                documentDownloadClient
+        );
+
+        initializePrefixesForInternalAppeal(detentionEngagementTeamLegalOfficerUploadAddendumEvidence);
+
+        Map<String, String> appellantInfo = new HashMap<>();
+        appellantInfo.put("appellantGivenNames", appellantGivenNames);
+        appellantInfo.put("appellantFamilyName", appellantFamilyName);
+        appellantInfo.put("homeOfficeReferenceNumber", homeOfficeReferenceNumber);
+        appellantInfo.put("appealReferenceNumber", appealReferenceNumber);
+
+        when(personalisationProvider.getAppellantPersonalisation(asylumCase)).thenReturn(appellantInfo);
+
+        when(asylumCase.read(NOTIFICATION_ATTACHMENT_DOCUMENTS)).thenReturn(Optional.of(newArrayList(uploadAdditionalEvidenceDocId)));
+
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(YES));
+
+        when(documentDownloadClient.getJsonObjectFromDocument(any(DocumentWithMetadata.class))).thenReturn(jsonDocument);
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        assertEquals(
+                templateId,
+                detentionEngagementTeamLegalOfficerUploadAddendumEvidence.getTemplateId(asylumCase)
+        );
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        assertEquals(caseId + uploadAdditionalEvidencePersonalisationReferenceId,
+                detentionEngagementTeamLegalOfficerUploadAddendumEvidence.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address_from_asylum_case() {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.of("immigrationRemovalCentre"));
+        when(detEmailService.getRecipientsList(asylumCase)).thenReturn(Collections.singleton(detEmailAddress));
+
+        assertTrue(
+                detentionEngagementTeamLegalOfficerUploadAddendumEvidence.getRecipientsList(asylumCase).contains(detEmailAddress));
+    }
+
+    @Test
+    public void should_return_empty_set_email_address_from_asylum_case_no_detention_facility() {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.empty());
+        assertEquals(Collections.emptySet(), detentionEngagementTeamLegalOfficerUploadAddendumEvidence.getRecipientsList(asylumCase));
+    }
+
+    @Test
+    public void should_return_empty_set_email_address_from_asylum_case_other_detention_facility() {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.of("other"));
+        assertEquals(Collections.emptySet(), detentionEngagementTeamLegalOfficerUploadAddendumEvidence.getRecipientsList(asylumCase));
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(
+                () -> detentionEngagementTeamLegalOfficerUploadAddendumEvidence.getPersonalisationForLink((AsylumCase) null))
+                .isExactlyInstanceOf(NullPointerException.class)
+                .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_legal_officer_upload_addendum_evidence_letter_is_missing() {
+        when(asylumCase.read(NOTIFICATION_ATTACHMENT_DOCUMENTS)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(
+                () -> detentionEngagementTeamLegalOfficerUploadAddendumEvidence.getPersonalisationForLink(asylumCase))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("legalOfficerUploadAdditionalEvidenceLetter document not available");
+    }
+
+    @ParameterizedTest
+    @EnumSource(YesOrNo.class)
+    public void should_return_personalisation_when_all_information_given(YesOrNo yesOrNo) {
+
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.ofNullable(yesOrNo));
+
+        Map<String, Object> personalisationForLink = detentionEngagementTeamLegalOfficerUploadAddendumEvidence.getPersonalisationForLink(asylumCase);
+
+        assertEquals(appellantGivenNames, personalisationForLink.get("appellantGivenNames"));
+        assertEquals(appellantFamilyName, personalisationForLink.get("appellantFamilyName"));
+        assertEquals(appealReferenceNumber, personalisationForLink.get("appealReferenceNumber"));
+        assertEquals(homeOfficeReferenceNumber, personalisationForLink.get("homeOfficeReferenceNumber"));
+        assertEquals(jsonDocument, personalisationForLink.get("documentLink"));
+
+        if (yesOrNo.equals(YES)) {
+            assertEquals(adaPrefix, personalisationForLink.get("subjectPrefix"));
+        } else {
+            assertEquals(nonAdaPrefix, personalisationForLink.get("subjectPrefix"));
+        }
+    }
+
+    @Test
+    public void should_throw_exception_when_notification_client_throws_Exception() throws NotificationClientException, IOException {
+        when(documentDownloadClient.getJsonObjectFromDocument(uploadAdditionalEvidenceDoc)).thenThrow(new NotificationClientException("File size is more than 2MB"));
+        assertThatThrownBy(() -> detentionEngagementTeamLegalOfficerUploadAddendumEvidence.getPersonalisationForLink(asylumCase))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("Failed to get Legal Officer upload addendum evidence letter in compatible format");
+    }
+
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/utils/AsylumCaseUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/utils/AsylumCaseUtilsTest.java
@@ -6,6 +6,9 @@ import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumC
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo.NO;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo.YES;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,13 +17,45 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
+
 
 @ExtendWith(MockitoExtension.class)
 public class AsylumCaseUtilsTest {
 
     @Mock
     private AsylumCase asylumCase;
+    @Mock
+    private Document document;
+
+    private final String legalOfficerAddendumUploadedByLabel = "TCW";
+    private final String legalOfficerAddendumUploadSuppliedByLabel = "The respondent";
+    private final IdValue<DocumentWithMetadata> addendumOne = new IdValue<>(
+            "1",
+            new DocumentWithMetadata(
+                    document,
+                    "Some description",
+                    "2018-12-25",
+                    DocumentTag.ADDENDUM_EVIDENCE,
+                    legalOfficerAddendumUploadSuppliedByLabel,
+                    legalOfficerAddendumUploadedByLabel
+            )
+    );
+
+    private final IdValue<DocumentWithMetadata> addendumTwo = new IdValue<>(
+            "2",
+            new DocumentWithMetadata(
+                    document,
+                    "Some description",
+                    "2018-12-26", DocumentTag.ADDENDUM_EVIDENCE,
+                    legalOfficerAddendumUploadSuppliedByLabel,
+                    legalOfficerAddendumUploadedByLabel
+            )
+    );
+
+
 
     @Test
     void should_return_correct_value_for_det() {
@@ -86,5 +121,34 @@ public class AsylumCaseUtilsTest {
         Optional<HearingCentre> mayBeListCaseHearingCenter = HearingCentre.from(hearingCentre);
         when(asylumCase.read(LIST_CASE_HEARING_CENTRE, HearingCentre.class)).thenReturn(mayBeListCaseHearingCenter);
         assertEquals(mayBeListCaseHearingCenter.isPresent(), AsylumCaseUtils.isAppealListed(asylumCase));
+    }
+
+    @Test
+    void should_get_addendum_document_when_present() {
+        List<IdValue<DocumentWithMetadata>> addendumDocuments = new ArrayList<>();
+        addendumDocuments.add(addendumOne);
+        when(asylumCase.read(ADDENDUM_EVIDENCE_DOCUMENTS)).thenReturn(Optional.of(addendumDocuments));
+
+        assertEquals(addendumDocuments, AsylumCaseUtils.getAddendumEvidenceDocuments(asylumCase));
+        assertEquals(Optional.of(addendumOne), AsylumCaseUtils.getLatestAddendumEvidenceDocument(asylumCase));
+    }
+
+    @Test
+    void should_get_addendum_documents_when_more_than_one_exists() {
+        List<IdValue<DocumentWithMetadata>> addendumDocuments = new ArrayList<>();
+        addendumDocuments.add(addendumOne);
+        addendumDocuments.add(addendumTwo);
+        when(asylumCase.read(ADDENDUM_EVIDENCE_DOCUMENTS)).thenReturn(Optional.of(addendumDocuments));
+
+        assertEquals(addendumDocuments, AsylumCaseUtils.getAddendumEvidenceDocuments(asylumCase));
+        assertEquals(2, AsylumCaseUtils.getAddendumEvidenceDocuments(asylumCase).size());
+    }
+
+    @Test
+    void should_return_empty_list_when_no_addendum_evidence_documents_present() {
+        when(asylumCase.read(ADDENDUM_EVIDENCE_DOCUMENTS)).thenReturn(Optional.empty());
+
+        assertEquals(Collections.emptyList(), AsylumCaseUtils.getAddendumEvidenceDocuments(asylumCase));
+        assertEquals(Optional.empty(), AsylumCaseUtils.getLatestAddendumEvidenceDocument(asylumCase));
     }
 }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/RIA-7443
https://tools.hmcts.net/jira/browse/RIA-7711


### Change description ###
* Imported docTag from docs-api
* Added new template for LO upload addendum evidence supplied by Respondent
* Created new generator and handler beans for uploadAddendumEvidence event for internal detained cases
* Imported addendum evidence document extraction/parsing fom docs-api.
* Added/updated unit/FTs

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
