### PR TITLE
DIAC-366 CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -327,9 +327,6 @@ dependencyManagement {
             entry 'jackson-datatype-jdk8'
         }
 
-        dependency group: 'org.bouncycastle', name: 'bcprov-jdk18on', version: '1.75'
-
-
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -379,8 +379,6 @@ dependencies {
     implementation group: 'com.sun.xml.bind', name: 'jaxb-osgi', version: '2.3.9'
     implementation (group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '6.0.0'){
         exclude group: "org.bouncycastle", module: "bcprov-jdk15on"
-        exclude group: "org.bouncycastle", module: "bcpkix-jdk15on"
-        exclude group: "org.bouncycastle", module: "bcutil-jdk15on"
     }
 
     implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
@@ -393,19 +391,13 @@ dependencies {
 
     implementation(group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '4.0.0') {
         exclude group: "org.bouncycastle", module: "bcprov-jdk15on"
-        exclude group: "org.bouncycastle", module: "bcpkix-jdk15on"
-        exclude group: "org.bouncycastle", module: "bcutil-jdk15on"
     }
 
     implementation(group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.1.8') {
         exclude group: "org.bouncycastle", module: "bcprov-jdk15on"
-        exclude group: "org.bouncycastle", module: "bcpkix-jdk15on"
-        exclude group: "org.bouncycastle", module: "bcutil-jdk15on:"
     }
     implementation(group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap' , version: '3.1.7') {
         exclude group: "org.bouncycastle", module: "bcprov-jdk15on"
-        exclude group: "org.bouncycastle", module: "bcpkix-jdk15on"
-        exclude group: "org.bouncycastle", module: "bcutil-jdk15on:"
     }
     implementation group: 'org.bouncycastle', name: 'bcprov-jdk18on', version: '1.75'
 

--- a/build.gradle
+++ b/build.gradle
@@ -351,8 +351,6 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
-    //implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: versions.springCloud
-    //implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: versions.springCloud
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
 
     implementation group: 'org.springframework.security', name: 'spring-security-oauth2-client'
@@ -382,16 +380,25 @@ dependencies {
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.83'
 
     implementation group: 'com.sun.xml.bind', name: 'jaxb-osgi', version: '2.3.9'
-    implementation group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '7.0.2'
+    implementation (group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '6.0.0'){
+        exclude group: "org.bouncycastle", module: "bcprov-jdk15on"
+        exclude group: "org.bouncycastle", module: "bcpkix-jdk15on"
+        exclude group: "org.bouncycastle", module: "bcutil-jdk15on"
+    }
 
     implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
     implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
     implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.1.0'
-    implementation group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '5.1.3'
 //    implementation group: 'uk.gov.hmcts.reform', name: 'health-spring-boot-starter', version: versions.reformHealthStarter
 
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
     implementation group: 'commons-io', name: 'commons-io', version: '2.15.1'
+
+    implementation(group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '4.0.0') {
+        exclude group: "org.bouncycastle", module: "bcprov-jdk15on"
+        exclude group: "org.bouncycastle", module: "bcpkix-jdk15on"
+        exclude group: "org.bouncycastle", module: "bcutil-jdk15on"
+    }
 
     implementation(group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.1.8') {
         exclude group: "org.bouncycastle", module: "bcprov-jdk15on"

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ def versions = [
         sonarPitest        : '0.5',
         springHystrix      : '2.2.10.RELEASE',
         springDoc          : '1.7.0',
-        springCloud        : '3.1.6'
+        springCloud        : '3.1.7'
 ]
 
 ext.libraries = [
@@ -327,6 +327,9 @@ dependencyManagement {
             entry 'jackson-datatype-jdk8'
         }
 
+        dependency group: 'org.bouncycastle', name: 'bcprov-jdk18on', version: '1.75'
+
+
     }
 }
 
@@ -348,8 +351,8 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
-    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: versions.springCloud
-    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: versions.springCloud
+    //implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: versions.springCloud
+    //implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: versions.springCloud
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
 
     implementation group: 'org.springframework.security', name: 'spring-security-oauth2-client'
@@ -379,32 +382,34 @@ dependencies {
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.83'
 
     implementation group: 'com.sun.xml.bind', name: 'jaxb-osgi', version: '2.3.9'
-    implementation group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '6.0.0'
+    implementation group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '7.0.2'
 
     implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
     implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
     implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.1.0'
-    implementation group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '3.1.4'
+    implementation group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '5.1.3'
 //    implementation group: 'uk.gov.hmcts.reform', name: 'health-spring-boot-starter', version: versions.reformHealthStarter
 
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
     implementation group: 'commons-io', name: 'commons-io', version: '2.15.1'
-    implementation(group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '4.0.0') {
-        exclude group: "org.bouncycastle", module: "bcprov-jdk15on"
-    }
+
     implementation(group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.1.8') {
         exclude group: "org.bouncycastle", module: "bcprov-jdk15on"
+        exclude group: "org.bouncycastle", module: "bcpkix-jdk15on"
+        exclude group: "org.bouncycastle", module: "bcutil-jdk15on:"
     }
     implementation(group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap' , version: '3.1.7') {
         exclude group: "org.bouncycastle", module: "bcprov-jdk15on"
+        exclude group: "org.bouncycastle", module: "bcpkix-jdk15on"
+        exclude group: "org.bouncycastle", module: "bcutil-jdk15on:"
     }
-    implementation group: 'org.bouncycastle', name: 'bcprov-jdk18on', version: '1.74'
+    implementation group: 'org.bouncycastle', name: 'bcprov-jdk18on', version: '1.75'
 
     implementation 'ch.qos.logback:logback-classic:1.2.13'
     implementation 'ch.qos.logback:logback-core:1.2.13'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-cache'
 
-    implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '3.19.2-RELEASE'
+    implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '5.0.1-RELEASE'
 
     implementation group: 'com.google.guava', name: 'guava', version: '32.1.3-jre'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,43 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2024-06-01">
-        <notes><![CDATA[
-            This vulnerability is about potential Remote Code Execution when serializing and deserializing Java classes
-            using HttpInvokerServiceExport and org.springframework.remoting.
-            As we don't use those constructs, we are not affected by it.
-            The suppression will be a long-term one. An expiry to the suppression is kept to allow re-evaluating whether
-            we're still unaffected by it.
-        ]]></notes>
-        <cve>CVE-2016-1000027</cve>
-    </suppress>
-    <suppress until="2024-06-01">
-        <notes>![CDATA[
-            False positive - https://github.com/jeremylong/DependencyCheck/issues/5502
 
-            We do not use the libraries affected by this vulnerability. This is a false positive in dependencycheck that is still current in version 8.2.1.
-            Try to remove it when a dependencycheck upgrade becomes available.
-            If it still happens, check that we don't use hutool-json and json-java. If we don't, extend the suppression date by another year.
-            ]]</notes>
-        <cve>CVE-2022-45688</cve>
-    </suppress>
-    <suppress until="2024-06-28">
-        <notes>Suppress until a new version of uk.gov.service.notify/notifications-java-client is released that includes
-            a version of JSON that is newer than version 20230618</notes>
-        <cve>CVE-2023-5072</cve>
-    </suppress>
-    <suppress until="2024-06-30">
-        <notes>Suppress until org.springframework.cloud and uk.gov.hmcts.reform/service-auth-provider-client upgrade their org.bouncycastle dependents</notes>
-        <cve>CVE-2023-33202</cve>
-    </suppress>
-    <suppress>
-        <notes>Until Jackson Databind release a 2.15.4</notes>
-        <cve>CVE-2023-35116</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: json-20230227.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.json/json@.*$</packageUrl>
-        <cpe>cpe:/a:json-java_project:json-java</cpe>
-    </suppress>
 </suppressions>


### PR DESCRIPTION
### Jira link (if applicable)

[DIAC-374](https://tools.hmcts.net/jira/browse/DIAC-374)
[DIAC-372](https://tools.hmcts.net/jira/browse/DIAC-372)
[DIAC-370](https://tools.hmcts.net/jira/browse/DIAC-370)
[DIAC-371](https://tools.hmcts.net/jira/browse/DIAC-371)

### Change description ###

Update uk.gov.service.notify:notifications-java-client:3.19.2-RELEASE to version 5.0.0 fixing CVE-2023-5072.

Update bouncy castle to bcprov-jdk18on v1.75 and exclude older bouncy castle modules from dependencies fixing CVE-2023-33202.

Remove unnecessary suppressions.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
