### PR TITLE
RIA-7795 respond_to_costs_respondent

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7795-RIA-7796_ho_respond_to_costs_notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-7795-RIA-7796_ho_respond_to_costs_notification.json
@@ -1,8 +1,8 @@
 {
-  "description": "RIA-7796: Legal rep responds to costs and notifies home office",
+  "description": "RIA-7795-RIA-7796: Home office lart responds to costs and notifies legal rep and receives notification as well",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
-    "credentials": "LegalRepresentative",
+    "credentials": "HomeOfficeGeneric",
     "input": {
       "id": 7796,
       "eventId": "respondToCosts",
@@ -10,10 +10,10 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "legalRepReferenceNumber": "A1234567",
+          "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
           "journeyType": "rep",
           "appealType": "revocationOfProtection",
-          "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
-          "legalRepReferenceNumber": "A1234567",
           "appealGroundsRevocation": {
             "values": [
               "revocationRefugeeConvention",
@@ -25,11 +25,11 @@
               "id": "1",
               "value": {
                 "appliedCostsType": "Unreasonable costs",
-                "respondentToCostsOrder": "Legal representative",
+                "respondentToCostsOrder": "Home office",
                 "applyForCostsHearingType": "No",
                 "scheduleOfCostsDocuments": [],
                 "applyForCostsCreationDate": "{$TODAY}",
-                "applyForCostsApplicantType": "Home office",
+                "applyForCostsApplicantType": "Legal representative",
                 "argumentsAndEvidenceDetails": "",
                 "argumentsAndEvidenceDocuments": [
                   {
@@ -45,7 +45,7 @@
               }
             }
           ],
-          "legalRepName": "Fake Org Ltd"
+        "legalRepName": "Fake Org Ltd"
         }
       }
     }
@@ -56,20 +56,33 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
-        "appealType": "revocationOfProtection",
         "legalRepReferenceNumber": "A1234567",
+        "appealType": "revocationOfProtection",
         "appealGroundsRevocation": {
           "values": [
             "revocationRefugeeConvention",
             "revocationHumanitarianProtection"
           ]
         },
-        "legalRepName": "Fake Org Ltd"
+      "legalRepName": "Fake Org Ltd"
       }
     },
     "notifications": [
       {
         "reference": "7796_RESPOND_TO_COSTS_APPLICANT_EMAIL",
+        "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
+        "subject": "Immigration and Asylum appeal: Costs application response received",
+        "body": [
+          "HMCTS reference: PA/12345/2019",
+          "Your reference: A1234567",
+          "Appellant name: Talha Awan",
+          "The online service: {$iaExUiFrontendUrl}",
+          "Application name: Cost application 1",
+          "Application type: Unreasonable Cost application"
+        ]
+      },
+      {
+        "reference": "7796_RESPOND_TO_COSTS_RESPONDENT_EMAIL",
         "recipient": "{$applyForCostsHomeOfficeEmailAddress}",
         "subject": "Immigration and Asylum appeal: Costs application response received",
         "body": [

--- a/src/functionalTest/resources/scenarios/RIA-7795-RIA-7796_legalrep_respond_to_costs_notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-7795-RIA-7796_legalrep_respond_to_costs_notification.json
@@ -1,8 +1,8 @@
 {
-  "description": "RIA-7796: Home office lart responds to costs and notifies legal rep(applier)",
+  "description": "RIA-7795-RIA-7796: Legal rep responds to costs and notifies home office and receives notification as well",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
-    "credentials": "HomeOfficeGeneric",
+    "credentials": "LegalRepresentative",
     "input": {
       "id": 7796,
       "eventId": "respondToCosts",
@@ -10,10 +10,10 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "legalRepReferenceNumber": "A1234567",
-          "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
           "journeyType": "rep",
           "appealType": "revocationOfProtection",
+          "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
+          "legalRepReferenceNumber": "A1234567",
           "appealGroundsRevocation": {
             "values": [
               "revocationRefugeeConvention",
@@ -25,11 +25,11 @@
               "id": "1",
               "value": {
                 "appliedCostsType": "Unreasonable costs",
-                "respondentToCostsOrder": "Home office",
+                "respondentToCostsOrder": "Legal representative",
                 "applyForCostsHearingType": "No",
                 "scheduleOfCostsDocuments": [],
                 "applyForCostsCreationDate": "{$TODAY}",
-                "applyForCostsApplicantType": "Legal representative",
+                "applyForCostsApplicantType": "Home office",
                 "argumentsAndEvidenceDetails": "",
                 "argumentsAndEvidenceDocuments": [
                   {
@@ -45,7 +45,7 @@
               }
             }
           ],
-        "legalRepName": "Fake Org Ltd"
+          "legalRepName": "Fake Org Ltd"
         }
       }
     }
@@ -56,20 +56,33 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
-        "legalRepReferenceNumber": "A1234567",
         "appealType": "revocationOfProtection",
+        "legalRepReferenceNumber": "A1234567",
         "appealGroundsRevocation": {
           "values": [
             "revocationRefugeeConvention",
             "revocationHumanitarianProtection"
           ]
         },
-      "legalRepName": "Fake Org Ltd"
+        "legalRepName": "Fake Org Ltd"
       }
     },
     "notifications": [
       {
         "reference": "7796_RESPOND_TO_COSTS_APPLICANT_EMAIL",
+        "recipient": "{$applyForCostsHomeOfficeEmailAddress}",
+        "subject": "Immigration and Asylum appeal: Costs application response received",
+        "body": [
+          "HMCTS reference: PA/12345/2019",
+          "Home office reference: A1234567",
+          "Appellant name: Talha Awan",
+          "The online service: {$iaExUiFrontendUrl}",
+          "Application name: Cost application 1",
+          "Application type: Unreasonable Cost application"
+        ]
+      },
+      {
+        "reference": "7796_RESPOND_TO_COSTS_RESPONDENT_EMAIL",
         "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
         "subject": "Immigration and Asylum appeal: Costs application response received",
         "body": [

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/applyforcosts/RespondToCostsRespondentPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/applyforcosts/RespondToCostsRespondentPersonalisation.java
@@ -16,21 +16,21 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFin
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PersonalisationProvider;
 
 @Service
-public class RespondToCostsApplicantPersonalisation implements EmailNotificationPersonalisation {
-    private final String respondToCostsNotificationForApplicantTemplateId;
+public class RespondToCostsRespondentPersonalisation implements EmailNotificationPersonalisation {
+    private final String respondToCostsNotificationForRespondentTemplateId;
     private final String homeOfficeEmailAddress;
     private final EmailAddressFinder emailAddressFinder;
     private final PersonalisationProvider personalisationProvider;
     private final CustomerServicesProvider customerServicesProvider;
 
-    public RespondToCostsApplicantPersonalisation(
-        @Value("${govnotify.template.respondToCostsNotification.applicant.email}") String respondToCostsNotificationForApplicantTemplateId,
+    public RespondToCostsRespondentPersonalisation(
+        @Value("${govnotify.template.respondToCostsNotification.respondent.email}") String respondToCostsNotificationForRespondentTemplateId,
         @Value("${applyForCostsHomeOfficeEmailAddress}") String homeOfficeEmailAddress,
         EmailAddressFinder emailAddressFinder,
         CustomerServicesProvider customerServicesProvider,
         PersonalisationProvider personalisationProvider
     ) {
-        this.respondToCostsNotificationForApplicantTemplateId = respondToCostsNotificationForApplicantTemplateId;
+        this.respondToCostsNotificationForRespondentTemplateId = respondToCostsNotificationForRespondentTemplateId;
         this.homeOfficeEmailAddress = homeOfficeEmailAddress;
         this.emailAddressFinder = emailAddressFinder;
         this.customerServicesProvider = customerServicesProvider;
@@ -39,21 +39,21 @@ public class RespondToCostsApplicantPersonalisation implements EmailNotification
 
     @Override
     public String getTemplateId(AsylumCase asylumCase) {
-        return respondToCostsNotificationForApplicantTemplateId;
+        return respondToCostsNotificationForRespondentTemplateId;
     }
 
     @Override
     public Set<String> getRecipientsList(AsylumCase asylumCase) {
         if (isHomeOfficeApplicant(asylumCase)) {
-            return Collections.singleton(homeOfficeEmailAddress);
-        } else {
             return Collections.singleton(emailAddressFinder.getLegalRepEmailAddress(asylumCase));
+        } else {
+            return Collections.singleton(homeOfficeEmailAddress);
         }
     }
 
     @Override
     public String getReferenceId(Long caseId) {
-        return caseId + "_RESPOND_TO_COSTS_APPLICANT_EMAIL";
+        return caseId + "_RESPOND_TO_COSTS_RESPONDENT_EMAIL";
     }
 
     @Override
@@ -66,9 +66,9 @@ public class RespondToCostsApplicantPersonalisation implements EmailNotification
             .putAll(customerServicesProvider.getCustomerServicesPersonalisation());
 
         if (isHomeOfficeApplicant(asylumCase)) {
-            personalisationBuilder.putAll(personalisationProvider.getHomeOfficeRecipientHeader(asylumCase));
-        } else {
             personalisationBuilder.putAll(personalisationProvider.getLegalRepRecipientHeader(asylumCase));
+        } else {
+            personalisationBuilder.putAll(personalisationProvider.getHomeOfficeRecipientHeader(asylumCase));
         }
 
         return personalisationBuilder.build();

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.appella
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.applyforcosts.ApplyForCostsApplicantPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.applyforcosts.ApplyForCostsRespondentPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.applyforcosts.RespondToCostsApplicantPersonalisation;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.applyforcosts.RespondToCostsRespondentPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.caseofficer.*;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.caseofficer.editdocument.CaseOfficerEditDocumentsPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.detentionengagementteam.*;
@@ -4639,11 +4640,12 @@ public class NotificationGeneratorConfiguration {
     @Bean("respondToCostsNotificationGenerator")
     public List<NotificationGenerator> respondToCostsNotificationGenerator(
         RespondToCostsApplicantPersonalisation respondToCostsApplicantPersonalisation,
+        RespondToCostsRespondentPersonalisation respondToCostsRespondentPersonalisation,
         GovNotifyNotificationSender notificationSender,
         NotificationIdAppender notificationIdAppender) {
 
         return Collections.singletonList(new EmailNotificationGenerator(
-            newArrayList(respondToCostsApplicantPersonalisation),
+            newArrayList(respondToCostsApplicantPersonalisation, respondToCostsRespondentPersonalisation),
             notificationSender,
             notificationIdAppender)
         );

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1132,6 +1132,8 @@ govnotify:
     respondToCostsNotification:
       applicant:
         email: bcf74bf3-e042-45dd-a4de-262dc81f0697
+      respondent:
+        email: 4cc2a1cc-b89d-46f2-8f79-dcd663ef14a0
     turnOnNotifications:
       homeOffice:
         beforeListing:

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/applyforcosts/RespondToCostsRespondentPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/applyforcosts/RespondToCostsRespondentPersonalisationTest.java
@@ -1,0 +1,160 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.applyforcosts;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.APPLIES_FOR_COSTS;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ApplyForCosts;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.CustomerServicesProvider;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PersonalisationProvider;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class RespondToCostsRespondentPersonalisationTest {
+    @Mock
+    AsylumCase asylumCase;
+    @Mock
+    EmailAddressFinder emailAddressFinder;
+    @Mock
+    CustomerServicesProvider customerServicesProvider;
+    @Mock
+    PersonalisationProvider personalisationProvider;
+
+    private Long caseId = 12345L;
+    private String templateId = "templateId";
+    private String homeOfficeEmailAddress = "homeOfficeEmailAddress@gmail.com";
+    private String legalRepEmailAddress = "legalRepEmailAddress@gmail.com";
+    private String iaExUiFrontendUrl = "http://localhost";
+    private String appealReferenceNumber = "someReferenceNumber";
+    private String legalRepRefNumber = "someLegalRepRefNumber";
+    private String appellantGivenNames = "someAppellantGivenNames";
+    private String appellantFamilyName = "someAppellantFamilyName";
+    private static String homeOffice = "Home office";
+    private String customerServicesTelephone = "555 555 555";
+    private String customerServicesEmail = "cust.services@example.com";
+    private static String newestApplicationCreatedNumber = "1";
+    private static String unreasonableCostsType = "Unreasonable costs";
+    private String homeOfficeReferenceNumber = "A1234567/001";
+    private RespondToCostsRespondentPersonalisation respondToCostsRespondentPersonalisation;
+
+    @BeforeEach
+    void setup() {
+        respondToCostsRespondentPersonalisation = new RespondToCostsRespondentPersonalisation(
+            templateId,
+            homeOfficeEmailAddress,
+            emailAddressFinder,
+            customerServicesProvider,
+            personalisationProvider
+        );
+
+        Map<String, String> respondToCostsRespondentPersonalisationTemplate = new HashMap<>();
+
+        respondToCostsRespondentPersonalisationTemplate.put("appellantGivenNames", appellantGivenNames);
+        respondToCostsRespondentPersonalisationTemplate.put("appellantFamilyName", appellantFamilyName);
+        respondToCostsRespondentPersonalisationTemplate.put("appealReferenceNumber", appealReferenceNumber);
+        respondToCostsRespondentPersonalisationTemplate.put("linkToOnlineService", iaExUiFrontendUrl);
+        respondToCostsRespondentPersonalisationTemplate.put("applicationId", newestApplicationCreatedNumber);
+        respondToCostsRespondentPersonalisationTemplate.put("appliedCostsType", "Wasted");
+
+        when((customerServicesProvider.getCustomerServicesTelephone())).thenReturn(customerServicesTelephone);
+        when((customerServicesProvider.getCustomerServicesEmail())).thenReturn(customerServicesEmail);
+        when(personalisationProvider.getApplyForCostsPesonalisation(asylumCase)).thenReturn(respondToCostsRespondentPersonalisationTemplate);
+        when(emailAddressFinder.getLegalRepEmailAddress(asylumCase)).thenReturn(legalRepEmailAddress);
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
+        when(asylumCase.read(LEGAL_REP_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(legalRepRefNumber));
+
+        Map<String, String> homeOfficeRecipientHeader = new HashMap<>();
+        homeOfficeRecipientHeader.put("recipient", homeOffice);
+        homeOfficeRecipientHeader.put("recipientReferenceNumber", homeOfficeReferenceNumber);
+
+        Map<String, String> legalRepRecipientHeader = new HashMap<>();
+        legalRepRecipientHeader.put("recipient", "Your");
+        legalRepRecipientHeader.put("recipientReferenceNumber", legalRepRefNumber);
+
+        when(personalisationProvider.getHomeOfficeRecipientHeader(asylumCase)).thenReturn(homeOfficeRecipientHeader);
+        when(personalisationProvider.getLegalRepRecipientHeader(asylumCase)).thenReturn(legalRepRecipientHeader);
+    }
+
+    @Test
+    void should_return_given_template_id() {
+        assertEquals(templateId, respondToCostsRespondentPersonalisation.getTemplateId(asylumCase));
+    }
+
+    @Test
+    void should_return_given_reference_id() {
+        assertEquals(caseId + "_RESPOND_TO_COSTS_RESPONDENT_EMAIL",
+            respondToCostsRespondentPersonalisation.getReferenceId(caseId));
+    }
+
+    @ParameterizedTest
+    @MethodSource("appliesForCostsProvider")
+    void should_return_given_email_address(List<IdValue<ApplyForCosts>> applyForCostsList) {
+        when(asylumCase.read(APPLIES_FOR_COSTS)).thenReturn(Optional.of(applyForCostsList));
+
+        if (applyForCostsList.get(0).getValue().getApplyForCostsApplicantType().equals(homeOffice)) {
+            assertTrue(respondToCostsRespondentPersonalisation.getRecipientsList(asylumCase).contains(legalRepEmailAddress));
+        } else {
+            assertTrue(respondToCostsRespondentPersonalisation.getRecipientsList(asylumCase).contains(homeOfficeEmailAddress));
+        }
+    }
+
+    @Test
+    void should_throw_exception_on_personalisation_when_case_is_null() {
+
+        assertThatThrownBy(() -> respondToCostsRespondentPersonalisation.getPersonalisation((AsylumCase) null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("asylumCase must not be null");
+    }
+
+    @ParameterizedTest
+    @MethodSource("appliesForCostsProvider")
+    void should_return_personalisation_when_all_information_given(List<IdValue<ApplyForCosts>> applyForCostsList) {
+        when(asylumCase.read(APPLIES_FOR_COSTS)).thenReturn(Optional.of(applyForCostsList));
+
+        Map<String, String> personalisation = respondToCostsRespondentPersonalisation.getPersonalisation(asylumCase);
+
+        assertEquals(appealReferenceNumber, personalisation.get("appealReferenceNumber"));
+        assertEquals(appellantGivenNames, personalisation.get("appellantGivenNames"));
+        assertEquals(appellantFamilyName, personalisation.get("appellantFamilyName"));
+        assertEquals(iaExUiFrontendUrl, personalisation.get("linkToOnlineService"));
+        assertEquals(customerServicesTelephone, customerServicesProvider.getCustomerServicesTelephone());
+        assertEquals(customerServicesEmail, customerServicesProvider.getCustomerServicesEmail());
+        assertEquals("1", personalisation.get("applicationId"));
+        assertEquals("Wasted", personalisation.get("appliedCostsType"));
+
+        if (applyForCostsList.get(0).getValue().getApplyForCostsApplicantType().equals("Home office")) {
+            assertEquals("Your", personalisation.get("recipient"));
+            assertEquals(legalRepRefNumber, personalisation.get("recipientReferenceNumber"));
+        } else {
+            assertEquals("Home office", personalisation.get("recipient"));
+            assertEquals(homeOfficeReferenceNumber, personalisation.get("recipientReferenceNumber"));
+        }
+    }
+
+    static Stream<Arguments> appliesForCostsProvider() {
+        return Stream.of(
+            Arguments.of(List.of(new IdValue<>(newestApplicationCreatedNumber, new ApplyForCosts(unreasonableCostsType, "Legal representative", homeOffice)))),
+            Arguments.of(List.of(new IdValue<>(newestApplicationCreatedNumber, new ApplyForCosts("Wasted costs", homeOffice, "Legal representative"))))
+        );
+    }
+}


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/RIA-7795


### Change description ###
Added Notification personalisation for respondent, when 'Respond to costs' event is triggered. Edited 7796 Ft tests. Added Junit tests. Fixed RespondToCostsApplicantPersonalisation.class typo in fields.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
