### PR TITLE
RIA-7428 RIA-7712 Notification for internal reinstate appeal

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7428-internal-reinstate-appeal-det-notification-ada.json
+++ b/src/functionalTest/resources/scenarios/RIA-7428-internal-reinstate-appeal-det-notification-ada.json
@@ -67,7 +67,7 @@
     "notifications": [
       {
         "reference": "7428_REINSTATE_APPEAL_HOME_OFFICE",
-        "recipient": "ia-respondentapc@fake.hmcts.net",
+        "recipient": "{$apcHomeOfficeEmailAddress}",
         "subject": "Accelerated detained appeal: appeal reinstated",
         "body": [
           "HMCTS reference: PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-7428-internal-reinstate-appeal-det-notification-ada.json
+++ b/src/functionalTest/resources/scenarios/RIA-7428-internal-reinstate-appeal-det-notification-ada.json
@@ -1,0 +1,91 @@
+{
+  "description": "RIA-7428 Internal Reinstate appeal DET notification - ADA",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 7428,
+      "eventId": "reinstateAppeal",
+      "state": "ended",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "stateBeforeEndAppeal": "appealSubmitted",
+          "reinstateAppealDate": "{$TODAY}",
+          "reinstateAppealReason": "Withdraw",
+          "reinstatedDecisionMaker": "Judge",
+          "detentionFacility": "immigrationRemovalCentre",
+          "ircName": "Brookhouse",
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "notificationAttachmentDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "internalReinstateAppealLetter",
+                "document": {
+                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                },
+                "suppliedBy": "",
+                "description": "",
+                "dateUploaded": "{$TODAY}"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "stateBeforeEndAppeal": "appealSubmitted",
+        "reinstateAppealDate": "{$TODAY}",
+        "reinstateAppealReason": "Withdraw",
+        "reinstatedDecisionMaker": "Judge",
+        "detentionFacility": "immigrationRemovalCentre",
+        "ircName": "Brookhouse",
+        "appellantInDetention": "Yes",
+        "isAcceleratedDetainedAppeal": "Yes",
+        "notificationsSent":[
+          {
+            "id": "7428_REINSTATE_APPEAL_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "7428_INTERNAL_DET_REINSTATE_APPEAL_EMAIL",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7428_REINSTATE_APPEAL_HOME_OFFICE",
+        "recipient": "ia-respondentapc@fake.hmcts.net",
+        "subject": "Accelerated detained appeal: appeal reinstated",
+        "body": [
+          "HMCTS reference: PA/12345/2019",
+          "Home Office reference: A1234567",
+          "Appellant name: Talha Awan",
+          "The online service: {$iaExUiFrontendUrl}"
+        ]
+      },
+      {
+        "reference": "7428_INTERNAL_DET_REINSTATE_APPEAL_EMAIL",
+        "recipient": "det-irc-brookhouse@example.com",
+        "subject": "ADA – SERVE IN PERSON: Appeal reinstated",
+        "body": [
+          "HMCTS reference: PA/12345/2019",
+          "Home Office reference: A1234567",
+          "Appellant name: Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7712-internal-reinstate-appeal-det-notification-non-ada.json
+++ b/src/functionalTest/resources/scenarios/RIA-7712-internal-reinstate-appeal-det-notification-non-ada.json
@@ -1,0 +1,91 @@
+{
+  "description": "RIA-7712 Internal Reinstate appeal DET notification - non-ADA",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 7712,
+      "eventId": "reinstateAppeal",
+      "state": "ended",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "stateBeforeEndAppeal": "appealSubmitted",
+          "reinstateAppealDate": "{$TODAY}",
+          "reinstateAppealReason": "Withdraw",
+          "reinstatedDecisionMaker": "Judge",
+          "detentionFacility": "immigrationRemovalCentre",
+          "ircName": "Brookhouse",
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "No",
+          "notificationAttachmentDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "internalReinstateAppealLetter",
+                "document": {
+                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                },
+                "suppliedBy": "",
+                "description": "",
+                "dateUploaded": "{$TODAY}"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "stateBeforeEndAppeal": "appealSubmitted",
+        "reinstateAppealDate": "{$TODAY}",
+        "reinstateAppealReason": "Withdraw",
+        "reinstatedDecisionMaker": "Judge",
+        "detentionFacility": "immigrationRemovalCentre",
+        "ircName": "Brookhouse",
+        "appellantInDetention": "Yes",
+        "isAcceleratedDetainedAppeal": "No",
+        "notificationsSent":[
+          {
+            "id": "7712_REINSTATE_APPEAL_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "7712_INTERNAL_DET_REINSTATE_APPEAL_EMAIL",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "7712_REINSTATE_APPEAL_HOME_OFFICE",
+        "recipient": "{$apcHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: appeal reinstated",
+        "body": [
+          "HMCTS reference: PA/12345/2019",
+          "Home Office reference: A1234567",
+          "Appellant name: Talha Awan",
+          "The online service: {$iaExUiFrontendUrl}"
+        ]
+      },
+      {
+        "reference": "7712_INTERNAL_DET_REINSTATE_APPEAL_EMAIL",
+        "recipient": "det-irc-brookhouse@example.com",
+        "subject": "IAFT – SERVE IN PERSON: Appeal reinstated",
+        "body": [
+          "HMCTS reference: PA/12345/2019",
+          "Home Office reference: A1234567",
+          "Appellant name: Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTag.java
@@ -69,6 +69,7 @@ public enum DocumentTag {
     INTERNAL_EDIT_APPEAL_LETTER("internalEditAppealLetter"),
     HOME_OFFICE_UPLOAD_ADDITIONAL_ADDENDUM_EVIDENCE_LETTER("homeOfficeUploadAdditionalAddendumEvidenceLetter"),
     LEGAL_OFFICER_UPLOAD_ADDITIONAL_EVIDENCE_LETTER("legalOfficerUploadAdditionalEvidenceLetter"),
+    INTERNAL_REINSTATE_APPEAL_LETTER("internalReinstateAppealLetter"),
 
     @JsonEnumDefaultValue
     NONE("");

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamReinstateAppealPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamReinstateAppealPersonalisation.java
@@ -1,0 +1,88 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentTag.INTERNAL_REINSTATE_APPEAL_LETTER;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.getLetterForNotification;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.isAcceleratedDetainedAppeal;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.*;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailWithLinkNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DetEmailService;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.DocumentDownloadClient;
+import uk.gov.service.notify.NotificationClientException;
+
+@Slf4j
+@Service
+public class DetentionEngagementTeamReinstateAppealPersonalisation implements EmailWithLinkNotificationPersonalisation {
+
+    private final String internalReinstateAppealAdaTemplateId;
+    private final String internalReinstateAppealNonAdaTemplateId;
+    private final DocumentDownloadClient documentDownloadClient;
+    private final DetEmailService detEmailService;
+    private String adaPrefix;
+    private String nonAdaPrefix;
+
+    public DetentionEngagementTeamReinstateAppealPersonalisation(
+        @Value("${govnotify.template.reinstateAppeal.detentionEngagementTeam.email.ada}") String internalReinstateAppealAdaTemplateId,
+        @Value("${govnotify.template.reinstateAppeal.detentionEngagementTeam.email.nonAda}") String internalReinstateAppealNonAdaTemplateId,
+        DetEmailService detEmailService,
+        DocumentDownloadClient documentDownloadClient,
+        @Value("${govnotify.emailPrefix.adaInPerson}") String adaPrefix,
+        @Value("${govnotify.emailPrefix.nonAdaInPerson}") String nonAdaPrefix
+    ) {
+        this.internalReinstateAppealAdaTemplateId = internalReinstateAppealAdaTemplateId;
+        this.internalReinstateAppealNonAdaTemplateId = internalReinstateAppealNonAdaTemplateId;
+        this.detEmailService = detEmailService;
+        this.documentDownloadClient = documentDownloadClient;
+        this.adaPrefix = adaPrefix;
+        this.nonAdaPrefix = nonAdaPrefix;
+    }
+
+    @Override
+    public String getTemplateId(AsylumCase asylumCase) {
+        return isAcceleratedDetainedAppeal(asylumCase) ? internalReinstateAppealAdaTemplateId : internalReinstateAppealNonAdaTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        return detEmailService.getRecipientsList(asylumCase);
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_INTERNAL_DET_REINSTATE_APPEAL_EMAIL";
+    }
+
+    @Override
+    public Map<String, Object> getPersonalisationForLink(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        return ImmutableMap
+            .<String, Object>builder()
+            .put("subjectPrefix", isAcceleratedDetainedAppeal(asylumCase) ? adaPrefix : nonAdaPrefix)
+            .put("appealReferenceNumber", asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+            .put("homeOfficeReferenceNumber", asylumCase.read(AsylumCaseDefinition.HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""))
+            .put("appellantGivenNames", asylumCase.read(AsylumCaseDefinition.APPELLANT_GIVEN_NAMES, String.class).orElse(""))
+            .put("appellantFamilyName", asylumCase.read(AsylumCaseDefinition.APPELLANT_FAMILY_NAME, String.class).orElse(""))
+            .put("documentLink", getInternalReinstateAppealDocumentInJsonObject(asylumCase))
+            .build();
+    }
+
+    private JSONObject getInternalReinstateAppealDocumentInJsonObject(AsylumCase asylumCase) {
+        try {
+            return documentDownloadClient.getJsonObjectFromDocument(getLetterForNotification(asylumCase, INTERNAL_REINSTATE_APPEAL_LETTER));
+        } catch (IOException | NotificationClientException e) {
+            log.error("Failed to get Internal Reinstate appeal letter in compatible format", e);
+            throw new IllegalStateException("Failed to get Internal Reinstate appeal letter in compatible format");
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -2908,18 +2908,25 @@ public class NotificationGeneratorConfiguration {
     @Bean("reinstateAppealInternalNotificationGenerator")
     public List<NotificationGenerator> reinstateAppealInternalNotificationHandler(
             HomeOfficeReinstateAppealPersonalisation homeOfficeReinstateAppealPersonalisation,
+            DetentionEngagementTeamReinstateAppealPersonalisation detentionEngagementTeamReinstateAppealPersonalisation,
             GovNotifyNotificationSender notificationSender,
             NotificationIdAppender notificationIdAppender
     ) {
-
-        return Collections.singletonList(
-                new EmailNotificationGenerator(
-                        newArrayList(
-                                homeOfficeReinstateAppealPersonalisation
-                        ),
-                        notificationSender,
-                        notificationIdAppender
-                )
+        return Arrays.asList(
+            new EmailNotificationGenerator(
+                newArrayList(
+                    homeOfficeReinstateAppealPersonalisation
+                ),
+                notificationSender,
+                notificationIdAppender
+            ),
+            new EmailWithLinkNotificationGenerator(
+                newArrayList(
+                    detentionEngagementTeamReinstateAppealPersonalisation
+                ),
+                notificationSender,
+                notificationIdAppender
+            )
         );
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -766,6 +766,10 @@ govnotify:
           sms: 2f7ae47e-733a-4e1b-bb1d-e62101dd6844
         afterListing:
           email: c193b002-fdd4-4e51-8cdf-064942937ff9
+      detentionEngagementTeam:
+        email:
+          ada: 3e328516-5262-44b4-8a65-41dc795d669b
+          nonAda: f4a9b5e9-f5d1-4659-a8c3-b4b61eb94cce
     makeAnApplication:
       appellant:
         sms: 5f1533b6-ee8c-448e-99a8-b3e0b6c2de30

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/DocumentTagTest.java
@@ -67,10 +67,11 @@ class DocumentTagTest {
         assertEquals("internalEditAppealLetter", DocumentTag.INTERNAL_EDIT_APPEAL_LETTER.toString());
         assertEquals("homeOfficeUploadAdditionalAddendumEvidenceLetter", DocumentTag.HOME_OFFICE_UPLOAD_ADDITIONAL_ADDENDUM_EVIDENCE_LETTER.toString());
         assertEquals("legalOfficerUploadAdditionalEvidenceLetter", DocumentTag.LEGAL_OFFICER_UPLOAD_ADDITIONAL_EVIDENCE_LETTER.toString());
+        assertEquals("internalReinstateAppealLetter", DocumentTag.INTERNAL_REINSTATE_APPEAL_LETTER.toString());
     }
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(65, DocumentTag.values().length);
+        assertEquals(66, DocumentTag.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamReinstateAppealPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/detentionengagementteam/DetentionEngagementTeamReinstateAppealPersonalisationTest.java
@@ -1,0 +1,183 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.TestUtils.compareStringsAndJsonObjects;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.TestUtils.getDocumentWithMetadata;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.utils.SubjectPrefixesInitializer.initializePrefixesForInternalAppeal;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentWithMetadata;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.DetEmailService;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.DocumentDownloadClient;
+import uk.gov.service.notify.NotificationClientException;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class DetentionEngagementTeamReinstateAppealPersonalisationTest {
+
+    @Mock
+    AsylumCase asylumCase;
+    @Mock
+    DetEmailService detEmailService;
+    @Mock
+    JSONObject jsonDocument;
+    @Mock
+    DocumentDownloadClient documentDownloadClient;
+    private String adaTemplateId = "adaTemplateId";
+    private String nonAdaTemplateId = "nonAdaTemplateId";
+    private final String uploadAdditionalEvidencePersonalisationReferenceId = "_INTERNAL_DET_REINSTATE_APPEAL_EMAIL";
+    private final String appealReferenceNumber = "someReferenceNumber";
+    private final String homeOfficeReferenceNumber = "1234-1234-1234-1234";
+    private final String appellantGivenNames = "someAppellantGivenNames";
+    private final String appellantFamilyName = "someAppellantFamilyName";
+    private final String detEmailAddress = "some@example.com";
+    private final String adaPrefix = "ADA - SERVE IN PERSON";
+    private final String nonAdaPrefix = "IAFT - SERVE IN PERSON";
+    private final Long caseId = 12345L;
+    private DetentionEngagementTeamReinstateAppealPersonalisation detentionEngagementTeamReinstateAppealPersonalisation;
+    DocumentWithMetadata reinstateAppealDoc = getDocumentWithMetadata(
+        "1", "internal-detained-reinstate-appeal-letter", "some other desc", DocumentTag.INTERNAL_REINSTATE_APPEAL_LETTER);
+    IdValue<DocumentWithMetadata> reinstateAppealDocId = new IdValue<>("1", reinstateAppealDoc);
+
+    DetentionEngagementTeamReinstateAppealPersonalisationTest() {
+    }
+
+    @BeforeEach
+    void setup() throws NotificationClientException, IOException {
+        detentionEngagementTeamReinstateAppealPersonalisation = new DetentionEngagementTeamReinstateAppealPersonalisation(
+            adaTemplateId,
+            nonAdaTemplateId,
+            detEmailService,
+            documentDownloadClient,
+            adaPrefix,
+            nonAdaPrefix
+        );
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(asylumCase.read(NOTIFICATION_ATTACHMENT_DOCUMENTS)).thenReturn(Optional.of(newArrayList(reinstateAppealDocId)));
+
+        when(documentDownloadClient.getJsonObjectFromDocument(any(DocumentWithMetadata.class))).thenReturn(jsonDocument);
+
+        initializePrefixesForInternalAppeal(detentionEngagementTeamReinstateAppealPersonalisation);
+    }
+
+    @Test
+    public void should_return_ada_template_id() {
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+        assertEquals(
+            adaTemplateId,
+            detentionEngagementTeamReinstateAppealPersonalisation.getTemplateId(asylumCase)
+        );
+    }
+
+    @Test
+    public void should_return_non_ada_template_id() {
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+
+        assertEquals(
+            nonAdaTemplateId,
+            detentionEngagementTeamReinstateAppealPersonalisation.getTemplateId(asylumCase)
+        );
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        Long caseId = 12345L;
+        assertEquals(caseId + uploadAdditionalEvidencePersonalisationReferenceId,
+            detentionEngagementTeamReinstateAppealPersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address_from_asylum_case() {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.of("immigrationRemovalCentre"));
+        when(detEmailService.getRecipientsList(asylumCase)).thenReturn(Collections.singleton(detEmailAddress));
+
+        assertTrue(
+            detentionEngagementTeamReinstateAppealPersonalisation.getRecipientsList(asylumCase).contains(detEmailAddress));
+    }
+
+    @Test
+    public void should_return_empty_set_email_address_from_asylum_case_no_detention_facility() {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.empty());
+        assertEquals(Collections.emptySet(), detentionEngagementTeamReinstateAppealPersonalisation.getRecipientsList(asylumCase));
+    }
+
+    @Test
+    public void should_return_empty_set_email_address_from_asylum_case_other_detention_facility() {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.of("other"));
+        assertEquals(Collections.emptySet(), detentionEngagementTeamReinstateAppealPersonalisation.getRecipientsList(asylumCase));
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(
+            () -> detentionEngagementTeamReinstateAppealPersonalisation.getPersonalisationForLink((AsylumCase) null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_upload_additional_evidence_document_is_missing() {
+        when(asylumCase.read(NOTIFICATION_ATTACHMENT_DOCUMENTS)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(
+            () -> detentionEngagementTeamReinstateAppealPersonalisation.getPersonalisationForLink(asylumCase))
+            .isExactlyInstanceOf(IllegalStateException.class)
+            .hasMessage("internalReinstateAppealLetter document not available");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given_refused() {
+
+        final Map<String, Object> expectedPersonalisation =
+            ImmutableMap
+                .<String, Object>builder()
+                .put("subjectPrefix", nonAdaPrefix)
+                .put("appealReferenceNumber", appealReferenceNumber)
+                .put("homeOfficeReferenceNumber", homeOfficeReferenceNumber)
+                .put("appellantGivenNames", appellantGivenNames)
+                .put("appellantFamilyName", appellantFamilyName)
+                .put("documentLink", jsonDocument)
+                .build();
+
+        Map<String, Object> actualPersonalisation =
+            detentionEngagementTeamReinstateAppealPersonalisation.getPersonalisationForLink(asylumCase);
+
+        assertTrue(compareStringsAndJsonObjects(expectedPersonalisation, actualPersonalisation));
+    }
+
+    @Test
+    public void should_throw_exception_when_notification_client_throws_Exception() throws NotificationClientException, IOException {
+        when(documentDownloadClient.getJsonObjectFromDocument(reinstateAppealDoc)).thenThrow(new NotificationClientException("File size is more than 2MB"));
+        assertThatThrownBy(() -> detentionEngagementTeamReinstateAppealPersonalisation.getPersonalisationForLink(asylumCase))
+            .isExactlyInstanceOf(IllegalStateException.class)
+            .hasMessage("Failed to get Internal Reinstate appeal letter in compatible format");
+    }
+
+}


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/RIA-7428 - ADA
https://tools.hmcts.net/jira/browse/RIA-7712 - Non-ADA

### Change description ###

- New notification to DET for internal reinstate appeal scenarios, ADA and detained non-ADA.
- Maintain the HO notification and reuse notification handler but with the DET personalisation added to the generator.
- Unit and functional tests.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
