### PR TITLE
RIA-8944 fix the incorrect email notification triggered for LO and HO

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerEditListingPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerEditListingPersonalisation.java
@@ -6,6 +6,7 @@ import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumC
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import com.google.common.collect.ImmutableMap;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
@@ -13,6 +14,7 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.C
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.HearingDetailsFinder;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PersonalisationProvider;
 
 @Service
@@ -22,16 +24,19 @@ public class CaseOfficerEditListingPersonalisation implements EmailNotificationP
     private final String listAssistHearingCaseOfficerCaseEditedTemplateId;
     private final PersonalisationProvider personalisationProvider;
     private final EmailAddressFinder emailAddressFinder;
+    private final HearingDetailsFinder hearingDetailsFinder;
 
     public CaseOfficerEditListingPersonalisation(
             @Value("${govnotify.template.caseEdited.caseOfficer.email}") String caseOfficerCaseEditedTemplateId,
             @Value("${govnotify.template.listAssistHearing.caseEdited.caseOfficer.email}") String listAssistHearingCaseOfficerCaseEditedTemplateId,
             EmailAddressFinder emailAddressFinder,
-            PersonalisationProvider personalisationProvider) {
+            PersonalisationProvider personalisationProvider,
+            HearingDetailsFinder hearingDetailsFinder) {
         this.caseOfficerCaseEditedTemplateId = caseOfficerCaseEditedTemplateId;
         this.listAssistHearingCaseOfficerCaseEditedTemplateId = listAssistHearingCaseOfficerCaseEditedTemplateId;
         this.emailAddressFinder = emailAddressFinder;
         this.personalisationProvider = personalisationProvider;
+        this.hearingDetailsFinder = hearingDetailsFinder;
     }
 
     @Override
@@ -54,7 +59,13 @@ public class CaseOfficerEditListingPersonalisation implements EmailNotificationP
     public Map<String, String> getPersonalisation(Callback<AsylumCase> callback) {
         requireNonNull(callback, "callback must not be null");
 
-        return personalisationProvider.getPersonalisation(callback);
+        final ImmutableMap.Builder<String, String> listCaseFields = ImmutableMap
+                .<String, String>builder()
+                .putAll(personalisationProvider.getPersonalisation(callback))
+                .put("hearingCentreAddress", hearingDetailsFinder
+                        .getHearingCentreLocation(callback.getCaseDetails().getCaseData()));
+
+        return listCaseFields.build();
 
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerEditListingPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerEditListingPersonalisation.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.IS_INTEGRATED;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import com.google.common.collect.ImmutableMap;
@@ -59,13 +60,11 @@ public class CaseOfficerEditListingPersonalisation implements EmailNotificationP
     public Map<String, String> getPersonalisation(Callback<AsylumCase> callback) {
         requireNonNull(callback, "callback must not be null");
 
-        final ImmutableMap.Builder<String, String> listCaseFields = ImmutableMap
-                .<String, String>builder()
-                .putAll(personalisationProvider.getPersonalisation(callback))
-                .put("hearingCentreAddress", hearingDetailsFinder
-                        .getHearingCentreLocation(callback.getCaseDetails().getCaseData()));
+        final Map<String, String> listCaseFields = new HashMap<>();
+        listCaseFields.putAll(personalisationProvider.getPersonalisation(callback));
+        listCaseFields.put("hearingCentreAddress", hearingDetailsFinder
+                .getHearingCentreLocation(callback.getCaseDetails().getCaseData()));
 
-        return listCaseFields.build();
-
+        return ImmutableMap.copyOf(listCaseFields);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeEditListingPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeEditListingPersonalisation.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesO
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.CustomerServicesProvider;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.HearingDetailsFinder;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PersonalisationProvider;
 
 @Service
@@ -28,19 +29,22 @@ public class HomeOfficeEditListingPersonalisation implements EmailNotificationPe
     private final PersonalisationProvider personalisationProvider;
     private EmailAddressFinder emailAddressFinder;
     private final CustomerServicesProvider customerServicesProvider;
+    private final HearingDetailsFinder hearingDetailsFinder;
 
     public HomeOfficeEditListingPersonalisation(
         @Value("${govnotify.template.caseEdited.homeOffice.email}") String homeOfficeCaseEditedTemplateId,
         @Value("${govnotify.template.listAssistHearing.caseEdited.homeOffice.email}") String listAssistHearingHomeOfficeCaseEditedTemplateId,
         EmailAddressFinder emailAddressFinder,
         PersonalisationProvider personalisationProvider,
-        CustomerServicesProvider customerServicesProvider
+        CustomerServicesProvider customerServicesProvider,
+        HearingDetailsFinder hearingDetailsFinder
     ) {
         this.homeOfficeCaseEditedTemplateId = homeOfficeCaseEditedTemplateId;
         this.listAssistHearingHomeOfficeCaseEditedTemplateId = listAssistHearingHomeOfficeCaseEditedTemplateId;
         this.emailAddressFinder = emailAddressFinder;
         this.personalisationProvider = personalisationProvider;
         this.customerServicesProvider = customerServicesProvider;
+        this.hearingDetailsFinder = hearingDetailsFinder;
     }
 
     @Override
@@ -69,7 +73,9 @@ public class HomeOfficeEditListingPersonalisation implements EmailNotificationPe
         final ImmutableMap.Builder<String, String> listCaseFields = ImmutableMap
             .<String, String>builder()
             .putAll(customerServicesProvider.getCustomerServicesPersonalisation())
-            .putAll(personalisationProvider.getPersonalisation(callback));
+            .putAll(personalisationProvider.getPersonalisation(callback))
+            .put("hearingCentreAddress", hearingDetailsFinder
+                    .getHearingCentreLocation(callback.getCaseDetails().getCaseData()));
 
         return listCaseFields.build();
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeEditListingPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeEditListingPersonalisation.java
@@ -6,6 +6,7 @@ import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumC
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -70,13 +71,12 @@ public class HomeOfficeEditListingPersonalisation implements EmailNotificationPe
     public Map<String, String> getPersonalisation(Callback<AsylumCase> callback) {
         requireNonNull(callback, "callback must not be null");
 
-        final ImmutableMap.Builder<String, String> listCaseFields = ImmutableMap
-            .<String, String>builder()
-            .putAll(customerServicesProvider.getCustomerServicesPersonalisation())
-            .putAll(personalisationProvider.getPersonalisation(callback))
-            .put("hearingCentreAddress", hearingDetailsFinder
-                    .getHearingCentreLocation(callback.getCaseDetails().getCaseData()));
+        final Map<String, String> listCaseFields = new HashMap<>();
+        listCaseFields.putAll(customerServicesProvider.getCustomerServicesPersonalisation());
+        listCaseFields.putAll(personalisationProvider.getPersonalisation(callback));
+        listCaseFields.put("hearingCentreAddress", hearingDetailsFinder
+                .getHearingCentreLocation(callback.getCaseDetails().getCaseData()));
 
-        return listCaseFields.build();
+        return ImmutableMap.copyOf(listCaseFields);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerEditListingPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/caseofficer/CaseOfficerEditListingPersonalisationTest.java
@@ -19,8 +19,10 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.HearingCentre;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.HearingDetailsFinder;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PersonalisationProvider;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,11 +32,15 @@ class CaseOfficerEditListingPersonalisationTest {
     @Mock
     Callback<AsylumCase> callback;
     @Mock
+    CaseDetails<AsylumCase> caseDetails;
+    @Mock
     AsylumCase asylumCase;
     @Mock
     EmailAddressFinder emailAddressFinder;
     @Mock
     PersonalisationProvider personalisationProvider;
+    @Mock
+    HearingDetailsFinder hearingDetailsFinder;
 
     private Long caseId = 12345L;
     private String templateId = "someTemplateId";
@@ -49,12 +55,14 @@ class CaseOfficerEditListingPersonalisationTest {
     private String appellantFamilyName = "appellantFamilyName";
     private String homeOfficeRefNumber = "homeOfficeRefNumber";
     private String hearingCentreName = "The Hearing Centre";
+    private String hearingCentreAddress = "hearingCentreAddress";
 
     private CaseOfficerEditListingPersonalisation caseOfficerEditListingPersonalisation;
 
     @BeforeEach
     public void setup() {
-
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(emailAddressFinder.getListCaseCaseOfficerHearingCentreEmailAddress(asylumCase)).thenReturn(listCaseHearingCentreEmailAddress);
         when(emailAddressFinder.getHearingCentreEmailAddress(asylumCase)).thenReturn(hearingCentreEmailAddress);
 
@@ -62,7 +70,8 @@ class CaseOfficerEditListingPersonalisationTest {
             templateId,
             listAssistHearingTemplateId,
             emailAddressFinder,
-            personalisationProvider);
+            personalisationProvider,
+            hearingDetailsFinder);
     }
 
     @Test
@@ -98,6 +107,8 @@ class CaseOfficerEditListingPersonalisationTest {
     @Test
     void should_return_personalisation_when_all_information_given() {
         when(personalisationProvider.getPersonalisation(callback)).thenReturn(getPersonalisationMapWithBlankValues());
+        when(hearingDetailsFinder.getHearingCentreLocation(callback.getCaseDetails().getCaseData()))
+                .thenReturn(hearingCentreAddress);
 
         Map<String, String> personalisation = caseOfficerEditListingPersonalisation.getPersonalisation(callback);
 
@@ -108,6 +119,8 @@ class CaseOfficerEditListingPersonalisationTest {
     @Test
     void should_return_personalisation_when_all_mandatory_information_given() {
         when(personalisationProvider.getPersonalisation(callback)).thenReturn(getPersonalisationMapWithGivenValues());
+        when(hearingDetailsFinder.getHearingCentreLocation(callback.getCaseDetails().getCaseData()))
+                .thenReturn(hearingCentreAddress);
 
         Map<String, String> personalisation = caseOfficerEditListingPersonalisation.getPersonalisation(callback);
 

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeEditListingPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/homeoffice/HomeOfficeEditListingPersonalisationTest.java
@@ -19,9 +19,11 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.HearingCentre;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.CustomerServicesProvider;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.HearingDetailsFinder;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.PersonalisationProvider;
 
 @ExtendWith(MockitoExtension.class)
@@ -31,6 +33,8 @@ class HomeOfficeEditListingPersonalisationTest {
     @Mock
     Callback<AsylumCase> callback;
     @Mock
+    CaseDetails<AsylumCase> caseDetails;
+    @Mock
     AsylumCase asylumCase;
     @Mock
     EmailAddressFinder emailAddressFinder;
@@ -38,6 +42,8 @@ class HomeOfficeEditListingPersonalisationTest {
     PersonalisationProvider personalisationProvider;
     @Mock
     CustomerServicesProvider customerServicesProvider;
+    @Mock
+    HearingDetailsFinder hearingDetailsFinder;
 
     private Long caseId = 12345L;
     private String templateId = "someTemplateId";
@@ -61,12 +67,14 @@ class HomeOfficeEditListingPersonalisationTest {
 
     private String customerServicesTelephone = "555 555 555";
     private String customerServicesEmail = "cust.services@example.com";
+    private String hearingCentreAddress = "hearingCentreAddress";
 
     private HomeOfficeEditListingPersonalisation homeOfficeEditListingPersonalisation;
 
     @BeforeEach
     public void setup() {
-
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(emailAddressFinder.getListCaseHomeOfficeEmailAddress(asylumCase)).thenReturn(listCaseHomeOfficeEmailAddress);
         when(emailAddressFinder.getHomeOfficeEmailAddress(asylumCase)).thenReturn(homeOfficeEmailAddress);
 
@@ -75,7 +83,8 @@ class HomeOfficeEditListingPersonalisationTest {
             listAssistHearingTemplateId,
             emailAddressFinder,
             personalisationProvider,
-            customerServicesProvider
+            customerServicesProvider,
+            hearingDetailsFinder
         );
     }
 
@@ -111,6 +120,8 @@ class HomeOfficeEditListingPersonalisationTest {
     @Test
     void should_return_personalisation_when_all_information_given() {
         when(personalisationProvider.getPersonalisation(callback)).thenReturn(getPersonalisationMapWithGivenValues());
+        when(hearingDetailsFinder.getHearingCentreLocation(callback.getCaseDetails().getCaseData()))
+                .thenReturn(hearingCentreAddress);
 
         Map<String, String> personalisation = homeOfficeEditListingPersonalisation.getPersonalisation(callback);
 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/RIA-8944


### Change description ###
- set the hearingCentreAddress to "remote hearing" when the value of "listCaseHearingCentre" is remote hearing
- update unit test
- this PR will affect two email template only ([LO email: "513c5d12-7e26-4430-8560-d3a42a2d5df0"](https://www.notifications.service.gov.uk/services/7f72d0fb-2bc4-421b-bceb-1bf5bf350ff9/templates/513c5d12-7e26-4430-8560-d3a42a2d5df0) and [HO email: "071cc334-89f7-4bce-bf88-637057f4811a"](https://www.notifications.service.gov.uk/services/7f72d0fb-2bc4-421b-bceb-1bf5bf350ff9/templates/071cc334-89f7-4bce-bf88-637057f4811a))


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
