### PR TITLE
RIA-9116 Rework for precompiled letter notifications generation

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/NotificationSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/NotificationSender.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.iacasenotificationsapi.domain;
 
+import java.io.InputStream;
 import java.util.Map;
 
 
@@ -24,5 +25,10 @@ public interface NotificationSender {
         String address,
         Map<String, String> personalisation,
         String reference
+    );
+
+    String sendPrecompiledLetter(
+        String reference,
+        InputStream stream
     );
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AsylumCaseDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/entities/AsylumCaseDefinition.java
@@ -466,7 +466,10 @@ public enum AsylumCaseDefinition {
     ),
 
     SOURCE_OF_REMITTAL(
-        "sourceOfRemittal", new TypeReference<SourceOfRemittal>(){});
+        "sourceOfRemittal", new TypeReference<SourceOfRemittal>(){}),
+
+    LETTER_BUNDLE_DOCUMENTS(
+        "letterBundleDocuments", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){});
 
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/PrecompiledLetterNotificationGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/PrecompiledLetterNotificationGenerator.java
@@ -1,0 +1,91 @@
+package uk.gov.hmcts.reform.iacasenotificationsapi.domain.service;
+
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.LETTER_BUNDLE_DOCUMENTS;
+
+import java.io.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.core.io.Resource;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.DocumentWithMetadata;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.DocumentDownloadClient;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.GovNotifyNotificationSender;
+
+public class PrecompiledLetterNotificationGenerator implements NotificationGenerator {
+
+    protected final List<DocumentTag> documentTagList;
+    protected final NotificationIdAppender notificationIdAppender;
+    protected final GovNotifyNotificationSender notificationSender;
+    protected final DocumentDownloadClient documentDownloadClient;
+
+    public PrecompiledLetterNotificationGenerator(
+        List<DocumentTag> documentTagList,
+        GovNotifyNotificationSender notificationSender,
+        NotificationIdAppender notificationIdAppender,
+        DocumentDownloadClient documentDownloadClient) {
+        this.documentTagList = documentTagList;
+        this.notificationSender = notificationSender;
+        this.notificationIdAppender = notificationIdAppender;
+        this.documentDownloadClient = documentDownloadClient;
+    }
+
+    @Override
+    public void generate(Callback<AsylumCase> callback) {
+
+        final AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+        documentTagList.forEach(documentTag -> {
+            String caseId = String.valueOf(callback.getCaseDetails().getId());
+            String referenceId = caseId + "_" + documentTag.name();
+            List<String> notificationIds;
+            try {
+                notificationIds = createPrecompiledLetter(documentTag, asylumCase, referenceId);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            notificationIdAppender.appendAll(asylumCase, referenceId, notificationIds);
+        });
+    }
+
+    protected List<String> createPrecompiledLetter(
+        final DocumentTag documentTag,
+        final AsylumCase asylumCase,
+        final String referenceId) throws IOException {
+        Optional<List<IdValue<DocumentWithMetadata>>> optionalLetterNotificationDocs = asylumCase.read(LETTER_BUNDLE_DOCUMENTS);
+
+        DocumentWithMetadata bundledLetterPdf = optionalLetterNotificationDocs
+            .orElse(Collections.emptyList())
+            .stream()
+            .map(IdValue::getValue)
+            .filter(d -> d.getTag() == documentTag)
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException(documentTag + " document not available"));
+
+        Resource resource =
+            documentDownloadClient.download(bundledLetterPdf.getDocument().getDocumentBinaryUrl());
+
+
+        return Arrays.asList(
+            sendPrecompiledLetter(
+                referenceId,
+                resource.getInputStream()));
+    }
+
+    protected String sendPrecompiledLetter(
+        final String referenceId,
+        final InputStream inputStream) throws IOException {
+
+        return notificationSender.sendPrecompiledLetter(
+            referenceId,
+            inputStream
+        );
+    }
+
+
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/clients/BailGovNotifyNotificationSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/clients/BailGovNotifyNotificationSender.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
+import java.io.InputStream;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -80,6 +81,20 @@ public class BailGovNotifyNotificationSender implements NotificationSender {
             address,
             personalisation,
             reference,
+            notificationBailClient,
+            deduplicateSendsWithinSeconds,
+            LOG
+        );
+    }
+
+    @Override
+    public synchronized String sendPrecompiledLetter(
+        final String reference,
+        final InputStream stream
+    ) {
+        return senderHelper.sendPrecompiledLetter(
+            reference,
+            stream,
             notificationBailClient,
             deduplicateSendsWithinSeconds,
             LOG

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/clients/GovNotifyNotificationSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/clients/GovNotifyNotificationSender.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
+import java.io.InputStream;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -91,6 +92,20 @@ public class GovNotifyNotificationSender implements NotificationSender {
             address,
             personalisation,
             reference,
+            notificationClient,
+            deduplicateSendsWithinSeconds,
+            LOG
+        );
+    }
+
+    @Override
+    public synchronized String sendPrecompiledLetter(
+        final String reference,
+        final InputStream stream
+    ) {
+        return senderHelper.sendPrecompiledLetter(
+            reference,
+            stream,
             notificationClient,
             deduplicateSendsWithinSeconds,
             LOG

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/clients/RetryableNotificationClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/clients/RetryableNotificationClient.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients;
 
+import java.io.InputStream;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.service.notify.*;
@@ -46,6 +47,15 @@ public class RetryableNotificationClient {
         } catch (NotificationClientException e) {
             log.warn("retry triggered: {}", e.getMessage());
             return notificationClient.sendLetter(templateId, personalisation, reference);
+        }
+    }
+
+    public LetterResponse sendPrecompiledLetter(String reference, InputStream stream) throws NotificationClientException {
+        try {
+            return notificationClient.sendPrecompiledLetterWithInputStream(reference, stream);
+        } catch (NotificationClientException e) {
+            log.warn("retry triggered: {}", e.getMessage());
+            return notificationClient.sendPrecompiledLetterWithInputStream(reference, stream);
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/clients/helper/NotificationSenderHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/clients/helper/NotificationSenderHelper.java
@@ -2,18 +2,15 @@ package uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.helper
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.NotificationServiceResponseException;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.RetryableNotificationClient;
-import uk.gov.service.notify.NotificationClientException;
-import uk.gov.service.notify.SendEmailResponse;
-import uk.gov.service.notify.SendLetterResponse;
-import uk.gov.service.notify.SendSmsResponse;
-
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
+import uk.gov.service.notify.*;
 
 @Component
 public class NotificationSenderHelper {
@@ -172,6 +169,42 @@ public class NotificationSenderHelper {
 
                 } catch (NotificationClientException e) {
                     logger.error("Failed to send letter using GovNotify", reference, e);
+                }
+                return Strings.EMPTY;
+            }
+        );
+    }
+
+    public String sendPrecompiledLetter(
+        String reference,
+        InputStream stream,
+        RetryableNotificationClient notificationClient,
+        Integer deduplicateSendsWithinSeconds,
+        Logger logger
+    ) {
+        recentDeliveryReceiptCache = getOrCreateDeliveryReceiptCache(deduplicateSendsWithinSeconds);
+        return recentDeliveryReceiptCache.get(
+            reference,
+            k -> {
+                try {
+                    logger.info("Attempting to send pre-compiled letter notification to GovNotify: {}", reference);
+
+                    LetterResponse response = notificationClient.sendPrecompiledLetter(
+                        reference,
+                        stream
+                    );
+
+                    String notificationId = response.getNotificationId().toString();
+
+                    logger.info("Successfully sent pre-compiled letter notification to GovNotify: {} ({})",
+                        reference,
+                        notificationId
+                    );
+
+                    return notificationId;
+
+                } catch (NotificationClientException e) {
+                    logger.error("Failed to send pre-compiled letter using GovNotify", reference, e);
                 }
                 return Strings.EMPTY;
             }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/NotificationGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/NotificationGeneratorTest.java
@@ -4,16 +4,13 @@ import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
-import static org.mockito.Mockito.mockStatic;
 import static java.util.Collections.singletonList;
-
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.LETTER_BUNDLE_DOCUMENTS;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.EmailAddressFinder.NO_EMAIL_ADDRESS_DECISION_WITHOUT_HEARING;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -21,24 +18,25 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.Spy;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.Resource;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.ApplicationContextProvider;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCase;
-import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.*;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.Document;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.EmailNotificationPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.LetterNotificationPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.domain.personalisation.SmsNotificationPersonalisation;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.CustomerServicesProvider;
+import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.DocumentDownloadClient;
 import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.clients.GovNotifyNotificationSender;
+import uk.gov.service.notify.NotificationClientException;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -71,11 +69,18 @@ public class NotificationGeneratorTest {
     static ApplicationContext applicationContext;
     @Mock
     static CustomerServicesProvider customerServicesProvider;
+    @Mock
+    DocumentDownloadClient documentDownloadClient;
+    @Mock
+    Resource resource;
+    @Mock
+    InputStream mockInputStream;
 
     private List<EmailNotificationPersonalisation> repEmailNotificationPersonalisationList;
     private List<EmailNotificationPersonalisation> aipEmailNotificationPersonalisationList;
     private List<SmsNotificationPersonalisation> aipSmsNotificationPersonalisationList;
     private List<LetterNotificationPersonalisation> letterNotificationPersonalisationList;
+    private List<DocumentTag> documentTagList;
 
     private NotificationGenerator notificationGenerator;
 
@@ -86,7 +91,6 @@ public class NotificationGeneratorTest {
 
     private String refId1 = "refId1";
     private String refId2 = "refId2";
-
     private String emailAddress1 = "email1@example.com";
     private String emailAddress2 = "email2@example.com";
 
@@ -103,9 +107,18 @@ public class NotificationGeneratorTest {
 
     private String notificationId1 = "notificationId1";
     private String notificationId2 = "notificationId2";
+    private String documentBinaryUrl = "http://host:8080/a/b/c";
+
+    private DocumentTag documentTag = DocumentTag.END_APPEAL;
+
+    Document document = new Document(documentBinaryUrl, documentBinaryUrl, "end-appeal-notice");
+    DocumentWithMetadata documentWithMetadata = new DocumentWithMetadata(document, "desc", null, documentTag);
+    IdValue<DocumentWithMetadata> documentWithMetadataId = new IdValue<>("1", documentWithMetadata);
+    private String refId3 = caseId + "_" + documentTag.name();
+
 
     @BeforeEach
-    public void setup() {
+    public void setup() throws NotificationClientException, IOException {
         mocked = mockStatic(ApplicationContextProvider.class);
         mocked.when(ApplicationContextProvider::getApplicationContext).thenReturn(applicationContext);
         when(applicationContext.getBean(CustomerServicesProvider.class)).thenReturn(customerServicesProvider);
@@ -169,6 +182,17 @@ public class NotificationGeneratorTest {
             newArrayList(smsNotificationPersonalisation1, smsNotificationPersonalisation2);
         letterNotificationPersonalisationList =
             newArrayList(letterNotificationPersonalisation1, letterNotificationPersonalisation2);
+
+        documentTagList = newArrayList(documentTag);
+
+        when(notificationSender.sendPrecompiledLetter(refId3, mockInputStream))
+            .thenReturn(notificationId1);
+        when(notificationIdAppender.append(notificationsSent, refId3, notificationId1)).thenReturn(notificationsSent);
+
+        when(asylumCase.read(LETTER_BUNDLE_DOCUMENTS)).thenReturn(Optional.of(newArrayList(documentWithMetadataId)));
+
+        when(documentDownloadClient.download(documentBinaryUrl)).thenReturn(resource);
+        when(resource.getInputStream()).thenReturn(mockInputStream);
 
     }
 
@@ -265,6 +289,21 @@ public class NotificationGeneratorTest {
     }
 
     @Test
+    public void should_send_notification_for_each_precompiled_letter_document_tag() {
+
+        notificationGenerator =
+            new PrecompiledLetterNotificationGenerator(documentTagList, notificationSender,
+                notificationIdAppender, documentDownloadClient);
+
+        notificationGenerator.generate(callback);
+
+        verify(notificationSender).sendPrecompiledLetter(refId3, mockInputStream);
+        verify(notificationIdAppender).append(notificationsSent, refId3, notificationId1);
+        verify(notificationIdAppender).appendAll(asylumCase, refId3, singletonList(notificationId1));
+        verify(asylumCase, times(1)).write(AsylumCaseDefinition.NOTIFICATIONS_SENT, notificationsSent);
+    }
+
+    @Test
     public void should_not_send_notification_when_email_personalisation_list_empty() {
         notificationGenerator = new EmailNotificationGenerator(emptyList(), notificationSender, notificationIdAppender);
         notificationGenerator.generate(callback);
@@ -312,6 +351,17 @@ public class NotificationGeneratorTest {
     @Test
     public void should_not_send_notification_when_letter_personalisation_list_empty() {
         notificationGenerator = new LetterNotificationGenerator(emptyList(), notificationSender, notificationIdAppender);
+        notificationGenerator.generate(callback);
+
+        verifyNoInteractions(notificationSender);
+        verifyNoInteractions(notificationIdAppender);
+
+        verify(asylumCase, times(0)).write(AsylumCaseDefinition.NOTIFICATIONS_SENT, notificationsSent);
+    }
+
+    @Test
+    public void should_not_send_notification_when_precompiled_letter_document_tag_list_empty() {
+        notificationGenerator = new PrecompiledLetterNotificationGenerator(emptyList(), notificationSender, notificationIdAppender, documentDownloadClient);
         notificationGenerator.generate(callback);
 
         verifyNoInteractions(notificationSender);

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/clients/BailGovNotifyNotificationSenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/clients/BailGovNotifyNotificationSenderTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import java.io.InputStream;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +29,7 @@ public class BailGovNotifyNotificationSenderTest {
     private RetryableNotificationClient notificationBailClient;
 
     @Mock private NotificationSenderHelper senderHelper;
+    @Mock private InputStream stream;
 
     private String templateId = "a-b-c-d-e-f";
     private String emailAddress = "recipient@example.com";
@@ -116,6 +118,35 @@ public class BailGovNotifyNotificationSenderTest {
                 LOG
         );
 
+        assertEquals(expectedNotificationId.toString(), actualNotificationId);
+    }
+
+    @Test
+    public void should_send_precompiled_letter_using_bail_gov_notify() throws NotificationClientException {
+
+        final UUID expectedNotificationId = UUID.randomUUID();
+
+        when(senderHelper.sendPrecompiledLetter(
+            reference,
+            stream,
+            notificationBailClient,
+            deduplicateSendsWithinSeconds,
+            LOG
+        )).thenReturn(String.valueOf(expectedNotificationId));
+
+        String actualNotificationId =
+            bailGovNotifyNotificationSender.sendPrecompiledLetter(
+                reference,
+                stream
+            );
+
+        verify(senderHelper, times(1)).sendPrecompiledLetter(
+            reference,
+            stream,
+            notificationBailClient,
+            deduplicateSendsWithinSeconds,
+            LOG
+        );
         assertEquals(expectedNotificationId.toString(), actualNotificationId);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/clients/GovNotifyNotificationSenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/clients/GovNotifyNotificationSenderTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import java.io.InputStream;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,6 +26,7 @@ public class GovNotifyNotificationSenderTest {
     private RetryableNotificationClient notificationClient;
 
     @Mock private NotificationSenderHelper senderHelper;
+    @Mock private InputStream stream;
 
     private String templateId = "a-b-c-d-e-f";
     private String emailAddress = "recipient@example.com";
@@ -182,6 +184,35 @@ public class GovNotifyNotificationSenderTest {
             address,
             personalisation,
             reference,
+            notificationClient,
+            deduplicateSendsWithinSeconds,
+            LOG
+        );
+        assertEquals(expectedNotificationId.toString(), actualNotificationId);
+    }
+
+    @Test
+    public void should_send_precompiled_letter_using_gov_notify() throws NotificationClientException {
+
+        final UUID expectedNotificationId = UUID.randomUUID();
+
+        when(senderHelper.sendPrecompiledLetter(
+            reference,
+            stream,
+            notificationClient,
+            deduplicateSendsWithinSeconds,
+            LOG
+        )).thenReturn(String.valueOf(expectedNotificationId));
+
+        String actualNotificationId =
+            govNotifyNotificationSender.sendPrecompiledLetter(
+                reference,
+                stream
+            );
+
+        verify(senderHelper, times(1)).sendPrecompiledLetter(
+            reference,
+            stream,
             notificationClient,
             deduplicateSendsWithinSeconds,
             LOG


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/RIA-9116

### Change description ###

- Rework adding a new generator and methods to allow precompiled letters to be sent to GovNotify for printing and sending
- New unit tests

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [X] Does this PR introduce a breaking change
