### PR TITLE
RIA-9217 OOC email template scenario added

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-9217-aip-appellant-in-country-refund-confirmation-notifications.json
+++ b/src/functionalTest/resources/scenarios/RIA-9217-aip-appellant-in-country-refund-confirmation-notifications.json
@@ -1,5 +1,5 @@
 {
-  "description": "RIA-9217 AIP Appellant Refund confirmation notifications - Email/SMS",
+  "description": "RIA-9217 AIP Appellant Refund confirmation notifications- In country - Email/SMS",
   "launchDarklyKey": "dlrm-refund-feature-flag:true",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",

--- a/src/functionalTest/resources/scenarios/RIA-9217-aip-appellant-out-of-country-refund-confirmation-notifications.json
+++ b/src/functionalTest/resources/scenarios/RIA-9217-aip-appellant-out-of-country-refund-confirmation-notifications.json
@@ -1,0 +1,71 @@
+{
+  "description": "RIA-9217 AIP Appellant Refund confirmation notifications- Out of country - Email/SMS",
+  "launchDarklyKey": "dlrm-refund-feature-flag:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 9217,
+      "eventId": "refundConfirmation",
+      "state": "*",
+      "caseData": {
+        "template": "aip-minimal-appeal-submitted.json",
+        "replacements": {
+          "appellantInUk": "No",
+          "homeOfficeReferenceNumber": null,
+          "previousDecisionHearingFeeOption": "decisionWithHearing",
+          "decisionHearingFeeOption": "decisionWithoutHearing",
+          "newFeeAmount": "8000",
+          "subscriptions": [
+            {
+              "id": "1",
+              "value": {
+                "subscriber": "appellant",
+                "email": "{$TEST_CITIZEN_USERNAME}",
+                "wantsEmail": "Yes",
+                "mobileNumber": "{$TEST_CITIZEN_MOBILE}",
+                "wantsSms": "Yes"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "aip-minimal-appeal-submitted.json",
+      "replacements": {
+        "appellantInUk": "No",
+        "homeOfficeReferenceNumber": null,
+        "previousDecisionHearingFeeOption": "decisionWithHearing",
+        "decisionHearingFeeOption": "decisionWithoutHearing",
+        "newFeeAmount": "8000",
+        "subscriptions": [
+          {
+            "id": "1",
+            "value": {
+              "subscriber": "appellant",
+              "email": "{$TEST_CITIZEN_USERNAME}",
+              "wantsEmail": "Yes",
+              "mobileNumber": "{$TEST_CITIZEN_MOBILE}",
+              "wantsSms": "Yes"
+            }
+          }
+        ],
+        "notificationsSent": [
+          {
+            "id": "9217_REFUND_CONFIRMATION_AIP_APPELLANT_EMAIL",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          },
+          {
+            "id": "9217_REFUND_CONFIRMATION_AIP_APPELLANT_SMS",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AipAppellantRefundConfirmationPersonalisationEmail.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AipAppellantRefundConfirmationPersonalisationEmail.java
@@ -20,7 +20,8 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.SystemDateProvi
 @Service
 public class AipAppellantRefundConfirmationPersonalisationEmail implements EmailNotificationPersonalisation {
 
-    private final String aipAppellantRefundConfirmationTemplateId;
+    private final String aipAppellantRefundConfirmationInCountryTemplateId;
+    private final String aipAppellantRefundConfirmationOutOfCountryTemplateId;
     private final String iaAipFrontendUrl;
     private final int daysAfterNotificationSent;
     private final CustomerServicesProvider customerServicesProvider;
@@ -28,14 +29,16 @@ public class AipAppellantRefundConfirmationPersonalisationEmail implements Email
     private final SystemDateProvider systemDateProvider;
 
     public AipAppellantRefundConfirmationPersonalisationEmail(
-        @Value("${govnotify.template.refundConfirmation.appellant.email}") String aipAppellantRefundConfirmationTemplateId,
+        @Value("${govnotify.template.refundConfirmation.appellant.inCountry.email}") String aipAppellantRefundConfirmationInCountryTemplateId,
+        @Value("${govnotify.template.refundConfirmation.appellant.outOfCountry.email}") String aipAppellantRefundConfirmationOutOfCountryTemplateId,
         @Value("${iaAipFrontendUrl}") String iaAipFrontendUrl,
         @Value("${appellantDaysToWait.afterNotificationSent}") int daysAfterNotificationSent,
         CustomerServicesProvider customerServicesProvider,
         RecipientsFinder recipientsFinder,
         SystemDateProvider systemDateProvider
     ) {
-        this.aipAppellantRefundConfirmationTemplateId = aipAppellantRefundConfirmationTemplateId;
+        this.aipAppellantRefundConfirmationInCountryTemplateId = aipAppellantRefundConfirmationInCountryTemplateId;
+        this.aipAppellantRefundConfirmationOutOfCountryTemplateId = aipAppellantRefundConfirmationOutOfCountryTemplateId;
         this.iaAipFrontendUrl = iaAipFrontendUrl;
         this.daysAfterNotificationSent = daysAfterNotificationSent;
         this.customerServicesProvider = customerServicesProvider;
@@ -50,7 +53,11 @@ public class AipAppellantRefundConfirmationPersonalisationEmail implements Email
 
     @Override
     public String getTemplateId(AsylumCase asylumCase) {
-        return aipAppellantRefundConfirmationTemplateId;
+        if (asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class).isPresent()) {
+            return  aipAppellantRefundConfirmationInCountryTemplateId;
+        } else {
+            return  aipAppellantRefundConfirmationOutOfCountryTemplateId;
+        }
     }
 
     @Override

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1327,8 +1327,11 @@ govnotify:
       legalRep:
         email: 28b12dcc-d365-43be-a918-0b1fe654323e
       appellant:
-        email: df941fa9-e41a-4ab2-8c0f-7a7ec5d7d924
         sms: 0a039334-5604-4f8a-b38b-0c1df140cb9c
+        inCountry:
+          email: df941fa9-e41a-4ab2-8c0f-7a7ec5d7d924
+        outOfCountry:
+          email: 3a4ab356-65df-4afb-ac49-4993d88b9bd7
 
   bail:
     key: ${IA_BAIL_GOV_NOTIFY_KEY}

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AipAppellantRefundConfirmationPersonalisationEmailTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/personalisation/appellant/email/AipAppellantRefundConfirmationPersonalisationEmailTest.java
@@ -29,7 +29,8 @@ import uk.gov.hmcts.reform.iacasenotificationsapi.infrastructure.SystemDateProvi
 class AipAppellantRefundConfirmationPersonalisationEmailTest {
 
     private Long caseId = 12345L;
-    private String refundConfirmationTemplateId = "refundConfirmationTemplateId";
+    private String refundConfirmationInCountryTemplateId = "refundConfirmationInCountryTemplateId";
+    private String refundConfirmationOutOfCountryTemplateId = "refundConfirmationOutOfCountryTemplateId";
     private String iaAipFrontendUrl = "http://localhost";
     private String appealReferenceNumber = "appealReferenceNumber";
     private String homeOfficeReferenceNumber = "homeOfficeReferenceNumber";
@@ -68,7 +69,8 @@ class AipAppellantRefundConfirmationPersonalisationEmailTest {
         when((customerServicesProvider.getCustomerServicesEmail())).thenReturn(customerServicesEmail);
 
         aipAppellantRefundConfirmationPersonalisationEmail = new AipAppellantRefundConfirmationPersonalisationEmail(
-            refundConfirmationTemplateId,
+            refundConfirmationInCountryTemplateId,
+            refundConfirmationOutOfCountryTemplateId,
             iaAipFrontendUrl,
             daysAfterRemissionDecision,
             customerServicesProvider,
@@ -78,8 +80,12 @@ class AipAppellantRefundConfirmationPersonalisationEmailTest {
     }
 
     @Test
-    void should_return_approved_template_id() {
-        assertTrue(aipAppellantRefundConfirmationPersonalisationEmail.getTemplateId(asylumCase).contains(refundConfirmationTemplateId));
+    void should_return_correct_template_id_with_or_without_home_office_reference() {
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
+        assertTrue(aipAppellantRefundConfirmationPersonalisationEmail.getTemplateId(asylumCase).contains(refundConfirmationInCountryTemplateId));
+
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.empty());
+        assertTrue(aipAppellantRefundConfirmationPersonalisationEmail.getTemplateId(asylumCase).contains(refundConfirmationOutOfCountryTemplateId));
     }
 
     @Test


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/RIA-9217

### Change description ###

- While testing OOC scenario on Preview, I realise I needed a new template to remove Home Office reference number from the header as this field is not present for AIP OOC cases. Have implemented this now.
- New functional test scenario for OOC added

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
