### PR TITLE
RIA-8192 No notifications for Admin in AdjournHearingWithoutDate and RecordAdjournmentDetails if isIntegrated

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-2959-adjourn-hearing-without-date.json
+++ b/src/functionalTest/resources/scenarios/RIA-2959-adjourn-hearing-without-date.json
@@ -1,5 +1,5 @@
 {
-  "description": "RIA-2959 Adjourn hearing without date",
+  "description": "RIA-2959 Adjourn hearing without date (List Assist non-integrated: Notifications including Admin)",
   "launchDarklyKey": "tcw-notifications-feature:true",
   "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
   "request": {

--- a/src/functionalTest/resources/scenarios/RIA-7991-record-adjournment-details.json
+++ b/src/functionalTest/resources/scenarios/RIA-7991-record-adjournment-details.json
@@ -1,5 +1,5 @@
 {
-  "description": "RIA-7991 Record adjournment details",
+  "description": "RIA-7991 Record adjournment details (List Assist non-integrated: Notification including Admin)",
   "launchDarklyKey": "tcw-notifications-feature:true",
   "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
   "request": {

--- a/src/functionalTest/resources/scenarios/RIA-8192-adjourn-hearing-without-date-list-assist-integrated.json
+++ b/src/functionalTest/resources/scenarios/RIA-8192-adjourn-hearing-without-date-list-assist-integrated.json
@@ -1,12 +1,12 @@
 {
-  "description": "RIA-3631 Adjourn hearing without date - (Home Office notification disabled) (List Assist non-integrated: Notifications including Admin)",
+  "description": "RIA-8192 Adjourn hearing without date (List Assist integrated: no Admin notification)",
   "launchDarklyKey": "tcw-notifications-feature:true",
-  "disabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "CaseOfficer",
     "input": {
-      "id": 3631678,
+      "id": 81921,
       "eventId": "adjournHearingWithoutDate",
       "state": "preHearing",
       "caseData": {
@@ -14,7 +14,7 @@
         "replacements": {
           "adjournHearingWithoutDateReasons": "some reason",
           "listCaseHearingCentre": "taylorHouse",
-          "ariaListingReference": "LP/12345/2019"
+          "isIntegrated": "Yes"
         }
       }
     }
@@ -28,15 +28,15 @@
         "listCaseHearingCentre": "taylorHouse",
         "notificationsSent": [
           {
-            "id": "3631678_LEGAL_REPRESENTATIVE_ADJOURN_HEARING_WITHOUT_DATE",
+            "id": "2959123_LEGAL_REPRESENTATIVE_ADJOURN_HEARING_WITHOUT_DATE",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {
-            "id": "3631678_CASE_OFFICER_ADJOURN_HEARING_WITHOUT_DATE",
+            "id": "2959123_RESPONDENT_ADJOURN_HEARING_WITHOUT_DATE",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {
-            "id": "3631678_ADJOURN_HEARING_WITHOUT_DATE_ADMIN_OFFICER",
+            "id": "2959123_CASE_OFFICER_ADJOURN_HEARING_WITHOUT_DATE",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
         ]
@@ -44,7 +44,7 @@
     },
     "notifications": [
       {
-        "reference": "1001_LEGAL_REPRESENTATIVE_ADJOURN_HEARING_WITHOUT_DATE",
+        "reference": "2959123_LEGAL_REPRESENTATIVE_ADJOURN_HEARING_WITHOUT_DATE",
         "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
         "subject": "Immigration and Asylum appeal: Hearing adjourned",
         "body": [
@@ -56,18 +56,19 @@
         ]
       },
       {
-        "reference": "3631678_CASE_OFFICER_ADJOURN_HEARING_WITHOUT_DATE",
-        "recipient": "{$hearingCentreEmailAddresses.taylorHouse}",
+        "reference": "2959123_RESPONDENT_ADJOURN_HEARING_WITHOUT_DATE",
+        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
         "subject": "Immigration and Asylum appeal: Hearing adjourned",
         "body": [
           "PA/12345/2019",
           "LP/12345/2019",
+          "A1234567",
           "Talha Awan"
         ]
       },
       {
-        "reference": "3631678_ADJOURN_HEARING_WITHOUT_DATE_ADMIN_OFFICER",
-        "recipient": "{$reviewHearingRequirementsAdminOfficerEmailAddress}",
+        "reference": "2959123_CASE_OFFICER_ADJOURN_HEARING_WITHOUT_DATE",
+        "recipient": "{$hearingCentreEmailAddresses.taylorHouse}",
         "subject": "Immigration and Asylum appeal: Hearing adjourned",
         "body": [
           "PA/12345/2019",

--- a/src/functionalTest/resources/scenarios/RIA-8192-record-adjournment-details-list-assist-integrated.json
+++ b/src/functionalTest/resources/scenarios/RIA-8192-record-adjournment-details-list-assist-integrated.json
@@ -1,20 +1,20 @@
 {
-  "description": "RIA-3631 Adjourn hearing without date - (Home Office notification disabled) (List Assist non-integrated: Notifications including Admin)",
+  "description": "RIA-8192 Record adjournment details (List Assist integrated: Notification excluding Admin)",
   "launchDarklyKey": "tcw-notifications-feature:true",
-  "disabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
+  "enabled": "{$featureFlag.homeOfficeGovNotifyEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "CaseOfficer",
     "input": {
-      "id": 3631678,
-      "eventId": "adjournHearingWithoutDate",
-      "state": "preHearing",
+      "id": 34536,
+      "eventId": "recordAdjournmentDetails",
+      "state": "prepareForHearing",
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "adjournHearingWithoutDateReasons": "some reason",
           "listCaseHearingCentre": "taylorHouse",
-          "ariaListingReference": "LP/12345/2019"
+          "relistCaseImmediately": "No",
+          "isIntegrated": "Yes"
         }
       }
     }
@@ -28,15 +28,15 @@
         "listCaseHearingCentre": "taylorHouse",
         "notificationsSent": [
           {
-            "id": "3631678_LEGAL_REPRESENTATIVE_ADJOURN_HEARING_WITHOUT_DATE",
+            "id": "34536_LEGAL_REPRESENTATIVE_RECORD_ADJOURNMENT_DETAILS",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {
-            "id": "3631678_CASE_OFFICER_ADJOURN_HEARING_WITHOUT_DATE",
+            "id": "34536_RESPONDENT_RECORD_ADJOURNMENT_DETAILS",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {
-            "id": "3631678_ADJOURN_HEARING_WITHOUT_DATE_ADMIN_OFFICER",
+            "id": "34536_CASE_OFFICER_RECORD_ADJOURNMENT_DETAILS",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
         ]
@@ -44,34 +44,31 @@
     },
     "notifications": [
       {
-        "reference": "1001_LEGAL_REPRESENTATIVE_ADJOURN_HEARING_WITHOUT_DATE",
+        "reference": "34536_LEGAL_REPRESENTATIVE_RECORD_ADJOURNMENT_DETAILS",
         "recipient": "{$TEST_LAW_FIRM_A_USERNAME}",
         "subject": "Immigration and Asylum appeal: Hearing adjourned",
         "body": [
           "PA/12345/2019",
-          "LP/12345/2019",
           "CASE001",
-          "Talha Awan",
-          "some reason"
-        ]
-      },
-      {
-        "reference": "3631678_CASE_OFFICER_ADJOURN_HEARING_WITHOUT_DATE",
-        "recipient": "{$hearingCentreEmailAddresses.taylorHouse}",
-        "subject": "Immigration and Asylum appeal: Hearing adjourned",
-        "body": [
-          "PA/12345/2019",
-          "LP/12345/2019",
           "Talha Awan"
         ]
       },
       {
-        "reference": "3631678_ADJOURN_HEARING_WITHOUT_DATE_ADMIN_OFFICER",
-        "recipient": "{$reviewHearingRequirementsAdminOfficerEmailAddress}",
+        "reference": "34536_RESPONDENT_RECORD_ADJOURNMENT_DETAILS",
+        "recipient": "{$homeOfficeEmailAddresses.taylorHouse}",
         "subject": "Immigration and Asylum appeal: Hearing adjourned",
         "body": [
           "PA/12345/2019",
-          "LP/12345/2019",
+          "A1234567",
+          "Talha Awan"
+        ]
+      },
+      {
+        "reference": "34536_CASE_OFFICER_RECORD_ADJOURNMENT_DETAILS",
+        "recipient": "{$hearingCentreEmailAddresses.taylorHouse}",
+        "subject": "Immigration and Asylum appeal: Hearing adjourned",
+        "body": [
+          "PA/12345/2019",
           "Talha Awan"
         ]
       }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -1972,8 +1972,8 @@ public class NotificationGeneratorConfiguration {
         );
     }
 
-    @Bean("adjournHearingWithoutDateNotificationGenerator")
-    public List<NotificationGenerator> adjournHearingWithoutDateNotificationGenerator(
+    @Bean("adjournHearingWithoutDateNonIntegratedNotificationGenerator")
+    public List<NotificationGenerator> adjournHearingWithoutDateNotificationNonIntegratedGenerator(
         LegalRepresentativeAdjournHearingWithoutDatePersonalisation legalRepresentativeAdjournHearingWithoutDatePersonalisation,
         RespondentAdjournHearingWithoutDatePersonalisation respondentAdjournHearingWithoutDatePersonalisation,
         AdminOfficerAdjournHearingWithoutDatePersonalisation adminOfficerAdjournHearingWithoutDatePersonalisation,
@@ -1996,8 +1996,30 @@ public class NotificationGeneratorConfiguration {
         );
     }
 
-    @Bean("recordAdjournmentDetailsNotificationGenerator")
-    public List<NotificationGenerator> recordAdjournmentDetailsNotificationGenerator(
+    @Bean("adjournHearingWithoutDateIntegratedNotificationGenerator")
+    public List<NotificationGenerator> adjournHearingWithoutDateNotificationIntegratedGenerator(
+        LegalRepresentativeAdjournHearingWithoutDatePersonalisation legalRepresentativeAdjournHearingWithoutDatePersonalisation,
+        RespondentAdjournHearingWithoutDatePersonalisation respondentAdjournHearingWithoutDatePersonalisation,
+        CaseOfficerAdjournHearingWithoutDatePersonalisation caseOfficerAdjournHearingWithoutDatePersonalisation,
+        GovNotifyNotificationSender notificationSender,
+        NotificationIdAppender notificationIdAppender
+    ) {
+
+        List<EmailNotificationPersonalisation> personalisations = isHomeOfficeGovNotifyEnabled
+            ?  newArrayList(legalRepresentativeAdjournHearingWithoutDatePersonalisation, respondentAdjournHearingWithoutDatePersonalisation, caseOfficerAdjournHearingWithoutDatePersonalisation)
+            : newArrayList(legalRepresentativeAdjournHearingWithoutDatePersonalisation, caseOfficerAdjournHearingWithoutDatePersonalisation);
+
+        return Collections.singletonList(
+            new EmailNotificationGenerator(
+                personalisations,
+                notificationSender,
+                notificationIdAppender
+            )
+        );
+    }
+
+    @Bean("recordAdjournmentDetailsNonIntegratedNotificationGenerator")
+    public List<NotificationGenerator> recordAdjournmentDetailsNonIntegratedNotificationGenerator(
             LegalRepresentativeRecordAdjournmentDetailsPersonalisation legalRepresentativeRecordAdjournmentDetailsPersonalisation,
             RespondentRecordAdjournmentDetailsPersonalisation respondentRecordAdjournmentDetailsPersonalisation,
             AdminOfficerRecordAdjournmentDetailsPersonalisation adminOfficerRecordAdjournmentDetailsPersonalisation,
@@ -2016,6 +2038,28 @@ public class NotificationGeneratorConfiguration {
                         notificationSender,
                         notificationIdAppender
                 )
+        );
+    }
+
+    @Bean("recordAdjournmentDetailsIntegratedNotificationGenerator")
+    public List<NotificationGenerator> recordAdjournmentDetailsIntegratedNotificationGenerator(
+        LegalRepresentativeRecordAdjournmentDetailsPersonalisation legalRepresentativeRecordAdjournmentDetailsPersonalisation,
+        RespondentRecordAdjournmentDetailsPersonalisation respondentRecordAdjournmentDetailsPersonalisation,
+        CaseOfficerRecordAdjournmentDetailsPersonalisation caseOfficerRecordAdjournmentDetailsPersonalisation,
+        GovNotifyNotificationSender notificationSender,
+        NotificationIdAppender notificationIdAppender
+    ) {
+
+        List<EmailNotificationPersonalisation> personalisations = isHomeOfficeGovNotifyEnabled
+            ?  newArrayList(legalRepresentativeRecordAdjournmentDetailsPersonalisation, respondentRecordAdjournmentDetailsPersonalisation, caseOfficerRecordAdjournmentDetailsPersonalisation)
+            : newArrayList(legalRepresentativeRecordAdjournmentDetailsPersonalisation, caseOfficerRecordAdjournmentDetailsPersonalisation);
+
+        return Collections.singletonList(
+            new EmailNotificationGenerator(
+                personalisations,
+                notificationSender,
+                notificationIdAppender
+            )
         );
     }
 


### PR DESCRIPTION
### Jira link (if applicable)
[RIA-8192](https://tools.hmcts.net/jira/browse/RIA-8192)


### Change description ###
- Made `adjournHearingWithoutDate` and `recordAdjournmentDetails` each be handled by an "integrated" handler and a "non-integrated" handler, so that the Admin notification generator is removed when the case is list assist integrated (`isIntegrated  =Yes`)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
