### PR TITLE
RIA-7810 - Decision notifications should send to both LR and HO

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/applyforcosts/DecideCostsRespondentAndApplicantPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/applyforcosts/DecideCostsRespondentAndApplicantPersonalisation.java
@@ -2,14 +2,12 @@ package uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.applyf
 
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.*;
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.*;
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.HOME_OFFICE;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.Collections;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
@@ -49,13 +47,7 @@ public class DecideCostsRespondentAndApplicantPersonalisation implements EmailNo
 
     @Override
     public Set<String> getRecipientsList(AsylumCase asylumCase) {
-        ImmutablePair<String, String> applicantAndRespondent = getApplicantAndRespondent(asylumCase, func -> retrieveLatestApplyForCosts(asylumCase));
-        if (applicantAndRespondent.getLeft().equals(HOME_OFFICE)) {
-            return Collections.singleton(homeOfficeEmailAddress);
-        } else {
-
-            return Collections.singleton(emailAddressFinder.getLegalRepEmailAddress(asylumCase));
-        }
+        return new HashSet<>(Arrays.asList(homeOfficeEmailAddress, emailAddressFinder.getLegalRepEmailAddress(asylumCase)));
     }
 
     @Override

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/applyforcosts/DecideCostsRespondentAndApplicantPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/applyforcosts/DecideCostsRespondentAndApplicantPersonalisationTest.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -97,16 +98,9 @@ class DecideCostsRespondentAndApplicantPersonalisationTest {
     @ParameterizedTest
     @MethodSource("appliesForCostsProvider")
     void should_return_given_email_address(List<IdValue<ApplyForCosts>> applyForCostsList, DynamicList respondsToCostsList) {
-        when(asylumCase.read(APPLIES_FOR_COSTS)).thenReturn(Optional.of(applyForCostsList));
-        when(asylumCase.read(DECIDE_COSTS_APPLICATION_LIST, DynamicList.class)).thenReturn(Optional.of(respondsToCostsList));
-
-        if (applyForCostsList.get(0).getValue().getApplyForCostsApplicantType().equals("Tribunal")) {
-            assertTrue(decideCostsRespondentAndApplicantPersonalisation.getRecipientsList(asylumCase).isEmpty());
-        } else if (applyForCostsList.get(0).getValue().getApplyForCostsApplicantType().equals(homeOffice)) {
-            assertTrue(decideCostsRespondentAndApplicantPersonalisation.getRecipientsList(asylumCase).contains(homeOfficeEmailAddress));
-        } else {
-            assertTrue(decideCostsRespondentAndApplicantPersonalisation.getRecipientsList(asylumCase).contains(legalRepEmailAddress));
-        }
+        Set<String> recipientsSet = decideCostsRespondentAndApplicantPersonalisation.getRecipientsList(asylumCase);
+        assertTrue(recipientsSet.contains(legalRepEmailAddress));
+        assertTrue(recipientsSet.contains(homeOfficeEmailAddress));
     }
 
     @Test


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/RIA-7810

### Change description ###
Decision notifications should send to both applicant and respondent (LR and HO) even if no responses are given.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x ] commit messages are meaningful and follow good commit message guidelines
- [ x] README and other documentation has been updated / added (if needed)
- [ x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
