### PR TITLE
RIA-7964 Removing HO DET notification when a Non standard direction is…

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7436-internal-detained-non-standard-direction-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-7436-internal-detained-non-standard-direction-notification.json
@@ -41,20 +41,6 @@
                 "description": "",
                 "dateUploaded": "{$TODAY}"
               }
-            },
-            {
-              "id": "2",
-              "value": {
-                "tag": "internalNonStandardDirectionToRespondentLetter",
-                "document": {
-                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
-                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
-                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
-                },
-                "suppliedBy": "",
-                "description": "",
-                "dateUploaded": "{$TODAY}"
-              }
             }
           ]
         }

--- a/src/functionalTest/resources/scenarios/RIA-7436-internal-detained-non-standard-direction-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-7436-internal-detained-non-standard-direction-notification.json
@@ -57,10 +57,6 @@
           {
             "id": "7436_INTERNAL_NON_STANDARD_DIRECTION_DET",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
-          },
-          {
-            "id": "7436_INTERNAL_NON_STANDARD_DIRECTION_TO_RESPONDENT_DET",
-            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
         ]
       }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -2255,13 +2255,12 @@ public class NotificationGeneratorConfiguration {
     @Bean("appellantRespondentInternalNonStandardDirectionGenerator")
     public List<NotificationGenerator> appellantRespondentInternalNonStandardDirectionGenerator(
         DetentionEngagementTeamNonStandardDirectionPersonalisation detentionEngagementTeamNonStandardDirectionPersonalisation,
-        DetentionEngagementTeamInternalNonStandardDirectionToRespondentPersonalisation detentionEngagementTeamInternalNonStandardDirectionToRespondentPersonalisation,
         GovNotifyNotificationSender notificationSender,
         NotificationIdAppender notificationIdAppender) {
 
         return Arrays.asList(
             new EmailWithLinkNotificationGenerator(
-                newArrayList(detentionEngagementTeamNonStandardDirectionPersonalisation, detentionEngagementTeamInternalNonStandardDirectionToRespondentPersonalisation),
+                newArrayList(detentionEngagementTeamNonStandardDirectionPersonalisation),
                 notificationSender,
                 notificationIdAppender
             )


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/RIA-7964

### Change description ###
Removing HO DET notifcation when a Non standard direction is sent to both appellant and respondent

### Checklist
- [x ] Does this PR introduce a breaking change
