### PR TITLE
RIA-7195 remove listing reference number from notification template when hearing list assist hearing v2

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -37,5 +37,10 @@
             Temporary suppression.
             ]]</notes>
         <cve>CVE-2023-41080</cve>
+        <cve>CVE-2023-5072</cve>
+        <cve>CVE-2023-42794</cve>
+        <cve>CVE-2023-44487</cve>
+        <cve>CVE-2023-42795</cve>
+        <cve>CVE-2023-45648</cve>
     </suppress>
 </suppressions>

--- a/src/functionalTest/resources/scenarios/RIA-1380-case-listed-notification-bradford-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-1380-case-listed-notification-bradford-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "bradford",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -50,6 +51,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "3 May 2019",
@@ -70,6 +72,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "3 May 2019",
@@ -90,6 +93,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "3 May 2019",
           "14:25",
           "IAC Bradford, Phoenix House, Rushton Avenue, Thornbury, Bradford, BD3 7BH"

--- a/src/functionalTest/resources/scenarios/RIA-1380-case-listed-notification-newport-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-1380-case-listed-notification-newport-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "newport",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -50,6 +51,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "3 May 2019",
@@ -70,6 +72,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "3 May 2019",
@@ -90,6 +93,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "3 May 2019",
           "14:25",
           "IAC Newport, Columbus House, Langstone Business Park, Chepstow Road, Newport, NP18 2LX"

--- a/src/functionalTest/resources/scenarios/RIA-1380-edit-case-listing-notification-bradford-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-1380-edit-case-listing-notification-bradford-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "bradford",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
@@ -20,6 +21,7 @@
       "caseDataBefore": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "taylorHouse",
           "listCaseHearingDate": "2019-05-01T13:30:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -59,6 +61,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -83,6 +86,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -107,6 +111,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "Taylor House",

--- a/src/functionalTest/resources/scenarios/RIA-1380-edit-case-listing-notification-newport-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-1380-edit-case-listing-notification-newport-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "newport",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
@@ -20,6 +21,7 @@
       "caseDataBefore": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "manchester",
           "listCaseHearingDate": "2019-05-01T13:30:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -59,6 +61,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "Manchester",
@@ -82,6 +85,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -106,6 +110,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "Manchester",

--- a/src/functionalTest/resources/scenarios/RIA-1610-RIA-437-RIA-438-case-listed-notification-manchester-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-1610-RIA-437-RIA-438-case-listed-notification-manchester-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "manchester",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -50,6 +51,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "3 May 2019",
@@ -68,6 +70,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "3 May 2019",
@@ -86,6 +89,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "3 May 2019",
           "14:25",
           "IAC Manchester, 1st Floor Piccadilly Exchange, 2 Piccadilly Plaza, Mosley Street, Manchester, M1 4AH"

--- a/src/functionalTest/resources/scenarios/RIA-1610-RIA-437-RIA-438-case-listed-notification-taylor-house-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-1610-RIA-437-RIA-438-case-listed-notification-taylor-house-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "taylorHouse",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -50,6 +51,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "3 May 2019",
@@ -68,6 +70,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "3 May 2019",
@@ -86,6 +89,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "3 May 2019",
           "14:25",
           "IAC Taylor House, 88 Rosebery Avenue, London, EC1R 4QU"

--- a/src/functionalTest/resources/scenarios/RIA-1616-admin-office-edit-case-listing-notification-bradford-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-1616-admin-office-edit-case-listing-notification-bradford-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "bradford",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net",
@@ -20,6 +21,7 @@
       "caseDataBefore": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "taylorHouse",
           "listCaseHearingDate": "2019-05-01T13:30:15.000",
           "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net"
@@ -59,6 +61,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "Taylor House",
@@ -82,6 +85,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -106,6 +110,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "Taylor House",

--- a/src/functionalTest/resources/scenarios/RIA-1976-case-listed-notification-birmingham-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-1976-case-listed-notification-birmingham-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "birmingham",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -50,6 +51,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -71,6 +73,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -92,6 +95,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "3 May 2019",

--- a/src/functionalTest/resources/scenarios/RIA-1976-case-listed-notification-glasgow-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-1976-case-listed-notification-glasgow-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "glasgow",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -50,6 +51,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -71,6 +73,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -92,6 +95,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "3 May 2019",

--- a/src/functionalTest/resources/scenarios/RIA-1976-case-listed-notification-hatton-cross-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-1976-case-listed-notification-hatton-cross-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "hattonCross",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -50,6 +51,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -71,6 +73,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -92,6 +95,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "3 May 2019",

--- a/src/functionalTest/resources/scenarios/RIA-1976-case-listed-notification-north-shields-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-1976-case-listed-notification-north-shields-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "northShields",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -50,6 +51,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -72,6 +74,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -93,6 +96,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "3 May 2019",

--- a/src/functionalTest/resources/scenarios/RIA-1976-edit-case-listing-notification-birmingham-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-1976-edit-case-listing-notification-birmingham-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "birmingham",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net",
@@ -20,6 +21,7 @@
       "caseDataBefore": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "taylorHouse",
           "listCaseHearingDate": "2019-05-01T13:30:15.000",
           "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net"
@@ -59,6 +61,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "Taylor House",
@@ -82,6 +85,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -106,6 +110,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "Taylor House",

--- a/src/functionalTest/resources/scenarios/RIA-1976-edit-case-listing-notification-glasgow-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-1976-edit-case-listing-notification-glasgow-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "glasgow",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net",
@@ -20,6 +21,7 @@
       "caseDataBefore": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "taylorHouse",
           "listCaseHearingDate": "2019-05-01T13:30:15.000",
           "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net"
@@ -59,6 +61,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "Taylor House",
@@ -82,6 +85,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -106,6 +110,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "Taylor House",

--- a/src/functionalTest/resources/scenarios/RIA-1976-edit-case-listing-notification-hatton-cross-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-1976-edit-case-listing-notification-hatton-cross-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "hattonCross",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net",
@@ -20,6 +21,7 @@
       "caseDataBefore": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "taylorHouse",
           "listCaseHearingDate": "2019-05-01T13:30:15.000",
           "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net"
@@ -59,6 +61,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "Taylor House",
@@ -82,6 +85,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -106,6 +110,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "Taylor House",

--- a/src/functionalTest/resources/scenarios/RIA-1976-edit-case-listing-notification-north-shields-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-1976-edit-case-listing-notification-north-shields-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "northShields",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net",
@@ -20,6 +21,7 @@
       "caseDataBefore": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "taylorHouse",
           "listCaseHearingDate": "2019-05-01T13:30:15.000",
           "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net"
@@ -59,6 +61,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "Taylor House",
@@ -82,6 +85,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -106,6 +110,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "Taylor House",

--- a/src/functionalTest/resources/scenarios/RIA-2011-case-listed-notification-bradford-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-2011-case-listed-notification-bradford-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "bradford",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
@@ -61,6 +62,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "3 May 2019",
@@ -79,6 +81,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "3 May 2019",
@@ -97,6 +100,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "3 May 2019",
           "14:25",
           "IAC Bradford, Phoenix House, Rushton Avenue, Thornbury, Bradford, BD3 7BH"

--- a/src/functionalTest/resources/scenarios/RIA-2252-edit-case-listing-notification-bradford-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-2252-edit-case-listing-notification-bradford-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "bradford",
           "listCaseHearingDate": "2019-05-03T13:30:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -19,6 +20,7 @@
       "caseDataBefore": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "bradford",
           "listCaseHearingDate": "2019-05-03T13:30:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -54,6 +56,7 @@
         "subject": "Immigration and Asylum appeal: change to Hearing requirements",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -77,6 +80,7 @@
         "subject": "Immigration and Asylum appeal: change to Hearing requirements",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",

--- a/src/functionalTest/resources/scenarios/RIA-2323-case-listed-notification-coventry-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-2323-case-listed-notification-coventry-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "coventry",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -50,6 +51,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -71,6 +73,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -92,6 +95,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "3 May 2019",

--- a/src/functionalTest/resources/scenarios/RIA-2323-case-listed-notification-glasgow-tribunal-centre-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-2323-case-listed-notification-glasgow-tribunal-centre-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "glasgowTribunalsCentre",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -50,6 +51,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -71,6 +73,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -92,6 +95,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "3 May 2019",

--- a/src/functionalTest/resources/scenarios/RIA-2323-case-listed-notification-newcastle-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-2323-case-listed-notification-newcastle-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "newcastle",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -50,6 +51,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -71,6 +73,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -92,6 +95,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "3 May 2019",

--- a/src/functionalTest/resources/scenarios/RIA-2323-case-listed-notification-nottingham-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-2323-case-listed-notification-nottingham-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "nottingham",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -50,6 +51,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -71,6 +73,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -92,6 +95,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "3 May 2019",

--- a/src/functionalTest/resources/scenarios/RIA-3631-case-listed-notification-nottingham-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-3631-case-listed-notification-nottingham-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "nottingham",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -46,6 +47,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -67,6 +69,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "3 May 2019",

--- a/src/functionalTest/resources/scenarios/RIA-3631-edit-case-listing-notification-north-shields-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-3631-edit-case-listing-notification-north-shields-hearing-centre.json
@@ -11,6 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "northShields",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net"
@@ -19,6 +20,7 @@
       "caseDataBefore": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "taylorHouse",
           "listCaseHearingDate": "2019-05-01T13:30:15.000",
           "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net"
@@ -54,6 +56,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -77,6 +80,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "Taylor House",

--- a/src/functionalTest/resources/scenarios/RIA-3720-case-listed-notification-birmingham-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-3720-case-listed-notification-birmingham-hearing-centre.json
@@ -12,6 +12,7 @@
         "replacements": {
           "remoteVideoCallTribunalResponse": "remote video call tribunal response",
           "hearingCentre": "birmingham",
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "birmingham",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -53,6 +54,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -75,6 +77,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -97,6 +100,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "3 May 2019",

--- a/src/functionalTest/resources/scenarios/RIA-3720-case-listed-notification-remote-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-3720-case-listed-notification-remote-hearing.json
@@ -12,6 +12,7 @@
         "replacements": {
           "appellantInUk": "No",
           "remoteVideoCallTribunalResponse": "remote video call tribunal response",
+          "ariaListingReference": "LP/12345/2021",
           "hearingCentre": "birmingham",
           "listCaseHearingCentre": "remoteHearing",
           "listCaseHearingDate": "2021-02-19T14:25:15.000",
@@ -55,6 +56,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2021",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -77,6 +79,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2021",
           "A1234567",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -100,6 +103,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2021",
           "{$iaExUiFrontendUrl}",
           "19 Feb 2021",
           "14:25",

--- a/src/functionalTest/resources/scenarios/RIA-3722-edit-case-listing-notification-remote-hearing-no-change.json
+++ b/src/functionalTest/resources/scenarios/RIA-3722-edit-case-listing-notification-remote-hearing-no-change.json
@@ -10,6 +10,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "hearingCentre": "bradford",
           "listCaseHearingCentre": "remoteHearing",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
@@ -20,6 +21,7 @@
       "caseDataBefore": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "remoteHearing",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -56,6 +58,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -80,6 +83,7 @@
         "subject": "Immigration and Asylum appeal: change to Hearing requirements",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",

--- a/src/functionalTest/resources/scenarios/RIA-3722-edit-case-listing-notification-remote-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-3722-edit-case-listing-notification-remote-hearing.json
@@ -10,6 +10,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "hearingCentre": "bradford",
           "listCaseHearingCentre": "remoteHearing",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
@@ -20,6 +21,7 @@
       "caseDataBefore": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "remoteHearing",
           "listCaseHearingDate": "2019-05-01T13:30:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -60,6 +62,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -84,6 +87,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -108,6 +112,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "Remote hearing",

--- a/src/functionalTest/resources/scenarios/RIA-3722-edit-case-listing-notification-transfer-hearing-centre-to-remote.json
+++ b/src/functionalTest/resources/scenarios/RIA-3722-edit-case-listing-notification-transfer-hearing-centre-to-remote.json
@@ -10,6 +10,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "hearingCentre": "taylorHouse",
           "listCaseHearingCentre": "remoteHearing",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
@@ -20,6 +21,7 @@
       "caseDataBefore": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "hearingCentre": "taylorHouse",
           "listCaseHearingCentre": "taylorHouse",
           "listCaseHearingDate": "2019-05-01T13:30:15.000",
@@ -61,6 +63,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -85,6 +88,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -109,6 +113,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "Taylor House",

--- a/src/functionalTest/resources/scenarios/RIA-3722-edit-case-listing-notification-transfer-remote-to-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-3722-edit-case-listing-notification-transfer-remote-to-hearing-centre.json
@@ -10,6 +10,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "hearingCentre": "bradford",
           "listCaseHearingCentre": "bradford",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
@@ -20,6 +21,7 @@
       "caseDataBefore": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "hearingCentre": "bradford",
           "listCaseHearingCentre": "remoteHearing",
           "listCaseHearingDate": "2019-05-01T13:30:15.000",
@@ -61,6 +63,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "A1234567",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -85,6 +88,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "CASE001",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
@@ -109,6 +113,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "Remote hearing",

--- a/src/functionalTest/resources/scenarios/RIA-4712-aip-edit-listing-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-4712-aip-edit-listing-notification.json
@@ -23,6 +23,7 @@
               }
             }
           ],
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "northShields",
           "listCaseHearingDate": "2019-05-03T14:25:15.000"
         }
@@ -30,6 +31,7 @@
       "caseDataBefore": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "taylorHouse",
           "listCaseHearingDate": "2019-05-01T13:30:15.000"
         }
@@ -71,6 +73,7 @@
         "subject": "Immigration and Asylum appeal: Your hearing details have changed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaAipFrontendUrl}",
           "{$customerServices.telephoneNumber}",
@@ -87,6 +90,7 @@
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Talha Awan",
           "{$iaExUiFrontendUrl}",
           "Taylor House",

--- a/src/functionalTest/resources/scenarios/RIA-4861-case-listed-notification-birmingham-hearing-centre-aip.json
+++ b/src/functionalTest/resources/scenarios/RIA-4861-case-listed-notification-birmingham-hearing-centre-aip.json
@@ -11,6 +11,7 @@
         "template": "aip-minimal-appeal-submitted.json",
         "replacements": {
           "hearingCentre": "birmingham",
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "birmingham",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "homeOfficeReferenceNumber": "1212-0099-0062-8083",
@@ -79,6 +80,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Pablo Jimenez",
           "3 May 2019",
           "14:25",
@@ -91,6 +93,7 @@
         "subject": "Immigration and Asylum appeal: Your hearing details",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "1212-0099-0062-8083",
           "Pablo Jimenez",
           "{$iaAipFrontendUrl}",
@@ -119,6 +122,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "1212-0099-0062-8083",
           "Pablo Jimenez",
           "{$iaExUiFrontendUrl}",

--- a/src/functionalTest/resources/scenarios/RIA-4975-case-listed-notification-remote-hearing-centre-aip.json
+++ b/src/functionalTest/resources/scenarios/RIA-4975-case-listed-notification-remote-hearing-centre-aip.json
@@ -11,6 +11,7 @@
         "template": "aip-minimal-appeal-submitted.json",
         "replacements": {
           "hearingCentre": "birmingham",
+          "ariaListingReference": "LP/12345/2019",
           "listCaseHearingCentre": "remoteHearing",
           "listCaseHearingDate": "2019-05-03T14:25:15.000",
           "homeOfficeReferenceNumber": "1212-0099-0062-8083",
@@ -79,6 +80,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "Pablo Jimenez",
           "3 May 2019",
           "14:25",
@@ -91,6 +93,7 @@
         "subject": "Immigration and Asylum appeal: Your hearing details",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "1212-0099-0062-8083",
           "Pablo Jimenez",
           "{$iaAipFrontendUrl}",
@@ -119,6 +122,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2019",
+          "LP/12345/2019",
           "1212-0099-0062-8083",
           "Pablo Jimenez",
           "{$iaExUiFrontendUrl}",

--- a/src/functionalTest/resources/scenarios/RIA-7195-aip-case-listed-notification-with-integrated-harmondsworth-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-aip-case-listed-notification-with-integrated-harmondsworth-hearing-centre.json
@@ -1,0 +1,108 @@
+{
+  "description": "RIA-7195 AIP Send case listed notification with isIntegrated field (Harmondsworth hearing centre)",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 1015,
+      "eventId": "listCase",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "aip-minimal-appeal-submitted.json",
+        "replacements": {
+          "appealReferenceNumber": "PA/12345/2023",
+          "hearingCentre": "harmondsworth",
+          "ariaListingReference": "LP/12345/2023",
+          "listCaseHearingCentre": "harmondsworth",
+          "listCaseHearingDate": "2023-09-03T14:25:15.000",
+          "isIntegrated": "Yes",
+          "subscriptions": [
+            {
+              "id": "1",
+              "value": {
+                "subscriber": "appellant",
+                "email": "{$TEST_CITIZEN_USERNAME}",
+                "wantsEmail": "Yes",
+                "mobileNumber": "{$TEST_CITIZEN_MOBILE}"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "aip-minimal-appeal-submitted.json",
+      "replacements": {
+        "appealReferenceNumber": "PA/12345/2023",
+        "listCaseHearingCentre": "harmondsworth",
+        "hearingCentre": "harmondsworth",
+        "listCaseHearingDate": "2023-09-03T14:25:15.000",
+        "subscriptions": [
+          {
+            "id": "1",
+            "value": {
+              "subscriber": "appellant",
+              "email": "{$TEST_CITIZEN_USERNAME}",
+              "wantsEmail": "Yes",
+              "mobileNumber": "{$TEST_CITIZEN_MOBILE}"
+            }
+          }
+        ],
+        "notificationsSent": [
+          {
+            "id": "1015_CASE_LISTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1015_CASE_LISTED_AIP_APPELLANT_EMAIL",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1015_CASE_LISTED_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "1015_CASE_LISTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.harmondsworth}",
+        "subject": "Immigration and Asylum appeal: case listed",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Harmondsworth Tribunal Hearing Centre, Colnbrook Bypass, UB7 0HB"
+        ]
+      },
+      {
+        "reference": "1015_CASE_LISTED_AIP_APPELLANT_EMAIL",
+        "recipient": "{$TEST_CITIZEN_USERNAME}",
+        "subject": "Immigration and Asylum appeal: Your hearing details",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Harmondsworth Tribunal Hearing Centre, Colnbrook Bypass, UB7 0HB"
+        ]
+      },
+      {
+        "reference": "1015_CASE_LISTED_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.harmondsworth}",
+        "subject": "Immigration and Asylum appeal: case listed",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Harmondsworth Tribunal Hearing Centre, Colnbrook Bypass, UB7 0HB"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7195-aip-case-listed-notification-with-integrated-harmondsworth-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-aip-case-listed-notification-with-integrated-harmondsworth-hearing-centre.json
@@ -4,7 +4,7 @@
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "AdminOfficer",
     "input": {
-      "id": 1015,
+      "id": 1018,
       "eventId": "listCase",
       "state": "prepareForHearing",
       "caseData": {
@@ -54,15 +54,15 @@
         ],
         "notificationsSent": [
           {
-            "id": "1015_CASE_LISTED_CASE_OFFICER",
+            "id": "1018_CASE_LISTED_CASE_OFFICER",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {
-            "id": "1015_CASE_LISTED_AIP_APPELLANT_EMAIL",
+            "id": "1018_CASE_LISTED_AIP_APPELLANT_EMAIL",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {
-            "id": "1015_CASE_LISTED_HOME_OFFICE",
+            "id": "1018_CASE_LISTED_HOME_OFFICE",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
         ]
@@ -70,7 +70,7 @@
     },
     "notifications": [
       {
-        "reference": "1015_CASE_LISTED_CASE_OFFICER",
+        "reference": "1018_CASE_LISTED_CASE_OFFICER",
         "recipient": "{$hearingCentreEmailAddresses.harmondsworth}",
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
@@ -81,7 +81,7 @@
         ]
       },
       {
-        "reference": "1015_CASE_LISTED_AIP_APPELLANT_EMAIL",
+        "reference": "1018_CASE_LISTED_AIP_APPELLANT_EMAIL",
         "recipient": "{$TEST_CITIZEN_USERNAME}",
         "subject": "Immigration and Asylum appeal: Your hearing details",
         "body": [
@@ -92,7 +92,7 @@
         ]
       },
       {
-        "reference": "1015_CASE_LISTED_HOME_OFFICE",
+        "reference": "1018_CASE_LISTED_HOME_OFFICE",
         "recipient": "{$homeOfficeEmailAddresses.harmondsworth}",
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [

--- a/src/functionalTest/resources/scenarios/RIA-7195-aip-case-listed-notification-with-integrated-harmondsworth-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-aip-case-listed-notification-with-integrated-harmondsworth-hearing-centre.json
@@ -1,6 +1,5 @@
 {
   "description": "RIA-7195 AIP Send case listed notification with isIntegrated field (Harmondsworth hearing centre)",
-  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "AdminOfficer",

--- a/src/functionalTest/resources/scenarios/RIA-7195-aip-edit-case-listing-notification-with-integrated-harmondsworth-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-aip-edit-case-listing-notification-with-integrated-harmondsworth-hearing-centre.json
@@ -4,7 +4,7 @@
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "AdminOfficer",
     "input": {
-      "id": 1015,
+      "id": 1019,
       "eventId": "editCaseListing",
       "state": "prepareForHearing",
       "caseData": {
@@ -59,15 +59,15 @@
         ],
         "notificationsSent": [
           {
-            "id": "1015_CASE_RE_LISTED_HOME_OFFICE",
+            "id": "1019_CASE_RE_LISTED_HOME_OFFICE",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {
-            "id": "1015_CASE_RE_LISTED_APPELLANT_EMAIL",
+            "id": "1019_CASE_RE_LISTED_APPELLANT_EMAIL",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {
-            "id": "1015_CASE_RE_LISTED_CASE_OFFICER",
+            "id": "1019_CASE_RE_LISTED_CASE_OFFICER",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
         ]
@@ -75,7 +75,7 @@
     },
     "notifications": [
       {
-        "reference": "1015_CASE_RE_LISTED_APPELLANT_EMAIL",
+        "reference": "1019_CASE_RE_LISTED_APPELLANT_EMAIL",
         "recipient": "{$TEST_CITIZEN_USERNAME}",
         "subject": "Immigration and Asylum appeal: Your hearing details have changed",
         "body": [
@@ -86,7 +86,7 @@
         ]
       },
       {
-        "reference": "1015_CASE_RE_LISTED_CASE_OFFICER",
+        "reference": "1019_CASE_RE_LISTED_CASE_OFFICER",
         "recipient": "{$hearingCentreEmailAddresses.harmondsworth}",
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
@@ -97,7 +97,7 @@
         ]
       },
       {
-        "reference": "1015_CASE_RE_LISTED_HOME_OFFICE",
+        "reference": "1019_CASE_RE_LISTED_HOME_OFFICE",
         "recipient": "{$homeOfficeEmailAddresses.harmondsworth}",
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [

--- a/src/functionalTest/resources/scenarios/RIA-7195-aip-edit-case-listing-notification-with-integrated-harmondsworth-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-aip-edit-case-listing-notification-with-integrated-harmondsworth-hearing-centre.json
@@ -1,6 +1,5 @@
 {
   "description": "RIA-7195 AIP edit case listing notification with isIntegrated field (Harmondsworth hearing centre)",
-  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "AdminOfficer",

--- a/src/functionalTest/resources/scenarios/RIA-7195-aip-edit-case-listing-notification-with-integrated-harmondsworth-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-aip-edit-case-listing-notification-with-integrated-harmondsworth-hearing-centre.json
@@ -1,0 +1,113 @@
+{
+  "description": "RIA-7195 AIP edit case listing notification with isIntegrated field (Harmondsworth hearing centre)",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 1015,
+      "eventId": "editCaseListing",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "aip-minimal-appeal-submitted.json",
+        "replacements": {
+          "appealReferenceNumber": "PA/12345/2023",
+          "ariaListingReference": "LP/12345/2023",
+          "listCaseHearingCentre": "harmondsworth",
+          "listCaseHearingDate": "2023-09-03T14:25:15.000",
+          "isIntegrated": "Yes",
+          "subscriptions": [
+            {
+              "id": "1",
+              "value": {
+                "subscriber": "appellant",
+                "email": "{$TEST_CITIZEN_USERNAME}",
+                "wantsEmail": "Yes",
+                "mobileNumber": "{$TEST_CITIZEN_MOBILE}"
+              }
+            }
+          ]
+        }
+      },
+      "caseDataBefore": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "listCaseHearingCentre": "harmondsworth",
+          "listCaseHearingDate": "2023-09-02T14:25:15.000"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "aip-minimal-appeal-submitted.json",
+      "replacements": {
+        "appealReferenceNumber": "PA/12345/2023",
+        "listCaseHearingCentre": "harmondsworth",
+        "listCaseHearingDate": "2023-09-03T14:25:15.000",
+        "subscriptions": [
+          {
+            "id": "1",
+            "value": {
+              "subscriber": "appellant",
+              "email": "{$TEST_CITIZEN_USERNAME}",
+              "wantsEmail": "Yes",
+              "mobileNumber": "{$TEST_CITIZEN_MOBILE}"
+            }
+          }
+        ],
+        "notificationsSent": [
+          {
+            "id": "1015_CASE_RE_LISTED_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1015_CASE_RE_LISTED_APPELLANT_EMAIL",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1015_CASE_RE_LISTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "1015_CASE_RE_LISTED_APPELLANT_EMAIL",
+        "recipient": "{$TEST_CITIZEN_USERNAME}",
+        "subject": "Immigration and Asylum appeal: Your hearing details have changed",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Harmondsworth"
+        ]
+      },
+      {
+        "reference": "1015_CASE_RE_LISTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.harmondsworth}",
+        "subject": "Immigration and Asylum appeal: case re-listed",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Harmondsworth"
+        ]
+      },
+      {
+        "reference": "1015_CASE_RE_LISTED_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.harmondsworth}",
+        "subject": "Immigration and Asylum appeal: case re-listed",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Harmondsworth"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7195-case-listed-notification-with-integrated-harmondsworth-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-case-listed-notification-with-integrated-harmondsworth-hearing-centre.json
@@ -4,7 +4,7 @@
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "AdminOfficer",
     "input": {
-      "id": 1015,
+      "id": 1020,
       "eventId": "listCase",
       "state": "prepareForHearing",
       "caseData": {
@@ -32,15 +32,15 @@
         "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
         "notificationsSent": [
           {
-            "id": "1015_CASE_LISTED_LEGAL_REPRESENTATIVE",
+            "id": "1020_CASE_LISTED_LEGAL_REPRESENTATIVE",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {
-            "id": "1015_CASE_LISTED_HOME_OFFICE",
+            "id": "1020_CASE_LISTED_HOME_OFFICE",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {
-            "id": "1015_CASE_LISTED_CASE_OFFICER",
+            "id": "1020_CASE_LISTED_CASE_OFFICER",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
         ]
@@ -48,7 +48,7 @@
     },
     "notifications": [
       {
-        "reference": "1015_CASE_LISTED_LEGAL_REPRESENTATIVE",
+        "reference": "1020_CASE_LISTED_LEGAL_REPRESENTATIVE",
         "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
@@ -59,7 +59,7 @@
         ]
       },
       {
-        "reference": "1015_CASE_LISTED_HOME_OFFICE",
+        "reference": "1020_CASE_LISTED_HOME_OFFICE",
         "recipient": "{$homeOfficeEmailAddresses.harmondsworth}",
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
@@ -70,7 +70,7 @@
         ]
       },
       {
-        "reference": "1015_CASE_LISTED_CASE_OFFICER",
+        "reference": "1020_CASE_LISTED_CASE_OFFICER",
         "recipient": "{$hearingCentreEmailAddresses.harmondsworth}",
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [

--- a/src/functionalTest/resources/scenarios/RIA-7195-case-listed-notification-with-integrated-harmondsworth-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-case-listed-notification-with-integrated-harmondsworth-hearing-centre.json
@@ -1,6 +1,5 @@
 {
   "description": "RIA-7195 Send case listed notification with isIntegrated field (Harmondsworth hearing centre)",
-  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "AdminOfficer",

--- a/src/functionalTest/resources/scenarios/RIA-7195-case-listed-notification-with-integrated-harmondsworth-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-case-listed-notification-with-integrated-harmondsworth-hearing-centre.json
@@ -1,0 +1,86 @@
+{
+  "description": "RIA-7195 Send case listed notification with isIntegrated field (Harmondsworth hearing centre)",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 1015,
+      "eventId": "listCase",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "appealReferenceNumber": "PA/12345/2023",
+          "ariaListingReference": "LP/12345/2023",
+          "listCaseHearingCentre": "harmondsworth",
+          "listCaseHearingDate": "2023-09-03T14:25:15.000",
+          "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
+          "isIntegrated": "Yes"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "appealReferenceNumber": "PA/12345/2023",
+        "listCaseHearingCentre": "harmondsworth",
+        "listCaseHearingDate": "2023-09-03T14:25:15.000",
+        "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
+        "notificationsSent": [
+          {
+            "id": "1015_CASE_LISTED_LEGAL_REPRESENTATIVE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1015_CASE_LISTED_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1015_CASE_LISTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "1015_CASE_LISTED_LEGAL_REPRESENTATIVE",
+        "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
+        "subject": "Immigration and Asylum appeal: check the details of your hearing",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Harmondsworth Tribunal Hearing Centre, Colnbrook Bypass, UB7 0HB"
+        ]
+      },
+      {
+        "reference": "1015_CASE_LISTED_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.harmondsworth}",
+        "subject": "Immigration and Asylum appeal: case listed",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Harmondsworth Tribunal Hearing Centre, Colnbrook Bypass, UB7 0HB"
+        ]
+      },
+      {
+        "reference": "1015_CASE_LISTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.harmondsworth}",
+        "subject": "Immigration and Asylum appeal: case listed",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Harmondsworth Tribunal Hearing Centre, Colnbrook Bypass, UB7 0HB"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7195-case-listed-notification-with-integrated-remote-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-case-listed-notification-with-integrated-remote-hearing.json
@@ -4,7 +4,7 @@
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "AdminOfficer",
     "input": {
-      "id": 1015,
+      "id": 1021,
       "eventId": "listCase",
       "state": "prepareForHearing",
       "caseData": {
@@ -34,15 +34,15 @@
         "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
         "notificationsSent": [
           {
-            "id": "1015_CASE_LISTED_LEGAL_REPRESENTATIVE",
+            "id": "1021_CASE_LISTED_LEGAL_REPRESENTATIVE",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {
-            "id": "1015_CASE_LISTED_HOME_OFFICE",
+            "id": "1021_CASE_LISTED_HOME_OFFICE",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {
-            "id": "1015_CASE_LISTED_CASE_OFFICER",
+            "id": "1021_CASE_LISTED_CASE_OFFICER",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
         ]
@@ -50,7 +50,7 @@
     },
     "notifications": [
       {
-        "reference": "1015_CASE_LISTED_LEGAL_REPRESENTATIVE",
+        "reference": "1021_CASE_LISTED_LEGAL_REPRESENTATIVE",
         "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
@@ -61,7 +61,7 @@
         ]
       },
       {
-        "reference": "1015_CASE_LISTED_HOME_OFFICE",
+        "reference": "1021_CASE_LISTED_HOME_OFFICE",
         "recipient": "{$homeOfficeEmailAddresses.birmingham}",
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
@@ -72,7 +72,7 @@
         ]
       },
       {
-        "reference": "1015_CASE_LISTED_CASE_OFFICER",
+        "reference": "1021_CASE_LISTED_CASE_OFFICER",
         "recipient": "{$hearingCentreEmailAddresses.birmingham}",
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [

--- a/src/functionalTest/resources/scenarios/RIA-7195-case-listed-notification-with-integrated-remote-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-case-listed-notification-with-integrated-remote-hearing.json
@@ -1,0 +1,88 @@
+{
+  "description": "RIA-7195 Send case listed notification with isIntegrated field (remote hearing)",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 1015,
+      "eventId": "listCase",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "appealReferenceNumber": "PA/12345/2023",
+          "ariaListingReference": "LP/12345/2023",
+          "hearingCentre": "harmondsworth",
+          "listCaseHearingCentre": "remoteHearing",
+          "listCaseHearingDate": "2023-09-03T14:25:15.000",
+          "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
+          "isIntegrated": "Yes"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "appealReferenceNumber": "PA/12345/2023",
+        "hearingCentre": "harmondsworth",
+        "listCaseHearingCentre": "remoteHearing",
+        "listCaseHearingDate": "2023-09-03T14:25:15.000",
+        "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
+        "notificationsSent": [
+          {
+            "id": "1015_CASE_LISTED_LEGAL_REPRESENTATIVE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1015_CASE_LISTED_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1015_CASE_LISTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "1015_CASE_LISTED_LEGAL_REPRESENTATIVE",
+        "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
+        "subject": "Immigration and Asylum appeal: check the details of your hearing",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Remote hearing"
+        ]
+      },
+      {
+        "reference": "1015_CASE_LISTED_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.harmondsworth}",
+        "subject": "Immigration and Asylum appeal: case listed",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Remote hearing"
+        ]
+      },
+      {
+        "reference": "1015_CASE_LISTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.harmondsworth}",
+        "subject": "Immigration and Asylum appeal: case listed",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Remote hearing"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7195-case-listed-notification-with-integrated-remote-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-case-listed-notification-with-integrated-remote-hearing.json
@@ -13,7 +13,7 @@
         "replacements": {
           "appealReferenceNumber": "PA/12345/2023",
           "ariaListingReference": "LP/12345/2023",
-          "hearingCentre": "harmondsworth",
+          "hearingCentre": "birmingham",
           "listCaseHearingCentre": "remoteHearing",
           "listCaseHearingDate": "2023-09-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
@@ -29,7 +29,7 @@
       "template": "minimal-appeal-submitted.json",
       "replacements": {
         "appealReferenceNumber": "PA/12345/2023",
-        "hearingCentre": "harmondsworth",
+        "hearingCentre": "birmingham",
         "listCaseHearingCentre": "remoteHearing",
         "listCaseHearingDate": "2023-09-03T14:25:15.000",
         "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
@@ -63,7 +63,7 @@
       },
       {
         "reference": "1015_CASE_LISTED_HOME_OFFICE",
-        "recipient": "{$homeOfficeEmailAddresses.harmondsworth}",
+        "recipient": "{$homeOfficeEmailAddresses.birmingham}",
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2023",
@@ -74,7 +74,7 @@
       },
       {
         "reference": "1015_CASE_LISTED_CASE_OFFICER",
-        "recipient": "{$hearingCentreEmailAddresses.harmondsworth}",
+        "recipient": "{$hearingCentreEmailAddresses.birmingham}",
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2023",

--- a/src/functionalTest/resources/scenarios/RIA-7195-case-listed-notification-with-integrated-remote-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-case-listed-notification-with-integrated-remote-hearing.json
@@ -1,6 +1,5 @@
 {
   "description": "RIA-7195 Send case listed notification with isIntegrated field (remote hearing)",
-  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "AdminOfficer",

--- a/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-harmondsworth-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-harmondsworth-hearing-centre.json
@@ -4,7 +4,7 @@
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "AdminOfficer",
     "input": {
-      "id": 1015,
+      "id": 1022,
       "eventId": "editCaseListing",
       "state": "prepareForHearing",
       "caseData": {
@@ -40,15 +40,15 @@
         "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
         "notificationsSent": [
           {
-            "id": "1015_CASE_RE_LISTED_HOME_OFFICE",
+            "id": "1022_CASE_RE_LISTED_HOME_OFFICE",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {
-            "id": "1015_CASE_RE_LISTED_LEGAL_REPRESENTATIVE",
+            "id": "1022_CASE_RE_LISTED_LEGAL_REPRESENTATIVE",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {
-            "id": "1015_CASE_RE_LISTED_CASE_OFFICER",
+            "id": "1022_CASE_RE_LISTED_CASE_OFFICER",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
         ]
@@ -56,7 +56,7 @@
     },
     "notifications": [
       {
-        "reference": "1015_CASE_RE_LISTED_LEGAL_REPRESENTATIVE",
+        "reference": "1022_CASE_RE_LISTED_LEGAL_REPRESENTATIVE",
         "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
@@ -67,7 +67,7 @@
         ]
       },
       {
-        "reference": "1015_CASE_RE_LISTED_HOME_OFFICE",
+        "reference": "1022_CASE_RE_LISTED_HOME_OFFICE",
         "recipient": "{$homeOfficeEmailAddresses.harmondsworth}",
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
@@ -78,7 +78,7 @@
         ]
       },
       {
-        "reference": "1015_CASE_RE_LISTED_CASE_OFFICER",
+        "reference": "1022_CASE_RE_LISTED_CASE_OFFICER",
         "recipient": "{$hearingCentreEmailAddresses.harmondsworth}",
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [

--- a/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-harmondsworth-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-harmondsworth-hearing-centre.json
@@ -1,6 +1,5 @@
 {
   "description": "RIA-7195 edit case listing notification with isIntegrated field (Harmondsworth hearing centre)",
-  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "AdminOfficer",

--- a/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-harmondsworth-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-harmondsworth-hearing-centre.json
@@ -1,0 +1,94 @@
+{
+  "description": "RIA-7195 edit case listing notification with isIntegrated field (Harmondsworth hearing centre)",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 1015,
+      "eventId": "editCaseListing",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "appealReferenceNumber": "PA/12345/2023",
+          "ariaListingReference": "LP/12345/2023",
+          "listCaseHearingCentre": "harmondsworth",
+          "listCaseHearingDate": "2023-09-03T14:25:15.000",
+          "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
+          "isIntegrated": "Yes"
+        }
+      },
+      "caseDataBefore": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "listCaseHearingCentre": "harmondsworth",
+          "listCaseHearingDate": "2023-09-02T14:25:15.000",
+          "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "appealReferenceNumber": "PA/12345/2023",
+        "listCaseHearingCentre": "harmondsworth",
+        "listCaseHearingDate": "2023-09-03T14:25:15.000",
+        "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
+        "notificationsSent": [
+          {
+            "id": "1015_CASE_RE_LISTED_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1015_CASE_RE_LISTED_LEGAL_REPRESENTATIVE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1015_CASE_RE_LISTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "1015_CASE_RE_LISTED_LEGAL_REPRESENTATIVE",
+        "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
+        "subject": "Immigration and Asylum appeal: case re-listed",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Harmondsworth"
+        ]
+      },
+      {
+        "reference": "1015_CASE_RE_LISTED_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.harmondsworth}",
+        "subject": "Immigration and Asylum appeal: case re-listed",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Harmondsworth"
+        ]
+      },
+      {
+        "reference": "1015_CASE_RE_LISTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.harmondsworth}",
+        "subject": "Immigration and Asylum appeal: case re-listed",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Harmondsworth"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-remote-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-remote-hearing.json
@@ -70,9 +70,9 @@
         ]
       },
       {
-        "reference": "1015_CASE_RE_LISTED_LEGAL_REPRESENTATIVE",
-        "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
-        "subject": "Immigration and Asylum appeal: check the details of your hearing",
+        "reference": "1015_CASE_RE_LISTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.harmondsworth}",
+        "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2023",
           "3 Sep 2023",
@@ -81,9 +81,9 @@
         ]
       },
       {
-        "reference": "1015_CASE_RE_LISTED_CASE_OFFICER",
-        "recipient": "{$hearingCentreEmailAddresses.harmondsworth}",
-        "subject": "Immigration and Asylum appeal: case re-listed",
+        "reference": "1015_CASE_RE_LISTED_LEGAL_REPRESENTATIVE",
+        "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
+        "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2023",
           "3 Sep 2023",

--- a/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-remote-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-remote-hearing.json
@@ -13,7 +13,7 @@
         "replacements": {
           "appealReferenceNumber": "PA/12345/2023",
           "ariaListingReference": "LP/12345/2023",
-          "hearingCentre": "harmondsworth",
+          "hearingCentre": "taylorHouse",
           "listCaseHearingCentre": "remoteHearing",
           "listCaseHearingDate": "2023-09-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
@@ -37,7 +37,7 @@
       "template": "minimal-appeal-submitted.json",
       "replacements": {
         "appealReferenceNumber": "PA/12345/2023",
-        "hearingCentre": "harmondsworth",
+        "hearingCentre": "taylorHouse",
         "listCaseHearingCentre": "remoteHearing",
         "listCaseHearingDate": "2023-09-03T14:25:15.000",
         "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
@@ -59,8 +59,19 @@
     },
     "notifications": [
       {
+        "reference": "1015_CASE_RE_LISTED_LEGAL_REPRESENTATIVE",
+        "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
+        "subject": "Immigration and Asylum appeal: check the details of your hearing",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Remote hearing"
+        ]
+      },
+      {
         "reference": "1015_CASE_RE_LISTED_HOME_OFFICE",
-        "recipient": "{$homeOfficeEmailAddresses.harmondsworth}",
+        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2023",
@@ -71,19 +82,8 @@
       },
       {
         "reference": "1015_CASE_RE_LISTED_CASE_OFFICER",
-        "recipient": "{$hearingCentreEmailAddresses.harmondsworth}",
+        "recipient": "{$hearingCentreEmailAddresses.taylorHouse}",
         "subject": "Immigration and Asylum appeal: case re-listed",
-        "body": [
-          "PA/12345/2023",
-          "3 Sep 2023",
-          "14:25",
-          "Remote hearing"
-        ]
-      },
-      {
-        "reference": "1015_CASE_RE_LISTED_LEGAL_REPRESENTATIVE",
-        "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
-        "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2023",
           "3 Sep 2023",

--- a/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-remote-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-remote-hearing.json
@@ -13,7 +13,7 @@
         "replacements": {
           "appealReferenceNumber": "PA/12345/2023",
           "ariaListingReference": "LP/12345/2023",
-          "hearingCentre": "taylorHouse",
+          "hearingCentre": "birmingham",
           "listCaseHearingCentre": "remoteHearing",
           "listCaseHearingDate": "2023-09-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
@@ -37,7 +37,7 @@
       "template": "minimal-appeal-submitted.json",
       "replacements": {
         "appealReferenceNumber": "PA/12345/2023",
-        "hearingCentre": "taylorHouse",
+        "hearingCentre": "birmingham",
         "listCaseHearingCentre": "remoteHearing",
         "listCaseHearingDate": "2023-09-03T14:25:15.000",
         "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
@@ -59,6 +59,17 @@
     },
     "notifications": [
       {
+        "reference": "1015_CASE_RE_LISTED_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.birmingham}",
+        "subject": "Immigration and Asylum appeal: case re-listed",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Remote hearing"
+        ]
+      },
+      {
         "reference": "1015_CASE_RE_LISTED_LEGAL_REPRESENTATIVE",
         "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
@@ -70,19 +81,8 @@
         ]
       },
       {
-        "reference": "1015_CASE_RE_LISTED_HOME_OFFICE",
-        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
-        "subject": "Immigration and Asylum appeal: case re-listed",
-        "body": [
-          "PA/12345/2023",
-          "3 Sep 2023",
-          "14:25",
-          "Remote hearing"
-        ]
-      },
-      {
         "reference": "1015_CASE_RE_LISTED_CASE_OFFICER",
-        "recipient": "{$hearingCentreEmailAddresses.taylorHouse}",
+        "recipient": "{$hearingCentreEmailAddresses.birmingham}",
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2023",

--- a/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-remote-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-remote-hearing.json
@@ -59,9 +59,9 @@
     },
     "notifications": [
       {
-        "reference": "1015_CASE_RE_LISTED_LEGAL_REPRESENTATIVE",
-        "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
-        "subject": "Immigration and Asylum appeal: check the details of your hearing",
+        "reference": "1015_CASE_RE_LISTED_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.harmondsworth}",
+        "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
           "PA/12345/2023",
           "3 Sep 2023",
@@ -70,9 +70,9 @@
         ]
       },
       {
-        "reference": "1015_CASE_RE_LISTED_HOME_OFFICE",
-        "recipient": "{$homeOfficeEmailAddresses.harmondsworth}",
-        "subject": "Immigration and Asylum appeal: case re-listed",
+        "reference": "1015_CASE_RE_LISTED_LEGAL_REPRESENTATIVE",
+        "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
+        "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2023",
           "3 Sep 2023",

--- a/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-remote-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-remote-hearing.json
@@ -4,7 +4,7 @@
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "CaseOfficer",
     "input": {
-      "id": 1015,
+      "id": 1016,
       "eventId": "editCaseListing",
       "state": "prepareForHearing",
       "caseData": {
@@ -23,6 +23,7 @@
       "caseDataBefore": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "ariaListingReference": "LP/12345/2023",
           "listCaseHearingCentre": "remoteHearing",
           "listCaseHearingDate": "2023-09-02T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
@@ -44,15 +45,15 @@
         "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
         "notificationsSent": [
           {
-            "id": "1015_CASE_RE_LISTED_HOME_OFFICE",
+            "id": "1016_CASE_RE_LISTED_HOME_OFFICE",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {
-            "id": "1015_CASE_RE_LISTED_LEGAL_REPRESENTATIVE",
+            "id": "1016_CASE_RE_LISTED_LEGAL_REPRESENTATIVE",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {
-            "id": "1015_CASE_RE_LISTED_CASE_OFFICER",
+            "id": "1016_CASE_RE_LISTED_CASE_OFFICER",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
         ]
@@ -60,7 +61,7 @@
     },
     "notifications": [
       {
-        "reference": "1015_CASE_RE_LISTED_HOME_OFFICE",
+        "reference": "1016_CASE_RE_LISTED_HOME_OFFICE",
         "recipient": "{$homeOfficeEmailAddresses.birmingham}",
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [
@@ -72,7 +73,7 @@
         ]
       },
       {
-        "reference": "1015_CASE_RE_LISTED_LEGAL_REPRESENTATIVE",
+        "reference": "1016_CASE_RE_LISTED_LEGAL_REPRESENTATIVE",
         "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
@@ -84,7 +85,7 @@
         ]
       },
       {
-        "reference": "1015_CASE_RE_LISTED_CASE_OFFICER",
+        "reference": "1016_CASE_RE_LISTED_CASE_OFFICER",
         "recipient": "{$hearingCentreEmailAddresses.birmingham}",
         "subject": "Immigration and Asylum appeal: case re-listed",
         "body": [

--- a/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-remote-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-remote-hearing.json
@@ -1,9 +1,8 @@
 {
   "description": "RIA-7195 edit case listing notification with isIntegrated field (remote hearing)",
-  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
-    "credentials": "AdminOfficer",
+    "credentials": "CaseOfficer",
     "input": {
       "id": 1015,
       "eventId": "editCaseListing",
@@ -17,6 +16,7 @@
           "listCaseHearingCentre": "remoteHearing",
           "listCaseHearingDate": "2023-09-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
+          "remoteVideoCallTribunalResponse": "Some tribunal response",
           "isIntegrated": "Yes"
         }
       },
@@ -25,7 +25,8 @@
         "replacements": {
           "listCaseHearingCentre": "remoteHearing",
           "listCaseHearingDate": "2023-09-02T14:25:15.000",
-          "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
+          "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
+          "isIntegrated": "Yes"
         }
       }
     }
@@ -66,7 +67,8 @@
           "PA/12345/2023",
           "3 Sep 2023",
           "14:25",
-          "Remote hearing"
+          "Remote hearing",
+          "Some tribunal response"
         ]
       },
       {
@@ -77,7 +79,8 @@
           "PA/12345/2023",
           "3 Sep 2023",
           "14:25",
-          "Remote hearing"
+          "Remote hearing",
+          "Some tribunal response"
         ]
       },
       {

--- a/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-remote-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7195-edit-case-listing-notification-with-integrated-remote-hearing.json
@@ -1,0 +1,96 @@
+{
+  "description": "RIA-7195 edit case listing notification with isIntegrated field (remote hearing)",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 1015,
+      "eventId": "editCaseListing",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "appealReferenceNumber": "PA/12345/2023",
+          "ariaListingReference": "LP/12345/2023",
+          "hearingCentre": "harmondsworth",
+          "listCaseHearingCentre": "remoteHearing",
+          "listCaseHearingDate": "2023-09-03T14:25:15.000",
+          "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
+          "isIntegrated": "Yes"
+        }
+      },
+      "caseDataBefore": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "listCaseHearingCentre": "remoteHearing",
+          "listCaseHearingDate": "2023-09-02T14:25:15.000",
+          "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "appealReferenceNumber": "PA/12345/2023",
+        "hearingCentre": "harmondsworth",
+        "listCaseHearingCentre": "remoteHearing",
+        "listCaseHearingDate": "2023-09-03T14:25:15.000",
+        "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
+        "notificationsSent": [
+          {
+            "id": "1015_CASE_RE_LISTED_HOME_OFFICE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1015_CASE_RE_LISTED_LEGAL_REPRESENTATIVE",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "1015_CASE_RE_LISTED_CASE_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "1015_CASE_RE_LISTED_LEGAL_REPRESENTATIVE",
+        "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
+        "subject": "Immigration and Asylum appeal: check the details of your hearing",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Remote hearing"
+        ]
+      },
+      {
+        "reference": "1015_CASE_RE_LISTED_HOME_OFFICE",
+        "recipient": "{$homeOfficeEmailAddresses.harmondsworth}",
+        "subject": "Immigration and Asylum appeal: case re-listed",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Remote hearing"
+        ]
+      },
+      {
+        "reference": "1015_CASE_RE_LISTED_CASE_OFFICER",
+        "recipient": "{$hearingCentreEmailAddresses.harmondsworth}",
+        "subject": "Immigration and Asylum appeal: case re-listed",
+        "body": [
+          "PA/12345/2023",
+          "3 Sep 2023",
+          "14:25",
+          "Remote hearing"
+        ]
+      }
+    ]
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7879-case-listed-notification-harmondsworth-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7879-case-listed-notification-harmondsworth-hearing-centre.json
@@ -5,7 +5,7 @@
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "AdminOfficer",
     "input": {
-      "id": 1015,
+      "id": 1017,
       "eventId": "listCase",
       "state": "prepareForHearing",
       "caseData": {
@@ -32,15 +32,15 @@
         "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
         "notificationsSent": [
           {
-            "id": "1015_CASE_LISTED_LEGAL_REPRESENTATIVE",
+            "id": "1017_CASE_LISTED_LEGAL_REPRESENTATIVE",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {
-            "id": "1015_CASE_LISTED_HOME_OFFICE",
+            "id": "1017_CASE_LISTED_HOME_OFFICE",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {
-            "id": "1015_CASE_LISTED_CASE_OFFICER",
+            "id": "1017_CASE_LISTED_CASE_OFFICER",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
         ]
@@ -48,7 +48,7 @@
     },
     "notifications": [
       {
-        "reference": "1015_CASE_LISTED_LEGAL_REPRESENTATIVE",
+        "reference": "1017_CASE_LISTED_LEGAL_REPRESENTATIVE",
         "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
@@ -60,7 +60,7 @@
         ]
       },
       {
-        "reference": "1015_CASE_LISTED_HOME_OFFICE",
+        "reference": "1017_CASE_LISTED_HOME_OFFICE",
         "recipient": "{$homeOfficeEmailAddresses.harmondsworth}",
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
@@ -72,7 +72,7 @@
         ]
       },
       {
-        "reference": "1015_CASE_LISTED_CASE_OFFICER",
+        "reference": "1017_CASE_LISTED_CASE_OFFICER",
         "recipient": "{$hearingCentreEmailAddresses.harmondsworth}",
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [

--- a/src/functionalTest/resources/scenarios/RIA-7879-case-listed-notification-harmondsworth-hearing-centre.json
+++ b/src/functionalTest/resources/scenarios/RIA-7879-case-listed-notification-harmondsworth-hearing-centre.json
@@ -12,6 +12,7 @@
         "template": "minimal-appeal-submitted.json",
         "replacements": {
           "appealReferenceNumber": "PA/12345/2023",
+          "ariaListingReference": "LP/12345/2023",
           "listCaseHearingCentre": "harmondsworth",
           "listCaseHearingDate": "2023-09-03T14:25:15.000",
           "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}"
@@ -52,6 +53,7 @@
         "subject": "Immigration and Asylum appeal: check the details of your hearing",
         "body": [
           "PA/12345/2023",
+          "LP/12345/2023",
           "3 Sep 2023",
           "14:25",
           "Harmondsworth Tribunal Hearing Centre, Colnbrook Bypass, UB7 0HB"
@@ -63,6 +65,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2023",
+          "LP/12345/2023",
           "3 Sep 2023",
           "14:25",
           "Harmondsworth Tribunal Hearing Centre, Colnbrook Bypass, UB7 0HB"
@@ -74,6 +77,7 @@
         "subject": "Immigration and Asylum appeal: case listed",
         "body": [
           "PA/12345/2023",
+          "LP/12345/2023",
           "3 Sep 2023",
           "14:25",
           "Harmondsworth Tribunal Hearing Centre, Colnbrook Bypass, UB7 0HB"

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AsylumCaseDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AsylumCaseDefinition.java
@@ -367,6 +367,9 @@ public enum AsylumCaseDefinition {
 
     APPELLANT_HAS_FIXED_ADDRESS("appellantHasFixedAddress", new TypeReference<YesOrNo>(){}),
 
+    IS_INTEGRATED(
+            "isIntegrated", new TypeReference<YesOrNo>(){}),
+
     CASE_LINKS(
             "caseLinks", new TypeReference<List<IdValue<CaseLink>>>(){})
     ;

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantEditListingPersonalisationEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantEditListingPersonalisationEmail.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appellant.email;
 
 import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.IS_INTEGRATED;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.NotificationType;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.RecipientsFinder;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.CustomerServicesProvider;
@@ -19,6 +21,7 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.Personalisation
 public class AppellantEditListingPersonalisationEmail implements EmailNotificationPersonalisation {
 
     private final String editListingAppellantEmailTemplateId;
+    private final String listAssistHearingEditListingAppellantEmailTemplateId;
     private final String iaAipFrontendUrl;
     private final PersonalisationProvider personalisationProvider;
     private final CustomerServicesProvider customerServicesProvider;
@@ -27,12 +30,14 @@ public class AppellantEditListingPersonalisationEmail implements EmailNotificati
 
     public AppellantEditListingPersonalisationEmail(
         @Value("${govnotify.template.caseEdited.appellant.email}") String editListingAppellantEmailTemplateId,
+        @Value("${govnotify.template.listAssistHearing.caseEdited.appellant.email}") String listAssistHearingEditListingAppellantEmailTemplateId,
         @Value("${iaAipFrontendUrl}") String iaAipFrontendUrl,
         PersonalisationProvider personalisationProvider,
         CustomerServicesProvider customerServicesProvider,
         RecipientsFinder recipientsFinder
     ) {
         this.editListingAppellantEmailTemplateId = editListingAppellantEmailTemplateId;
+        this.listAssistHearingEditListingAppellantEmailTemplateId = listAssistHearingEditListingAppellantEmailTemplateId;
         this.iaAipFrontendUrl = iaAipFrontendUrl;
         this.personalisationProvider = personalisationProvider;
         this.customerServicesProvider = customerServicesProvider;
@@ -40,8 +45,9 @@ public class AppellantEditListingPersonalisationEmail implements EmailNotificati
     }
 
     @Override
-    public String getTemplateId() {
-        return editListingAppellantEmailTemplateId;
+    public String getTemplateId(AsylumCase asylumCase) {
+        return asylumCase.read(IS_INTEGRATED, YesOrNo.class).orElse(YesOrNo.NO) == YesOrNo.YES
+                ? listAssistHearingEditListingAppellantEmailTemplateId : editListingAppellantEmailTemplateId;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantListCasePersonalisationEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantListCasePersonalisationEmail.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.NotificationType;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.RecipientsFinder;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.CustomerServicesProvider;
@@ -23,6 +24,7 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.HearingDetailsF
 public class AppellantListCasePersonalisationEmail implements EmailNotificationPersonalisation {
 
     private final String appellantCaseListedTemplateId;
+    private final String listAssistHearingAppellantCaseListedTemplateId;
     private final DateTimeExtractor dateTimeExtractor;
     private final CustomerServicesProvider customerServicesProvider;
     private final HearingDetailsFinder hearingDetailsFinder;
@@ -32,6 +34,7 @@ public class AppellantListCasePersonalisationEmail implements EmailNotificationP
 
     public AppellantListCasePersonalisationEmail(
         @Value("${govnotify.template.caseListed.appellant.email}") String appellantCaseListedEmailTemplateId,
+        @Value("${govnotify.template.listAssistHearing.caseListed.appellant.email}") String listAssistHearingAppellantCaseListedTemplateId,
         @Value("${iaAipFrontendUrl}") String iaAipFrontendUrl,
         DateTimeExtractor dateTimeExtractor,
         CustomerServicesProvider customerServicesProvider,
@@ -39,6 +42,7 @@ public class AppellantListCasePersonalisationEmail implements EmailNotificationP
         RecipientsFinder recipientsFinder
     ) {
         this.appellantCaseListedTemplateId = appellantCaseListedEmailTemplateId;
+        this.listAssistHearingAppellantCaseListedTemplateId = listAssistHearingAppellantCaseListedTemplateId;
         this.iaAipFrontendUrl = iaAipFrontendUrl;
         this.dateTimeExtractor = dateTimeExtractor;
         this.customerServicesProvider = customerServicesProvider;
@@ -48,7 +52,8 @@ public class AppellantListCasePersonalisationEmail implements EmailNotificationP
 
     @Override
     public String getTemplateId(AsylumCase asylumCase) {
-        return appellantCaseListedTemplateId;
+        return asylumCase.read(IS_INTEGRATED, YesOrNo.class).orElse(YesOrNo.NO) == YesOrNo.YES
+                ? listAssistHearingAppellantCaseListedTemplateId : appellantCaseListedTemplateId;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerEditListingPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerEditListingPersonalisation.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.caseofficer;
 
 import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.IS_INTEGRATED;
 
 import java.util.Collections;
 import java.util.Map;
@@ -9,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PersonalisationProvider;
@@ -17,21 +19,25 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.Personalisation
 public class CaseOfficerEditListingPersonalisation implements EmailNotificationPersonalisation {
 
     private final String caseOfficerCaseEditedTemplateId;
+    private final String listAssistHearingCaseOfficerCaseEditedTemplateId;
     private final PersonalisationProvider personalisationProvider;
     private final EmailAddressFinder emailAddressFinder;
 
     public CaseOfficerEditListingPersonalisation(
             @Value("${govnotify.template.caseEdited.caseOfficer.email}") String caseOfficerCaseEditedTemplateId,
+            @Value("${govnotify.template.listAssistHearing.caseEdited.caseOfficer.email}") String listAssistHearingCaseOfficerCaseEditedTemplateId,
             EmailAddressFinder emailAddressFinder,
             PersonalisationProvider personalisationProvider) {
         this.caseOfficerCaseEditedTemplateId = caseOfficerCaseEditedTemplateId;
+        this.listAssistHearingCaseOfficerCaseEditedTemplateId = listAssistHearingCaseOfficerCaseEditedTemplateId;
         this.emailAddressFinder = emailAddressFinder;
         this.personalisationProvider = personalisationProvider;
     }
 
     @Override
-    public String getTemplateId() {
-        return caseOfficerCaseEditedTemplateId;
+    public String getTemplateId(AsylumCase asylumCase) {
+        return asylumCase.read(IS_INTEGRATED, YesOrNo.class).orElse(YesOrNo.NO) == YesOrNo.YES
+                ? listAssistHearingCaseOfficerCaseEditedTemplateId : caseOfficerCaseEditedTemplateId;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerListCasePersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerListCasePersonalisation.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.DateTimeExtractor;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
@@ -20,6 +21,7 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.HearingDetailsF
 public class CaseOfficerListCasePersonalisation implements EmailNotificationPersonalisation {
 
     private final String caseOfficerCaseListedTemplateId;
+    private final String listAssistHearingCaseOfficerCaseListedTemplateId;
     private final String iaExUiFrontendUrl;
     private final DateTimeExtractor dateTimeExtractor;
     private final EmailAddressFinder emailAddressFinder;
@@ -29,11 +31,13 @@ public class CaseOfficerListCasePersonalisation implements EmailNotificationPers
 
     public CaseOfficerListCasePersonalisation(
             @Value("${govnotify.template.caseListed.caseOfficer.email}") String caseOfficerCaseListedTemplateId,
+            @Value("${govnotify.template.listAssistHearing.caseListed.caseOfficer.email}") String listAssistHearingCaseOfficerCaseListedTemplateId,
             @Value("${iaExUiFrontendUrl}") String iaExUiFrontendUrl,
             DateTimeExtractor dateTimeExtractor,
             EmailAddressFinder emailAddressFinder,
             HearingDetailsFinder hearingDetailsFinder) {
         this.caseOfficerCaseListedTemplateId = caseOfficerCaseListedTemplateId;
+        this.listAssistHearingCaseOfficerCaseListedTemplateId = listAssistHearingCaseOfficerCaseListedTemplateId;
         this.iaExUiFrontendUrl = iaExUiFrontendUrl;
         this.dateTimeExtractor = dateTimeExtractor;
         this.emailAddressFinder = emailAddressFinder;
@@ -41,8 +45,9 @@ public class CaseOfficerListCasePersonalisation implements EmailNotificationPers
     }
 
     @Override
-    public String getTemplateId() {
-        return caseOfficerCaseListedTemplateId;
+    public String getTemplateId(AsylumCase asylumCase) {
+        return asylumCase.read(IS_INTEGRATED, YesOrNo.class).orElse(YesOrNo.NO) == YesOrNo.YES
+                ? listAssistHearingCaseOfficerCaseListedTemplateId : caseOfficerCaseListedTemplateId;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeEditListingPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeEditListingPersonalisation.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.homeoffice;
 
 import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.IS_INTEGRATED;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.LIST_CASE_HEARING_CENTRE;
 
 import com.google.common.collect.ImmutableMap;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.HearingCentre;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.CustomerServicesProvider;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
@@ -22,25 +24,29 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.Personalisation
 public class HomeOfficeEditListingPersonalisation implements EmailNotificationPersonalisation {
 
     private final String homeOfficeCaseEditedTemplateId;
+    private final String listAssistHearingHomeOfficeCaseEditedTemplateId;
     private final PersonalisationProvider personalisationProvider;
     private EmailAddressFinder emailAddressFinder;
     private final CustomerServicesProvider customerServicesProvider;
 
     public HomeOfficeEditListingPersonalisation(
         @Value("${govnotify.template.caseEdited.homeOffice.email}") String homeOfficeCaseEditedTemplateId,
+        @Value("${govnotify.template.listAssistHearing.caseEdited.homeOffice.email}") String listAssistHearingHomeOfficeCaseEditedTemplateId,
         EmailAddressFinder emailAddressFinder,
         PersonalisationProvider personalisationProvider,
         CustomerServicesProvider customerServicesProvider
     ) {
         this.homeOfficeCaseEditedTemplateId = homeOfficeCaseEditedTemplateId;
+        this.listAssistHearingHomeOfficeCaseEditedTemplateId = listAssistHearingHomeOfficeCaseEditedTemplateId;
         this.emailAddressFinder = emailAddressFinder;
         this.personalisationProvider = personalisationProvider;
         this.customerServicesProvider = customerServicesProvider;
     }
 
     @Override
-    public String getTemplateId() {
-        return homeOfficeCaseEditedTemplateId;
+    public String getTemplateId(AsylumCase asylumCase) {
+        return asylumCase.read(IS_INTEGRATED, YesOrNo.class).orElse(YesOrNo.NO) == YesOrNo.YES
+                ? listAssistHearingHomeOfficeCaseEditedTemplateId : homeOfficeCaseEditedTemplateId;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeListCasePersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeListCasePersonalisation.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.*;
 
@@ -18,6 +19,7 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.*;
 public class HomeOfficeListCasePersonalisation implements EmailNotificationPersonalisation {
 
     private final String homeOfficeCaseListedTemplateId;
+    private final String listAssistHearingHomeOfficeCaseListedTemplateId;
     private final String iaExUiFrontendUrl;
     private final DateTimeExtractor dateTimeExtractor;
     private final EmailAddressFinder emailAddressFinder;
@@ -26,6 +28,7 @@ public class HomeOfficeListCasePersonalisation implements EmailNotificationPerso
 
     public HomeOfficeListCasePersonalisation(
         @Value("${govnotify.template.caseListed.homeOffice.email}") String homeOfficeCaseListedTemplateId,
+        @Value("${govnotify.template.listAssistHearing.caseListed.homeOffice.email}") String listAssistHearingHomeOfficeCaseListedTemplateId,
         @Value("${iaExUiFrontendUrl}") String iaExUiFrontendUrl,
         DateTimeExtractor dateTimeExtractor,
         EmailAddressFinder emailAddressFinder,
@@ -33,6 +36,7 @@ public class HomeOfficeListCasePersonalisation implements EmailNotificationPerso
         HearingDetailsFinder hearingDetailsFinder
     ) {
         this.homeOfficeCaseListedTemplateId = homeOfficeCaseListedTemplateId;
+        this.listAssistHearingHomeOfficeCaseListedTemplateId = listAssistHearingHomeOfficeCaseListedTemplateId;
         this.iaExUiFrontendUrl = iaExUiFrontendUrl;
         this.dateTimeExtractor = dateTimeExtractor;
         this.emailAddressFinder = emailAddressFinder;
@@ -41,8 +45,9 @@ public class HomeOfficeListCasePersonalisation implements EmailNotificationPerso
     }
 
     @Override
-    public String getTemplateId() {
-        return homeOfficeCaseListedTemplateId;
+    public String getTemplateId(AsylumCase asylumCase) {
+        return asylumCase.read(IS_INTEGRATED, YesOrNo.class).orElse(YesOrNo.NO) == YesOrNo.YES
+                ? listAssistHearingHomeOfficeCaseListedTemplateId : homeOfficeCaseListedTemplateId;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeEditListingPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeEditListingPersonalisation.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.HearingCentre;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.CustomerServicesProvider;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PersonalisationProvider;
 
@@ -19,25 +20,37 @@ public class LegalRepresentativeEditListingPersonalisation implements LegalRepre
 
     private final String legalRepresentativeCaseEditedTemplateId;
     private final String legalRepresentativeCaseEditedRemoteHearingTemplateId;
+    private final String listAssistHearingLegalRepresentativeCaseEditedTemplateId;
+    private final String listAssistHearingLegalRepresentativeCaseEditedRemoteHearingTemplateId;
     private final PersonalisationProvider personalisationProvider;
     private final CustomerServicesProvider customerServicesProvider;
 
     public LegalRepresentativeEditListingPersonalisation(
         @Value("${govnotify.template.caseEdited.legalRep.email}") String legalRepresentativeCaseEditedTemplateId,
         @Value("${govnotify.template.caseEditedRemoteHearing.legalRep.email}") String legalRepresentativeCaseEditedRemoteHearingTemplateId,
+        @Value("${govnotify.template.listAssistHearing.caseEdited.legalRep.email}") String listAssistHearingLegalRepresentativeCaseEditedTemplateId,
+        @Value("${govnotify.template.listAssistHearing.caseEditedRemoteHearing.legalRep.email}") String listAssistHearingLegalRepresentativeCaseEditedRemoteHearingTemplateId,
         PersonalisationProvider personalisationProvider,
         CustomerServicesProvider customerServicesProvider
     ) {
         this.legalRepresentativeCaseEditedTemplateId = legalRepresentativeCaseEditedTemplateId;
         this.legalRepresentativeCaseEditedRemoteHearingTemplateId = legalRepresentativeCaseEditedRemoteHearingTemplateId;
+        this.listAssistHearingLegalRepresentativeCaseEditedTemplateId = listAssistHearingLegalRepresentativeCaseEditedTemplateId;
+        this.listAssistHearingLegalRepresentativeCaseEditedRemoteHearingTemplateId = listAssistHearingLegalRepresentativeCaseEditedRemoteHearingTemplateId;
         this.personalisationProvider = personalisationProvider;
         this.customerServicesProvider = customerServicesProvider;
     }
 
     @Override
     public String getTemplateId(AsylumCase asylumCase) {
-        return asylumCase.read(LIST_CASE_HEARING_CENTRE, HearingCentre.class).equals(Optional.of(HearingCentre.REMOTE_HEARING))
-            ? legalRepresentativeCaseEditedRemoteHearingTemplateId : legalRepresentativeCaseEditedTemplateId;
+        YesOrNo isIntegrated = asylumCase.read(IS_INTEGRATED, YesOrNo.class).orElse(YesOrNo.NO);
+        if (asylumCase.read(LIST_CASE_HEARING_CENTRE, HearingCentre.class).equals(Optional.of(HearingCentre.REMOTE_HEARING))) {
+            return isIntegrated == YesOrNo.YES ?
+                    listAssistHearingLegalRepresentativeCaseEditedRemoteHearingTemplateId : legalRepresentativeCaseEditedRemoteHearingTemplateId;
+        } else {
+            return isIntegrated == YesOrNo.YES ?
+                    listAssistHearingLegalRepresentativeCaseEditedTemplateId : legalRepresentativeCaseEditedTemplateId;
+        }
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeListCasePersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeListCasePersonalisation.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.HearingCentre;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.*;
 
 @Service
@@ -17,6 +18,8 @@ public class LegalRepresentativeListCasePersonalisation implements LegalRepresen
 
     private final String legalRepresentativeCaseListedTemplateId;
     private final String legalRepresentativeOutOfCountryCaseListedTemplateId;
+    private final String listAssistHearingLegalRepresentativeCaseListedTemplateId;
+    private final String listAssistHearingLegalRepresentativeOutOfCountryCaseListedTemplateId;
     private final String iaExUiFrontendUrl;
     private final DateTimeExtractor dateTimeExtractor;
     private final CustomerServicesProvider customerServicesProvider;
@@ -26,6 +29,8 @@ public class LegalRepresentativeListCasePersonalisation implements LegalRepresen
     public LegalRepresentativeListCasePersonalisation(
         @Value("${govnotify.template.caseListed.legalRep.email}") String legalRepresentativeCaseListedTemplateId,
         @Value("${govnotify.template.caseListed.remoteHearing.legalRep.email}") String legalRepresentativeOutOfCountryCaseListedTemplateId,
+        @Value("${govnotify.template.listAssistHearing.caseListed.legalRep.email}") String listAssistHearingLegalRepresentativeCaseListedTemplateId,
+        @Value("${govnotify.template.listAssistHearing.caseListed.remoteHearing.legalRep.email}") String listAssistHearingLegalRepresentativeOutOfCountryCaseListedTemplateId,
         @Value("${iaExUiFrontendUrl}") String iaExUiFrontendUrl,
         DateTimeExtractor dateTimeExtractor,
         CustomerServicesProvider customerServicesProvider,
@@ -33,6 +38,8 @@ public class LegalRepresentativeListCasePersonalisation implements LegalRepresen
     ) {
         this.legalRepresentativeCaseListedTemplateId = legalRepresentativeCaseListedTemplateId;
         this.legalRepresentativeOutOfCountryCaseListedTemplateId = legalRepresentativeOutOfCountryCaseListedTemplateId;
+        this.listAssistHearingLegalRepresentativeCaseListedTemplateId = listAssistHearingLegalRepresentativeCaseListedTemplateId;
+        this.listAssistHearingLegalRepresentativeOutOfCountryCaseListedTemplateId = listAssistHearingLegalRepresentativeOutOfCountryCaseListedTemplateId;
         this.iaExUiFrontendUrl = iaExUiFrontendUrl;
         this.dateTimeExtractor = dateTimeExtractor;
         this.customerServicesProvider = customerServicesProvider;
@@ -41,12 +48,15 @@ public class LegalRepresentativeListCasePersonalisation implements LegalRepresen
 
     @Override
     public String getTemplateId(AsylumCase asylumCase) {
+        YesOrNo isIntegrated = asylumCase.read(IS_INTEGRATED, YesOrNo.class).orElse(YesOrNo.NO);
         if (asylumCase.read(LIST_CASE_HEARING_CENTRE, HearingCentre.class)
             .map(centre -> centre == HearingCentre.REMOTE_HEARING)
             .orElse(false)) {
-            return legalRepresentativeOutOfCountryCaseListedTemplateId;
+            return (isIntegrated == YesOrNo.YES ?
+                    listAssistHearingLegalRepresentativeOutOfCountryCaseListedTemplateId : legalRepresentativeOutOfCountryCaseListedTemplateId);
         } else {
-            return legalRepresentativeCaseListedTemplateId;
+            return (isIntegrated == YesOrNo.YES ?
+                    listAssistHearingLegalRepresentativeCaseListedTemplateId : legalRepresentativeCaseListedTemplateId);
         }
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -239,26 +239,26 @@ govnotify:
         email: a1df610c-cd9a-494a-9100-15ed94f6fe66
     caseListed:
       caseOfficer:
-        email: ddb88c55-c97e-45df-a6b1-dc92fd0433b3
+        email: 8bac3c7d-5fb7-4777-add3-5d7ade17ee71
       homeOffice:
-        email: 9e7b4606-78c1-41dd-b294-5eb432a6b92f
+        email: 621d266e-a0a0-498d-800e-0f13dd8357b8
       legalRep:
-        email: 59000d04-4a97-45ae-8a1e-036ca9faa9b5
+        email: 84dbdaba-df43-4096-9b16-5817ba3e002c
       appellant:
-        email: 398c92a5-10db-43d9-980b-2de2981d22f7
+        email: f55d3aa3-fe59-48f8-9d53-adc43ad95e14
         sms: 5b7faa5a-792e-48bf-a512-d21a27ae9b23
       remoteHearing:
         legalRep:
-          email: 031b65ee-6f5f-4c02-8a5f-8d56221272e9
+          email: e79249e2-ecbf-4d2b-8458-006285613402
     caseEdited:
       homeOffice:
-        email: 0f1f382e-f62a-4fed-b9ed-ffdcee555a03
+        email: b4cfdb17-6130-4f52-aec4-f3571e030790
       caseOfficer:
-        email: 513c5d12-7e26-4430-8560-d3a42a2d5df0
+        email: fec967bf-79f6-4683-b908-d1eea3cc591e
       legalRep:
-        email: 6a4155a9-9b59-4db8-ac28-fe440f90242c
+        email: 60adb2b5-7a46-43bb-a03b-218b342e3d77
       appellant:
-        email: 524ad0a6-ad22-4d65-84a9-a566ee1c6981
+        email: 11254ed3-abfb-4fd2-a2bf-8453f470321a
         sms: 7d23fda4-9ff7-4642-aa97-1a8a3ccafaba
     caseEditedNoChange:
       legalRep:
@@ -267,7 +267,32 @@ govnotify:
         email: 7f36a473-948f-4ccf-a76a-122a36237d29
     caseEditedRemoteHearing:
       legalRep:
-        email: 2cb4adf3-24da-4795-93b3-379f08b01300
+        email: 9fa63eec-3827-4cc5-b399-2469dd7034f6
+    listAssistHearing:
+      caseListed:
+        caseOfficer:
+          email: ddb88c55-c97e-45df-a6b1-dc92fd0433b3
+        homeOffice:
+          email: 9e7b4606-78c1-41dd-b294-5eb432a6b92f
+        legalRep:
+          email: 59000d04-4a97-45ae-8a1e-036ca9faa9b5
+        appellant:
+          email: 398c92a5-10db-43d9-980b-2de2981d22f7
+        remoteHearing:
+          legalRep:
+            email: 031b65ee-6f5f-4c02-8a5f-8d56221272e9
+      caseEdited:
+        homeOffice:
+          email: 0f1f382e-f62a-4fed-b9ed-ffdcee555a03
+        caseOfficer:
+          email: 513c5d12-7e26-4430-8560-d3a42a2d5df0
+        legalRep:
+          email: 6a4155a9-9b59-4db8-ac28-fe440f90242c
+        appellant:
+          email: 524ad0a6-ad22-4d65-84a9-a566ee1c6981
+      caseEditedRemoteHearing:
+        legalRep:
+          email: 2cb4adf3-24da-4795-93b3-379f08b01300
     appealOutcomeAllowed:
       homeOffice:
         email: 0e8c3a70-4ba3-442b-8b12-235ee69a8d20

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantEditListingPersonalisationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantEditListingPersonalisationEmailTest.java
@@ -84,7 +84,7 @@ public class AppellantEditListingPersonalisationEmailTest {
 
     @Test
     public void should_return_given_template_id() {
-        assertEquals(templateId, appellantEditListingPersonalisationEmail.getTemplateId());
+        assertEquals(templateId, appellantEditListingPersonalisationEmail.getTemplateId(asylumCase));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantEditListingPersonalisationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantEditListingPersonalisationEmailTest.java
@@ -43,6 +43,7 @@ public class AppellantEditListingPersonalisationEmailTest {
 
     private Long caseId = 12345L;
     private String templateId = "someTemplateId";
+    private String listAssistHearingTemplateId = "listAssistHearingTemplateId";
     private String iaExUiFrontendUrl = "http://localhost";
     private String mockedAppellantEmailAddress = "legalRep@example.com";
     private String hearingCentreAddress = "some hearing centre address";
@@ -73,6 +74,7 @@ public class AppellantEditListingPersonalisationEmailTest {
 
         appellantEditListingPersonalisationEmail = new AppellantEditListingPersonalisationEmail(
             templateId,
+            listAssistHearingTemplateId,
             iaAipFrontendUrl,
             personalisationProvider,
             customerServicesProvider,

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantListCasePersonalisationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AppellantListCasePersonalisationEmailTest.java
@@ -46,6 +46,7 @@ public class AppellantListCasePersonalisationEmailTest {
 
     private Long caseId = 12345L;
     private String templateId = "someTemplateId";
+    private String listAssistHEaringTemplateId = "listAssistHearingTemplateId";
     private String iaAipFrontendUrl = "http://somefrontendurl";
     private HearingCentre hearingCentre = HearingCentre.TAYLOR_HOUSE;
     private String hearingCentreAddress = "some hearing centre address";
@@ -92,6 +93,7 @@ public class AppellantListCasePersonalisationEmailTest {
 
         appellantListCasePersonalisationEmail = new AppellantListCasePersonalisationEmail(
             templateId,
+                listAssistHEaringTemplateId,
                 iaAipFrontendUrl,
                 dateTimeExtractor,
                 customerServicesProvider,

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerEditListingPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerEditListingPersonalisationTest.java
@@ -38,6 +38,7 @@ class CaseOfficerEditListingPersonalisationTest {
 
     private Long caseId = 12345L;
     private String templateId = "someTemplateId";
+    private String listAssistHearingTemplateId = "listAssistHearingTemplateId";
     private String iaExUiFrontendUrl = "http://somefrontendurl";
     private String hearingCentreEmailAddress = "hearingCentre@example.com";
     private String listCaseHearingCentreEmailAddress = "listCaseHearingCentre@example.com";
@@ -59,6 +60,7 @@ class CaseOfficerEditListingPersonalisationTest {
 
         caseOfficerEditListingPersonalisation = new CaseOfficerEditListingPersonalisation(
             templateId,
+            listAssistHearingTemplateId,
             emailAddressFinder,
             personalisationProvider);
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerEditListingPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerEditListingPersonalisationTest.java
@@ -67,7 +67,7 @@ class CaseOfficerEditListingPersonalisationTest {
 
     @Test
     void should_return_given_template_id() {
-        assertEquals(templateId, caseOfficerEditListingPersonalisation.getTemplateId());
+        assertEquals(templateId, caseOfficerEditListingPersonalisation.getTemplateId(asylumCase));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerListCasePersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerListCasePersonalisationTest.java
@@ -40,6 +40,7 @@ public class CaseOfficerListCasePersonalisationTest {
 
     private Long caseId = 12345L;
     private String templateId = "someTemplateId";
+    private String listAssistHearingTemplateId = "listAssistHearingTemplateId";
     private String iaExUiFrontendUrl = "http://somefrontendurl";
     private HearingCentre hearingCentre = HearingCentre.TAYLOR_HOUSE;
     private String hearingCentreEmailAddress = "hearingCentre@example.com";
@@ -84,6 +85,7 @@ public class CaseOfficerListCasePersonalisationTest {
 
         caseOfficerListCasePersonalisation = new CaseOfficerListCasePersonalisation(
             templateId,
+            listAssistHearingTemplateId,
             iaExUiFrontendUrl,
             dateTimeExtractor,
             emailAddressFinder,

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerListCasePersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerListCasePersonalisationTest.java
@@ -94,7 +94,7 @@ public class CaseOfficerListCasePersonalisationTest {
 
     @Test
     public void should_return_given_template_id() {
-        assertEquals(templateId, caseOfficerListCasePersonalisation.getTemplateId());
+        assertEquals(templateId, caseOfficerListCasePersonalisation.getTemplateId(asylumCase));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeEditListingPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeEditListingPersonalisationTest.java
@@ -41,6 +41,7 @@ class HomeOfficeEditListingPersonalisationTest {
 
     private Long caseId = 12345L;
     private String templateId = "someTemplateId";
+    private String listAssistHearingTemplateId = "listAssistHearingTemplateId";
     private String iaExUiFrontendUrl = "http://localhost";
     private String homeOfficeEmailAddress = "homeoffice@example.com";
     private String listCaseHomeOfficeEmailAddress = "listCaseHomeoOffice@example.com";
@@ -71,6 +72,7 @@ class HomeOfficeEditListingPersonalisationTest {
 
         homeOfficeEditListingPersonalisation = new HomeOfficeEditListingPersonalisation(
             templateId,
+            listAssistHearingTemplateId,
             emailAddressFinder,
             personalisationProvider,
             customerServicesProvider

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeEditListingPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeEditListingPersonalisationTest.java
@@ -81,7 +81,7 @@ class HomeOfficeEditListingPersonalisationTest {
 
     @Test
     void should_return_given_template_id() {
-        assertEquals(templateId, homeOfficeEditListingPersonalisation.getTemplateId());
+        assertEquals(templateId, homeOfficeEditListingPersonalisation.getTemplateId(asylumCase));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeListCasePersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeListCasePersonalisationTest.java
@@ -135,7 +135,7 @@ public class HomeOfficeListCasePersonalisationTest {
 
     @Test
     public void should_return_given_template_id() {
-        assertEquals(templateId, homeOfficeListCasePersonalisation.getTemplateId());
+        assertEquals(templateId, homeOfficeListCasePersonalisation.getTemplateId(asylumCase));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeListCasePersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeListCasePersonalisationTest.java
@@ -39,6 +39,7 @@ public class HomeOfficeListCasePersonalisationTest {
 
     private Long caseId = 12345L;
     private String templateId = "someTemplateId";
+    private String listAssistHearingTemplateId = "listAssistHearingTemplateId";
     private String iaExUiFrontendUrl = "http://somefrontendurl";
     private HearingCentre hearingCentre = HearingCentre.TAYLOR_HOUSE;
     private String homeOfficeEmailAddress = "homeoffice@example.com";
@@ -123,6 +124,7 @@ public class HomeOfficeListCasePersonalisationTest {
 
         homeOfficeListCasePersonalisation = new HomeOfficeListCasePersonalisation(
             templateId,
+            listAssistHearingTemplateId,
             iaExUiFrontendUrl,
             dateTimeExtractor,
             emailAddressFinder,

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeEditListingPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeEditListingPersonalisationTest.java
@@ -39,6 +39,8 @@ public class LegalRepresentativeEditListingPersonalisationTest {
     private Long caseId = 12345L;
     private String templateId = "someTemplateId";
     private String templateIdRemoteHearing = "remoteTemplateId";
+    private String listAssistHearingTemplateId = "listAssistHearingTemplateId";
+    private String listAssistHearingTemplateIdRemoteHearing = "listAssistHearingRemoteTemplateId";
     private String iaExUiFrontendUrl = "http://localhost";
     private String legalRepEmailAddress = "legalRep@example.com";
     private String hearingCentreAddress = "some hearing centre address";
@@ -72,6 +74,8 @@ public class LegalRepresentativeEditListingPersonalisationTest {
         legalRepresentativeEditListingPersonalisation = new LegalRepresentativeEditListingPersonalisation(
             templateId,
             templateIdRemoteHearing,
+            listAssistHearingTemplateId,
+            listAssistHearingTemplateIdRemoteHearing,
             personalisationProvider,
             customerServicesProvider
         );

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeListCasePersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeListCasePersonalisationTest.java
@@ -41,6 +41,8 @@ public class LegalRepresentativeListCasePersonalisationTest {
     private Long caseId = 12345L;
     private String templateId = "someTemplateId";
     private String outOfCountryTemplateId = "someOocTemplateId";
+    private String listAssistHearingTemplateId = "listAssistHearingTemplateId";
+    private String listAssistHearingOutOfCountryTemplateId = "listAssistHearingOocTemplateId";
     private String iaExUiFrontendUrl = "http://somefrontendurl";
     private HearingCentre hearingCentre = HearingCentre.TAYLOR_HOUSE;
     private String legalRepEmailAddress = "legalRepEmailAddress@example.com";
@@ -128,6 +130,8 @@ public class LegalRepresentativeListCasePersonalisationTest {
         legalRepresentativeListCasePersonalisation = new LegalRepresentativeListCasePersonalisation(
             templateId,
             outOfCountryTemplateId,
+            listAssistHearingTemplateId,
+            listAssistHearingOutOfCountryTemplateId,
             iaExUiFrontendUrl,
             dateTimeExtractor,
             customerServicesProvider,


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/RIA-7195


### Change description ###
- use isIntegrated field to determine this hearing whether is list assist hearing or not
- if isIntegrated set to true, it will be "list assist hearing" and the notification will display without listing reference number
- if isIntegrated set to false, it will be "aria hearing" and the notification will display listing reference number
- temporary suppress the CVE problem



### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
