### PR TITLE
RIA-7791 Notice is sent when hearing is adjourned with no future hearing date

### DIFF
--- a/charts/ia-case-notifications-api/Chart.yaml
+++ b/charts/ia-case-notifications-api/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
     email: ImmigrationandAsylum@HMCTS.NET
 dependencies:
   - name: java
-    version: 4.0.13
+    version: 5.0.0
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/

--- a/charts/ia-case-notifications-api/Chart.yaml
+++ b/charts/ia-case-notifications-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ia-case-notifications-api
 home: https://github.com/hmcts/ia-case-notifications-api
-version: 0.0.43
+version: 0.0.44
 description: Immigration & Asylum Case Notifications Service
 maintainers:
   - name: HMCTS Immigration & Asylum Team

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -32,7 +32,7 @@
     <suppress until="2023-12-31">
         <cve>CVE-2023-35116</cve><!-- 2023-08-03 jackson-databind 2.15.2 (latest version at time of writing) is still vulnerable. Check again once a new version becomes available -->
     </suppress>
-    <suppress until="2023-11-05">
+    <suppress until="2023-12-05">
         <notes>![CDATA[
             Temporary suppression.
             ]]</notes>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -42,5 +42,6 @@
         <cve>CVE-2023-44487</cve>
         <cve>CVE-2023-42795</cve>
         <cve>CVE-2023-45648</cve>
+        <cve>CVE-2023-31582</cve>
     </suppress>
 </suppressions>

--- a/src/functionalTest/resources/scenarios/RIA-7991-record-adjournment-details.json
+++ b/src/functionalTest/resources/scenarios/RIA-7991-record-adjournment-details.json
@@ -1,0 +1,89 @@
+{
+  "description": "RIA-7991 Record adjournment details",
+  "launchDarklyKey": "tcw-notifications-feature:true",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 34536,
+      "eventId": "recordAdjournmentDetails",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "listCaseHearingCentre": "taylorHouse",
+          "relistCaseImmediately": "No"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "listCaseHearingCentre": "taylorHouse",
+        "notificationsSent": [
+          {
+            "id": "34536_LEGAL_REPRESENTATIVE_RECORD_ADJOURNMENT_DETAILS",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "34536_RESPONDENT_RECORD_ADJOURNMENT_DETAILS",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "34536_RECORD_ADJOURNMENT_DETAILS_ADMIN_OFFICER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "34536_CASE_OFFICER_RECORD_ADJOURNMENT_DETAILS",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    },
+    "notifications": [
+      {
+        "reference": "34536_LEGAL_REPRESENTATIVE_RECORD_ADJOURNMENT_DETAILS",
+        "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
+        "subject": "Immigration and Asylum appeal: Hearing adjourned",
+        "body": [
+          "PA/12345/2019",
+          "CASE001",
+          "Talha Awan"
+        ]
+      },
+      {
+        "reference": "34536_RESPONDENT_RECORD_ADJOURNMENT_DETAILS",
+        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: Hearing adjourned",
+        "body": [
+          "PA/12345/2019",
+          "A1234567",
+          "Talha Awan"
+        ]
+      },
+      {
+        "reference": "34536_RECORD_ADJOURNMENT_DETAILS_ADMIN_OFFICER",
+        "recipient": "{$reviewHearingRequirementsAdminOfficerEmailAddress}",
+        "subject": "Immigration and Asylum appeal: Hearing adjourned",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan"
+        ]
+      },
+      {
+        "reference": "34536_CASE_OFFICER_RECORD_ADJOURNMENT_DETAILS",
+        "recipient": "{$hearingCentreEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: Hearing adjourned",
+        "body": [
+          "PA/12345/2019",
+          "Talha Awan"
+        ]
+      }
+    ]
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AsylumCaseDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AsylumCaseDefinition.java
@@ -205,6 +205,9 @@ public enum AsylumCaseDefinition {
     ADJOURN_HEARING_WITHOUT_DATE_REASONS(
         "adjournHearingWithoutDateReasons", new TypeReference<String>() {}),
 
+    RELIST_CASE_IMMEDIATELY(
+            "relistCaseImmediately", new TypeReference<YesOrNo>(){}),
+
     REASON_FOR_LINK_APPEAL(
         "reasonForLinkAppeal", new TypeReference<ReasonForLinkAppealOptions>() {}),
 

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/Event.java
@@ -59,6 +59,7 @@ public enum Event {
     FORCE_CASE_TO_CASE_UNDER_REVIEW("forceCaseToCaseUnderReview"),
     FORCE_CASE_TO_SUBMIT_HEARING_REQUIREMENTS("forceCaseToSubmitHearingRequirements"),
     ADJOURN_HEARING_WITHOUT_DATE("adjournHearingWithoutDate"),
+    RECORD_ADJOURNMENT_DETAILS("recordAdjournmentDetails"),
     RESTORE_STATE_FROM_ADJOURN("restoreStateFromAdjourn"),
     REQUEST_CMA_REQUIREMENTS("requestCmaRequirements"),
     SUBMIT_CMA_REQUIREMENTS("submitCmaRequirements"),

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerRecordAdjournmentDetailsPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerRecordAdjournmentDetailsPersonalisation.java
@@ -1,0 +1,53 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
+
+import javax.validation.constraints.NotNull;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+@Service
+public class AdminOfficerRecordAdjournmentDetailsPersonalisation implements EmailNotificationPersonalisation {
+
+    private final String recordAdjournmentDetailsAdminOfficerTemplateId;
+    private final String reviewHearingRequirementsAdminOfficerEmailAddress;
+    private final AdminOfficerPersonalisationProvider adminOfficerPersonalisationProvider;
+
+    public AdminOfficerRecordAdjournmentDetailsPersonalisation(
+        @NotNull(message = "recordAdjournmentDetailsAdminOfficerTemplateId cannot be null") @Value("${govnotify.template.recordAdjournmentDetails.adminOfficer.email}") String recordAdjournmentDetailsAdminOfficerTemplateId,
+        @Value("${reviewHearingRequirementsAdminOfficerEmailAddress}") String reviewHearingRequirementsAdminOfficerEmailAddress,
+        AdminOfficerPersonalisationProvider adminOfficerPersonalisationProvider
+    ) {
+        this.recordAdjournmentDetailsAdminOfficerTemplateId = recordAdjournmentDetailsAdminOfficerTemplateId;
+        this.reviewHearingRequirementsAdminOfficerEmailAddress = reviewHearingRequirementsAdminOfficerEmailAddress;
+        this.adminOfficerPersonalisationProvider = adminOfficerPersonalisationProvider;
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_RECORD_ADJOURNMENT_DETAILS_ADMIN_OFFICER";
+    }
+
+    @Override
+    public String getTemplateId() {
+        return recordAdjournmentDetailsAdminOfficerTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        return Collections.singleton(reviewHearingRequirementsAdminOfficerEmailAddress);
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+        return adminOfficerPersonalisationProvider.getChangeToHearingRequirementsPersonalisation(asylumCase);
+
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerRecordAdjournmentDetailsPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerRecordAdjournmentDetailsPersonalisation.java
@@ -1,0 +1,63 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.caseofficer;
+
+import com.google.common.collect.ImmutableMap;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.FeatureToggler;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+@Service
+public class CaseOfficerRecordAdjournmentDetailsPersonalisation implements EmailNotificationPersonalisation {
+
+    private final String caseOfficerRecordAdjournmentDetailsTemplateId;
+    private EmailAddressFinder emailAddressFinder;
+    private final FeatureToggler featureToggler;
+
+    public CaseOfficerRecordAdjournmentDetailsPersonalisation(
+            @Value("${govnotify.template.recordAdjournmentDetails.caseOfficer.email}") String caseOfficerRecordAdjournmentDetailsTemplateId,
+            EmailAddressFinder emailAddressFinder,
+            FeatureToggler featureToggler) {
+        this.caseOfficerRecordAdjournmentDetailsTemplateId = caseOfficerRecordAdjournmentDetailsTemplateId;
+        this.emailAddressFinder = emailAddressFinder;
+        this.featureToggler = featureToggler;
+    }
+
+    @Override
+    public String getTemplateId() {
+        return caseOfficerRecordAdjournmentDetailsTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        return featureToggler.getValue("tcw-notifications-feature", false)
+                ? Collections.singleton(emailAddressFinder.getHearingCentreEmailAddress(asylumCase))
+                : Collections.emptySet();
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_CASE_OFFICER_RECORD_ADJOURNMENT_DETAILS";
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        return
+            ImmutableMap
+                .<String, String>builder()
+                .put("appealReferenceNumber", asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+                .put("appellantGivenNames", asylumCase.read(APPELLANT_GIVEN_NAMES, String.class).orElse(""))
+                .put("appellantFamilyName", asylumCase.read(APPELLANT_FAMILY_NAME, String.class).orElse(""))
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeRecordAdjournmentDetailsPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeRecordAdjournmentDetailsPersonalisation.java
@@ -1,0 +1,47 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.legalrepresentative;
+
+import com.google.common.collect.ImmutableMap;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+@Service
+public class LegalRepresentativeRecordAdjournmentDetailsPersonalisation implements LegalRepresentativeEmailNotificationPersonalisation {
+
+    private final String legalRepresentativeRecordAdjournmentDetailsTemplateId;
+
+    public LegalRepresentativeRecordAdjournmentDetailsPersonalisation(
+        @Value("${govnotify.template.recordAdjournmentDetails.legalRep.email}") String legalRepresentativeRecordAdjournmentDetailsTemplateId
+    ) {
+        this.legalRepresentativeRecordAdjournmentDetailsTemplateId = legalRepresentativeRecordAdjournmentDetailsTemplateId;
+    }
+
+    @Override
+    public String getTemplateId() {
+        return legalRepresentativeRecordAdjournmentDetailsTemplateId;
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_LEGAL_REPRESENTATIVE_RECORD_ADJOURNMENT_DETAILS";
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        return
+            ImmutableMap
+                .<String, String>builder()
+                .put("appealReferenceNumber", asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+                .put("legalRepReferenceNumber", asylumCase.read(LEGAL_REP_REFERENCE_NUMBER, String.class).orElse(""))
+                .put("appellantGivenNames", asylumCase.read(APPELLANT_GIVEN_NAMES, String.class).orElse(""))
+                .put("appellantFamilyName", asylumCase.read(APPELLANT_FAMILY_NAME, String.class).orElse(""))
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/respondent/RespondentRecordAdjournmentDetailsPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/respondent/RespondentRecordAdjournmentDetailsPersonalisation.java
@@ -1,0 +1,65 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent;
+
+import com.google.common.collect.ImmutableMap;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+@Service
+public class RespondentRecordAdjournmentDetailsPersonalisation implements EmailNotificationPersonalisation {
+
+    private final String respondentRecordAdjournmentDetailsTemplateId;
+    private final EmailAddressFinder respondentEmailAddressAfterRespondentReview;
+
+    public RespondentRecordAdjournmentDetailsPersonalisation(
+        @Value("${govnotify.template.recordAdjournmentDetails.respondent.email}") String respondentRecordAdjournmentDetailsTemplateId,
+        EmailAddressFinder respondentEmailAddressAfterRespondentReview
+    ) {
+
+        this.respondentRecordAdjournmentDetailsTemplateId = respondentRecordAdjournmentDetailsTemplateId;
+        this.respondentEmailAddressAfterRespondentReview = respondentEmailAddressAfterRespondentReview;
+    }
+
+    @Override
+    public String getTemplateId() {
+        return respondentRecordAdjournmentDetailsTemplateId;
+    }
+
+    @Override
+    public Set<String> getRecipientsList(AsylumCase asylumCase) {
+        return Collections.singleton(getRespondentEmailAddress(asylumCase));
+    }
+
+    @Override
+    public String getReferenceId(Long caseId) {
+        return caseId + "_RESPONDENT_RECORD_ADJOURNMENT_DETAILS";
+    }
+
+    @Override
+    public Map<String, String> getPersonalisation(AsylumCase asylumCase) {
+        requireNonNull(asylumCase, "asylumCase must not be null");
+
+        return ImmutableMap
+            .<String, String>builder()
+            .put("appealReferenceNumber", asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class).orElse(""))
+            .put("homeOfficeReferenceNumber", asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""))
+            .put("appellantGivenNames", asylumCase.read(APPELLANT_GIVEN_NAMES, String.class).orElse(""))
+            .put("appellantFamilyName", asylumCase.read(APPELLANT_FAMILY_NAME, String.class).orElse(""))
+            .build();
+    }
+
+    private String getRespondentEmailAddress(AsylumCase asylumCase) {
+
+        return respondentEmailAddressAfterRespondentReview.getListCaseHomeOfficeEmailAddress(asylumCase);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminof
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerFtpaDecisionAppellantPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerFtpaDecisionRespondentPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerFtpaSubmittedPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerRecordAdjournmentDetailsPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerReListCasePersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerRemissionDecisionPartiallyApprovedPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer.AdminOfficerRequestFeeRemissionPersonalisation;
@@ -1960,6 +1961,29 @@ public class NotificationGeneratorConfiguration {
                 notificationSender,
                 notificationIdAppender
             )
+        );
+    }
+
+    @Bean("recordAdjournmentDetailsNotificationGenerator")
+    public List<NotificationGenerator> recordAdjournmentDetailsNotificationGenerator(
+            LegalRepresentativeRecordAdjournmentDetailsPersonalisation legalRepresentativeRecordAdjournmentDetailsPersonalisation,
+            RespondentRecordAdjournmentDetailsPersonalisation respondentRecordAdjournmentDetailsPersonalisation,
+            AdminOfficerRecordAdjournmentDetailsPersonalisation adminOfficerRecordAdjournmentDetailsPersonalisation,
+            CaseOfficerRecordAdjournmentDetailsPersonalisation caseOfficerRecordAdjournmentDetailsPersonalisation,
+            GovNotifyNotificationSender notificationSender,
+            NotificationIdAppender notificationIdAppender
+    ) {
+
+        List<EmailNotificationPersonalisation> personalisations = isHomeOfficeGovNotifyEnabled
+                ?  newArrayList(legalRepresentativeRecordAdjournmentDetailsPersonalisation, respondentRecordAdjournmentDetailsPersonalisation, adminOfficerRecordAdjournmentDetailsPersonalisation, caseOfficerRecordAdjournmentDetailsPersonalisation)
+                : newArrayList(legalRepresentativeRecordAdjournmentDetailsPersonalisation, adminOfficerRecordAdjournmentDetailsPersonalisation, caseOfficerRecordAdjournmentDetailsPersonalisation);
+
+        return Collections.singletonList(
+                new EmailNotificationGenerator(
+                        personalisations,
+                        notificationSender,
+                        notificationIdAppender
+                )
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -1878,6 +1878,28 @@ public class NotificationHandlerConfiguration {
     }
 
     @Bean
+    public PreSubmitCallbackHandler<AsylumCase> recordAdjournmentDetailsHandler(
+        @Qualifier("recordAdjournmentDetailsNotificationGenerator")
+            List<NotificationGenerator> notificationGenerator) {
+
+        return new NotificationHandler(
+                (callbackStage, callback) -> {
+                    AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+                    boolean cannotRelistCaseImmediately =
+                            asylumCase.read(RELIST_CASE_IMMEDIATELY, YesOrNo.class)
+                                .map(relistCaseImmediately -> relistCaseImmediately == NO)
+                                .orElse(false);
+
+                    return (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                            && callback.getEvent() == Event.RECORD_ADJOURNMENT_DETAILS
+                            && cannotRelistCaseImmediately);
+                },
+                notificationGenerator
+        );
+    }
+
+    @Bean
     public PreSubmitCallbackHandler<AsylumCase> decisionWithoutHearingHandler(
             @Qualifier("decisionWithoutHearingNotificationGenerator") List<NotificationGenerator> notificationGenerator) {
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -518,6 +518,15 @@ govnotify:
         email: f5e4cbca-4fc8-4e39-bb92-9fe915aa8c61
       adminOfficer:
         email: 5469078a-4ccf-4579-b72b-37900e091455
+    recordAdjournmentDetails:
+      respondent:
+        email: 85442b94-d5ed-4542-b483-94556cc4e3bb
+      caseOfficer:
+        email: ea5abf36-c37b-4d9d-88ff-ef9cda6fd3cf
+      legalRep:
+        email: 153cab2a-0533-424f-bcaf-41b916d06321
+      adminOfficer:
+        email: 6c007d84-488d-498a-9d53-85ba5e008d31
     reListCase:
       adminOfficer:
         email: efec8c6f-38ea-46b6-ad00-9e6870935a4b
@@ -1118,6 +1127,7 @@ security:
       - "decisionWithoutHearing"
       - "createCaseLink"
       - "maintainCaseLinks"
+      - "recordAdjournmentDetails"
     caseworker-ia-admofficer:
       - "listCase"
       - "editCaseListing"
@@ -1149,6 +1159,7 @@ security:
       - "createBailCaseLink"
       - "maintainBailCaseLinks"
       - "decisionWithoutHearing"
+      - "recordAdjournmentDetails"
     caseworker-ia-homeofficeapc:
       - "uploadHomeOfficeBundle"
       - "uploadAdditionalEvidenceHomeOffice"
@@ -1202,6 +1213,7 @@ security:
       - "endAppealAutomatically"
       - "updatePaymentStatus"
       - "listCase"
+      - "recordAdjournmentDetails"
     caseworker-ia-homeofficebail:
       - "submitApplication"
       - "uploadBailSummary"

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/ccd/EventTest.java
@@ -63,6 +63,7 @@ public class EventTest {
         assertEquals("forceCaseToCaseUnderReview", Event.FORCE_CASE_TO_CASE_UNDER_REVIEW.toString());
         assertEquals("forceCaseToSubmitHearingRequirements", Event.FORCE_CASE_TO_SUBMIT_HEARING_REQUIREMENTS.toString());
         assertEquals("adjournHearingWithoutDate", Event.ADJOURN_HEARING_WITHOUT_DATE.toString());
+        assertEquals("recordAdjournmentDetails", Event.RECORD_ADJOURNMENT_DETAILS.toString());
         assertEquals("restoreStateFromAdjourn", Event.RESTORE_STATE_FROM_ADJOURN.toString());
         assertEquals("requestCmaRequirements", Event.REQUEST_CMA_REQUIREMENTS.toString());
         assertEquals("submitCmaRequirements", Event.SUBMIT_CMA_REQUIREMENTS.toString());
@@ -111,6 +112,6 @@ public class EventTest {
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(99, Event.values().length);
+        assertEquals(100, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerRecordAdjournmentDetailsPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/adminofficer/AdminOfficerRecordAdjournmentDetailsPersonalisationTest.java
@@ -1,0 +1,89 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.adminofficer;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class AdminOfficerRecordAdjournmentDetailsPersonalisationTest {
+
+    @Mock
+    AsylumCase asylumCase;
+    @Mock
+    AdminOfficerPersonalisationProvider adminOfficerPersonalisationProvider;
+
+    private String templateId = "someTemplateId";
+
+    private String adminOfficerEmailAddress = "adminOfficer@example.com";
+
+    private AdminOfficerRecordAdjournmentDetailsPersonalisation adminOfficerRecordAdjournmentDetailsPersonalisation;
+
+    @BeforeEach
+    public void setup() {
+        String appealReferenceNumber = "someReferenceNumber";
+        String appellantGivenNames = "someAppellantGivenNames";
+        String appellantFamilyName = "someAppellantFamilyName";
+        when(adminOfficerPersonalisationProvider.getChangeToHearingRequirementsPersonalisation(asylumCase))
+            .thenReturn(ImmutableMap
+                .<String, String>builder()
+                .put("appealReferenceNumber", appealReferenceNumber)
+                .put("appellantGivenNames", appellantGivenNames)
+                .put("appellantFamilyName", appellantFamilyName)
+                .build());
+
+        adminOfficerRecordAdjournmentDetailsPersonalisation =
+            new AdminOfficerRecordAdjournmentDetailsPersonalisation(templateId, adminOfficerEmailAddress,
+                adminOfficerPersonalisationProvider);
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        assertEquals(templateId, adminOfficerRecordAdjournmentDetailsPersonalisation.getTemplateId());
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        Long caseId = 12345L;
+        assertEquals(caseId + "_RECORD_ADJOURNMENT_DETAILS_ADMIN_OFFICER",
+            adminOfficerRecordAdjournmentDetailsPersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address_from_asylum_case() {
+        assertTrue(adminOfficerRecordAdjournmentDetailsPersonalisation.getRecipientsList(asylumCase)
+            .contains(adminOfficerEmailAddress));
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(
+            () -> adminOfficerRecordAdjournmentDetailsPersonalisation.getPersonalisation((AsylumCase) null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given() {
+
+        Map<String, String> personalisation =
+            adminOfficerRecordAdjournmentDetailsPersonalisation.getPersonalisation(asylumCase);
+
+        assertThat(personalisation).isEqualToComparingOnlyGivenFields(asylumCase);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerRecordAdjournmentDetailsPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerRecordAdjournmentDetailsPersonalisationTest.java
@@ -1,0 +1,98 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.caseofficer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.service.FeatureToggler;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class CaseOfficerRecordAdjournmentDetailsPersonalisationTest {
+
+    @Mock
+    AsylumCase asylumCase;
+    @Mock
+    EmailAddressFinder emailAddressFinder;
+    @Mock
+    FeatureToggler featureToggler;
+
+    private Long caseId = 12345L;
+    private String templateId = "someTemplateId";
+
+    private String caseOfficerEmailAddress = "caseOfficer@example.com";
+
+    private String appealReferenceNumber = "someReferenceNumber";
+    private String appellantGivenNames = "someAppellantGivenNames";
+    private String appellantFamilyName = "someAppellantFamilyName";
+
+    private CaseOfficerRecordAdjournmentDetailsPersonalisation caseOfficerRecordAdjournmentDetailsPersonalisation;
+
+    @BeforeEach
+    public void setup() {
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(emailAddressFinder.getHearingCentreEmailAddress(asylumCase)).thenReturn(caseOfficerEmailAddress);
+
+        caseOfficerRecordAdjournmentDetailsPersonalisation =
+            new CaseOfficerRecordAdjournmentDetailsPersonalisation(templateId, emailAddressFinder, featureToggler);
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        assertEquals(templateId, caseOfficerRecordAdjournmentDetailsPersonalisation.getTemplateId());
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        assertEquals(caseId + "_CASE_OFFICER_RECORD_ADJOURNMENT_DETAILS",
+            caseOfficerRecordAdjournmentDetailsPersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address_from_asylum_case_when_feature_flag_is_On() {
+        when(featureToggler.getValue("tcw-notifications-feature", false)).thenReturn(true);
+        assertTrue(caseOfficerRecordAdjournmentDetailsPersonalisation.getRecipientsList(asylumCase)
+            .contains(caseOfficerEmailAddress));
+    }
+
+    @Test
+    public void should_return_given_email_address_from_asylum_case_when_feature_flag_is_Off() {
+        assertTrue(caseOfficerRecordAdjournmentDetailsPersonalisation.getRecipientsList(asylumCase)
+                .isEmpty());
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(
+            () -> caseOfficerRecordAdjournmentDetailsPersonalisation.getPersonalisation((AsylumCase) null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given() {
+
+        Map<String, String> personalisation =
+            caseOfficerRecordAdjournmentDetailsPersonalisation.getPersonalisation(asylumCase);
+
+        assertThat(personalisation).isEqualToComparingOnlyGivenFields(asylumCase);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeRecordAdjournmentDetailsPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/legalrepresentative/LegalRepresentativeRecordAdjournmentDetailsPersonalisationTest.java
@@ -1,0 +1,99 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.legalrepresentative;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class LegalRepresentativeRecordAdjournmentDetailsPersonalisationTest {
+
+    @Mock
+    AsylumCase asylumCase;
+
+    private Long caseId = 12345L;
+    private String templateId = "someTemplateId";
+
+    private String legalRepEmailAddress = "legalrep@example.com";
+
+    private String appealReferenceNumber = "someReferenceNumber";
+    private String legalRepRefNumber = "somelegalRepRefNumber";
+    private String appellantGivenNames = "someAppellantGivenNames";
+    private String appellantFamilyName = "someAppellantFamilyName";
+
+    private LegalRepresentativeRecordAdjournmentDetailsPersonalisation
+        legalRepresentativeRecordAdjournmentDetailsPersonalisation;
+
+    @BeforeEach
+    public void setup() {
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(asylumCase.read(LEGAL_REP_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(legalRepRefNumber));
+        when(asylumCase.read(LEGAL_REPRESENTATIVE_EMAIL_ADDRESS, String.class))
+            .thenReturn(Optional.of(legalRepEmailAddress));
+
+        legalRepresentativeRecordAdjournmentDetailsPersonalisation =
+            new LegalRepresentativeRecordAdjournmentDetailsPersonalisation(templateId);
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        assertEquals(templateId, legalRepresentativeRecordAdjournmentDetailsPersonalisation.getTemplateId());
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        assertEquals(caseId + "_LEGAL_REPRESENTATIVE_RECORD_ADJOURNMENT_DETAILS",
+            legalRepresentativeRecordAdjournmentDetailsPersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address_from_asylum_case() {
+        assertTrue(legalRepresentativeRecordAdjournmentDetailsPersonalisation.getRecipientsList(asylumCase)
+            .contains(legalRepEmailAddress));
+    }
+
+    @Test
+    public void should_throw_exception_when_cannot_find_email_address_for_legal_rep() {
+        when(asylumCase.read(LEGAL_REPRESENTATIVE_EMAIL_ADDRESS, String.class)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(
+            () -> legalRepresentativeRecordAdjournmentDetailsPersonalisation.getRecipientsList(asylumCase))
+            .isExactlyInstanceOf(IllegalStateException.class)
+            .hasMessage("legalRepresentativeEmailAddress is not present");
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(
+            () -> legalRepresentativeRecordAdjournmentDetailsPersonalisation.getPersonalisation((AsylumCase) null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given() {
+
+        Map<String, String> personalisation =
+            legalRepresentativeRecordAdjournmentDetailsPersonalisation.getPersonalisation(asylumCase);
+
+        assertThat(personalisation).isEqualToComparingOnlyGivenFields(asylumCase);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/respondent/RespondentRecordAdjournmentDetailsPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/respondent/RespondentRecordAdjournmentDetailsPersonalisationTest.java
@@ -1,0 +1,93 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.respondent;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class RespondentRecordAdjournmentDetailsPersonalisationTest {
+
+    @Mock
+    AsylumCase asylumCase;
+    @Mock
+    EmailAddressFinder emailAddressFinder;
+
+    private Long caseId = 12345L;
+    private String templateId = "someTemplateId";
+    private String respondentReviewEmailAddress = "respondentReview@example.com";
+    private String appealReferenceNumber = "someReferenceNumber";
+    private String homeOfficeRefNumber = "someHomeOfficeRefNumber";
+    private String appellantGivenNames = "someAppellantGivenNames";
+    private String appellantFamilyName = "someAppellantFamilyName";
+
+    private RespondentRecordAdjournmentDetailsPersonalisation respondentRecordAdjournmentDetailsPersonalisation;
+
+    @BeforeEach
+    public void setup() {
+
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeRefNumber));
+        when(emailAddressFinder.getListCaseHomeOfficeEmailAddress(asylumCase)).thenReturn(respondentReviewEmailAddress);
+
+        respondentRecordAdjournmentDetailsPersonalisation = new RespondentRecordAdjournmentDetailsPersonalisation(
+            templateId,
+            emailAddressFinder
+        );
+    }
+
+    @Test
+    public void should_return_given_template_id() {
+        assertEquals(templateId, respondentRecordAdjournmentDetailsPersonalisation.getTemplateId());
+    }
+
+    @Test
+    public void should_return_given_reference_id() {
+        assertEquals(caseId + "_RESPONDENT_RECORD_ADJOURNMENT_DETAILS",
+            respondentRecordAdjournmentDetailsPersonalisation.getReferenceId(caseId));
+    }
+
+    @Test
+    public void should_return_given_email_address_from_asylum_case() {
+        assertTrue(respondentRecordAdjournmentDetailsPersonalisation.getRecipientsList(asylumCase)
+            .contains(respondentReviewEmailAddress));
+    }
+
+    @Test
+    public void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(
+            () -> respondentRecordAdjournmentDetailsPersonalisation.getPersonalisation((AsylumCase) null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("asylumCase must not be null");
+    }
+
+    @Test
+    public void should_return_personalisation_when_all_information_given() {
+
+        Map<String, String> personalisation =
+            respondentRecordAdjournmentDetailsPersonalisation.getPersonalisation(asylumCase);
+
+        assertEquals(appealReferenceNumber, personalisation.get("appealReferenceNumber"));
+        assertEquals(appellantGivenNames, personalisation.get("appellantGivenNames"));
+        assertEquals(appellantFamilyName, personalisation.get("appellantFamilyName"));
+        assertEquals(homeOfficeRefNumber, personalisation.get("homeOfficeReferenceNumber"));
+    }
+}


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/RIA-7791


### Change description ###
- Added new email template for for CO, LR, AO and appellant when trigger recordAdjournmentDetails event
- Added the RecordAdjournmentDetailsPersonalisation for CO, LR, AO and appellant when trigger recordAdjournmentDetails event  with the condition "hearing could not be relisted right away"
- Added unit test and functional test for the notification of recordAdjournmentDetails event
- Updated the suppression list of CVE
- Updated the version of java helm chart to 5.0.0 from 4.0.13 because of pipeline failure


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
