### PR TITLE
DIAC-366 CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -398,7 +398,7 @@ dependencies {
     implementation 'ch.qos.logback:logback-classic:1.2.13'
     implementation 'ch.qos.logback:logback-core:1.2.13'
 
-    implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '3.19.2-RELEASE'
+    implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '5.0.0-RELEASE'
 
     implementation group: 'com.google.guava', name: 'guava', version: '32.1.3-jre'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,28 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2024-06-01">
-        <notes><![CDATA[
-            This vulnerability is about potential Remote Code Execution when serializing and deserializing Java classes
-            using HttpInvokerServiceExport and org.springframework.remoting.
-            As we don't use those constructs, we are not affected by it.
-            The suppression will be a long-term one. An expiry to the suppression is kept to allow re-evaluating whether
-            we're still unaffected by it.
-        ]]></notes>
-        <cve>CVE-2016-1000027</cve>
-    </suppress>
-    <suppress until="2024-06-01">
-        <notes>![CDATA[
-            False positive - https://github.com/jeremylong/DependencyCheck/issues/5502
 
-            We don't use the libraries affected by this vulnerability. This is a false positive in dependencycheck that is still current in version 8.2.1.
-            Try to remove it when a dependencycheck upgrade becomes available.
-            If it still happens, check that we don't use hutool-json and json-java. If we don't, extend the suppression date by another year.
-            ]]</notes>
-        <cve>CVE-2022-45688</cve>
-    </suppress>
-    <suppress until="2024-06-28">
-        <notes>Suppress until a new version of uk.gov.service.notify/notifications-java-client is released that includes
-            a version of JSON that is newer than version 20230618</notes>
-        <cve>CVE-2023-5072</cve>
-    </suppress>
 </suppressions>


### PR DESCRIPTION

### Jira link (if applicable)

[DIAC-366](https://tools.hmcts.net/jira/browse/DIAC-366)

### Change description ###

Update uk.gov.service.notify:notifications-java-client:3.19.2-RELEASE to version 5.0.0 fixing CVE-2023-5072 and remove unnecessary suppressions.
### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
