### PR TITLE
DIAC-612 removing recordDecision from getEventsToSkip

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/presubmit/NotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/handlers/presubmit/NotificationHandler.java
@@ -62,7 +62,6 @@ public class NotificationHandler implements PreSubmitCallbackHandler<AsylumCase>
             Event.EDIT_BAIL_APPLICATION_AFTER_SUBMIT,
             Event.CREATE_BAIL_CASE_LINK,
             Event.MAINTAIN_BAIL_CASE_LINKS,
-            Event.RECORD_THE_DECISION,
             Event.SEND_UPLOAD_BAIL_SUMMARY_DIRECTION,
             Event.CASE_LISTING
         );


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/SNI-6120

### Change description ###
Removing decide an application event from getEventsToSkip for a preview env to test if this allows notifications to be sent

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
