### PR TITLE
RIA-9460 bug_fix

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7030-reinstate-appeal-internal-notification-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7030-reinstate-appeal-internal-notification-after-listing.json
@@ -16,7 +16,8 @@
           "reinstateAppealDate": "{$TODAY}",
           "reinstateAppealReason": "Withdraw",
           "reinstatedDecisionMaker": "Admin Officer",
-          "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net"
+          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
+          "appellantsRepresentation": "No"
         }
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-7030-reinstate-appeal-internal-notification-before-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-7030-reinstate-appeal-internal-notification-before-listing.json
@@ -14,7 +14,8 @@
           "reinstateAppealDate": "{$TODAY}",
           "reinstateAppealReason": "Withdraw",
           "reinstatedDecisionMaker": "Admin Officer",
-          "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net"
+          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
+          "appellantsRepresentation": "No"
         }
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-7417_appeal_edited_ada_notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-7417_appeal_edited_ada_notification.json
@@ -17,7 +17,8 @@
           "ircName": "Brookhouse",
           "appellantInDetention": "Yes",
           "isAcceleratedDetainedAppeal": "Yes",
-          "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net",
+          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
+          "appellantsRepresentation": "No",
           "notificationAttachmentDocuments": [
             {
               "id": "1",

--- a/src/functionalTest/resources/scenarios/RIA-7428-internal-reinstate-appeal-det-notification-ada.json
+++ b/src/functionalTest/resources/scenarios/RIA-7428-internal-reinstate-appeal-det-notification-ada.json
@@ -18,7 +18,8 @@
           "ircName": "Brookhouse",
           "appellantInDetention": "Yes",
           "isAcceleratedDetainedAppeal": "Yes",
-          "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net",
+          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
+          "appellantsRepresentation": "No",
           "notificationAttachmentDocuments": [
             {
               "id": "1",

--- a/src/functionalTest/resources/scenarios/RIA-7691-internal-upload-addendum-evidence-admin-officer-det-notification-ada.json
+++ b/src/functionalTest/resources/scenarios/RIA-7691-internal-upload-addendum-evidence-admin-officer-det-notification-ada.json
@@ -17,7 +17,8 @@
           "isAcceleratedDetainedAppeal": "Yes",
           "appellantInDetention": "Yes",
           "isAppellantRespondent": "The appellant",
-          "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net",
+          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
+          "appellantsRepresentation": "No",
           "notificationAttachmentDocuments": [
             {
               "id": "1",

--- a/src/functionalTest/resources/scenarios/RIA-7693-internal-upload-addendum-evidence-admin-officer-det-notification-non-ada.json
+++ b/src/functionalTest/resources/scenarios/RIA-7693-internal-upload-addendum-evidence-admin-officer-det-notification-non-ada.json
@@ -17,7 +17,8 @@
           "isAcceleratedDetainedAppeal": "No",
           "appellantInDetention": "Yes",
           "isAppellantRespondent": "The appellant",
-          "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net",
+          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
+          "appellantsRepresentation": "No",
           "notificationAttachmentDocuments": [
             {
               "id": "1",

--- a/src/functionalTest/resources/scenarios/RIA-7707_appeal_edited_non-ada_notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-7707_appeal_edited_non-ada_notification.json
@@ -17,7 +17,8 @@
           "ircName": "Brookhouse",
           "appellantInDetention": "Yes",
           "isAcceleratedDetainedAppeal": "No",
-          "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net",
+          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
+          "appellantsRepresentation": "No",
           "notificationAttachmentDocuments": [
             {
               "id": "1",

--- a/src/functionalTest/resources/scenarios/RIA-7712-internal-reinstate-appeal-det-notification-non-ada.json
+++ b/src/functionalTest/resources/scenarios/RIA-7712-internal-reinstate-appeal-det-notification-non-ada.json
@@ -18,7 +18,8 @@
           "ircName": "Brookhouse",
           "appellantInDetention": "Yes",
           "isAcceleratedDetainedAppeal": "No",
-          "legalRepresentativeEmailAddress": "ia-law-firm-a@fake.hmcts.net",
+          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
+          "appellantsRepresentation": "No",
           "notificationAttachmentDocuments": [
             {
               "id": "1",

--- a/src/functionalTest/resources/scenarios/RIA-8338-internal-edit-appeal-post-submit-letter-notification-in-country.json
+++ b/src/functionalTest/resources/scenarios/RIA-8338-internal-edit-appeal-post-submit-letter-notification-in-country.json
@@ -12,7 +12,8 @@
         "replacements": {
           "currentCaseStateVisibleToHomeOfficeAll": "appealSubmitted",
           "isAdmin": "Yes",
-          "appellantsRepresentation": "Yes",
+          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
+          "appellantsRepresentation": "No",
           "appellantInDetention": "No",
           "appellantInUk": "Yes",
           "appellantHasFixedAddress": "Yes",

--- a/src/functionalTest/resources/scenarios/RIA-8338-internal-edit-appeal-post-submit-letter-notification-in-country.json
+++ b/src/functionalTest/resources/scenarios/RIA-8338-internal-edit-appeal-post-submit-letter-notification-in-country.json
@@ -12,8 +12,7 @@
         "replacements": {
           "currentCaseStateVisibleToHomeOfficeAll": "appealSubmitted",
           "isAdmin": "Yes",
-          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
-          "appellantsRepresentation": "No",
+          "appellantsRepresentation": "Yes",
           "appellantInDetention": "No",
           "appellantInUk": "Yes",
           "appellantHasFixedAddress": "Yes",
@@ -51,10 +50,6 @@
         "notificationsSent": [
           {
             "id": "8338_EDIT_APPEAL_AFTER_SUBMIT_RESPONDENT",
-            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
-          },
-          {
-            "id": "8338_EDIT_APPEAL_AFTER_SUBMIT_LEGAL_REPRESENTATIVE",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {

--- a/src/functionalTest/resources/scenarios/RIA-8338-internal-edit-appeal-post-submit-letter-notification-ooc.json
+++ b/src/functionalTest/resources/scenarios/RIA-8338-internal-edit-appeal-post-submit-letter-notification-ooc.json
@@ -12,8 +12,7 @@
         "replacements": {
           "currentCaseStateVisibleToHomeOfficeAll": "appealSubmitted",
           "isAdmin": "Yes",
-          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
-          "appellantsRepresentation": "No",
+          "appellantsRepresentation": "Yes",
           "appellantInDetention": "No",
           "appellantInUk": "No",
           "appellantHasFixedAddressAdminJ": "Yes",
@@ -43,10 +42,6 @@
         "notificationsSent": [
           {
             "id": "83382_EDIT_APPEAL_AFTER_SUBMIT_RESPONDENT",
-            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
-          },
-          {
-            "id": "83382_EDIT_APPEAL_AFTER_SUBMIT_LEGAL_REPRESENTATIVE",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {

--- a/src/functionalTest/resources/scenarios/RIA-8338-internal-edit-appeal-post-submit-letter-notification-ooc.json
+++ b/src/functionalTest/resources/scenarios/RIA-8338-internal-edit-appeal-post-submit-letter-notification-ooc.json
@@ -12,7 +12,8 @@
         "replacements": {
           "currentCaseStateVisibleToHomeOfficeAll": "appealSubmitted",
           "isAdmin": "Yes",
-          "appellantsRepresentation": "Yes",
+          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
+          "appellantsRepresentation": "No",
           "appellantInDetention": "No",
           "appellantInUk": "No",
           "appellantHasFixedAddressAdminJ": "Yes",

--- a/src/functionalTest/resources/scenarios/RIA-8339-internal-aip-reinstate-appeal-letter-notification-in-country.json
+++ b/src/functionalTest/resources/scenarios/RIA-8339-internal-aip-reinstate-appeal-letter-notification-in-country.json
@@ -11,8 +11,7 @@
         "template": "minimal-appeal-submitted.json",
         "replacements": {
           "isAdmin": "Yes",
-          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
-          "appellantsRepresentation": "No",
+          "appellantsRepresentation": "Yes",
           "appellantInDetention": "No",
           "stateBeforeEndAppeal": "appealSubmitted",
           "reinstateAppealDate": "{$TODAY}",
@@ -57,10 +56,6 @@
         "notificationsSent": [
           {
             "id": "8339_REINSTATE_APPEAL_HOME_OFFICE",
-            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
-          },
-          {
-            "id": "8339_REINSTATE_APPEAL_LEGAL_REP",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {

--- a/src/functionalTest/resources/scenarios/RIA-8339-internal-aip-reinstate-appeal-letter-notification-in-country.json
+++ b/src/functionalTest/resources/scenarios/RIA-8339-internal-aip-reinstate-appeal-letter-notification-in-country.json
@@ -11,7 +11,8 @@
         "template": "minimal-appeal-submitted.json",
         "replacements": {
           "isAdmin": "Yes",
-          "appellantsRepresentation": "Yes",
+          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
+          "appellantsRepresentation": "No",
           "appellantInDetention": "No",
           "stateBeforeEndAppeal": "appealSubmitted",
           "reinstateAppealDate": "{$TODAY}",

--- a/src/functionalTest/resources/scenarios/RIA-8339-internal-aip-reinstate-appeal-letter-notification-out-of-country.json
+++ b/src/functionalTest/resources/scenarios/RIA-8339-internal-aip-reinstate-appeal-letter-notification-out-of-country.json
@@ -11,7 +11,8 @@
         "template": "minimal-appeal-submitted.json",
         "replacements": {
           "isAdmin": "Yes",
-          "appellantsRepresentation": "Yes",
+          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
+          "appellantsRepresentation": "No",
           "appellantInDetention": "No",
           "stateBeforeEndAppeal": "appealSubmitted",
           "reinstateAppealDate": "{$TODAY}",

--- a/src/functionalTest/resources/scenarios/RIA-8339-internal-aip-reinstate-appeal-letter-notification-out-of-country.json
+++ b/src/functionalTest/resources/scenarios/RIA-8339-internal-aip-reinstate-appeal-letter-notification-out-of-country.json
@@ -11,8 +11,7 @@
         "template": "minimal-appeal-submitted.json",
         "replacements": {
           "isAdmin": "Yes",
-          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
-          "appellantsRepresentation": "No",
+          "appellantsRepresentation": "Yes",
           "appellantInDetention": "No",
           "stateBeforeEndAppeal": "appealSubmitted",
           "reinstateAppealDate": "{$TODAY}",
@@ -50,10 +49,6 @@
         "notificationsSent": [
           {
             "id": "8339_REINSTATE_APPEAL_HOME_OFFICE",
-            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
-          },
-          {
-            "id": "8339_REINSTATE_APPEAL_LEGAL_REP",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           },
           {

--- a/src/functionalTest/resources/scenarios/RIA-9187-non-standard-in-country-non-detained-send-direction-hearing-requirements-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-9187-non-standard-in-country-non-detained-send-direction-hearing-requirements-after-listing.json
@@ -13,6 +13,8 @@
           "isAdmin": "Yes",
           "appellantInUk": "Yes",
           "listCaseHearingCentre": "taylorHouse",
+          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
+          "appellantsRepresentation": "No",
           "ariaListingReference": "LP/12345/2019",
           "currentCaseStateVisibleToHomeOfficeAll": "preHearing",
           "directions": [

--- a/src/functionalTest/resources/scenarios/RIA-9187-non-standard-in-country-non-detained-send-direction-hearing-requirements-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-9187-non-standard-in-country-non-detained-send-direction-hearing-requirements-after-listing.json
@@ -12,8 +12,8 @@
         "replacements": {
           "isAdmin": "Yes",
           "appellantInUk": "Yes",
+          "legalRepEmail": "RIA-9187-test-case-1@example.com",
           "listCaseHearingCentre": "taylorHouse",
-          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
           "appellantsRepresentation": "No",
           "ariaListingReference": "LP/12345/2019",
           "currentCaseStateVisibleToHomeOfficeAll": "preHearing",
@@ -29,8 +29,7 @@
               }
             }
           ],
-          "notificationsSent": [],
-          "legalRepresentativeEmailAddress": "RIA-9187-test-case-1@example.com"
+          "notificationsSent": []
         }
       }
     }
@@ -65,8 +64,7 @@
             "id": "9187_LEGAL_REP_NON_STANDARD_DIRECTION",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
-        ],
-        "legalRepresentativeEmailAddress": "RIA-9187-test-case-1@example.com"
+        ]
       }
     },
     "notifications": [

--- a/src/functionalTest/resources/scenarios/RIA-9187-non-standard-out-of-country-send-direction-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-9187-non-standard-out-of-country-send-direction-after-listing.json
@@ -12,6 +12,8 @@
         "replacements": {
           "isAdmin": "Yes",
           "appellantInUk": "No",
+          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
+          "appellantsRepresentation": "No",
           "listCaseHearingCentre": "taylorHouse",
           "ariaListingReference": "LP/12345/2019",
           "currentCaseStateVisibleToHomeOfficeAll": "preHearing",

--- a/src/functionalTest/resources/scenarios/RIA-9187-non-standard-out-of-country-send-direction-after-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-9187-non-standard-out-of-country-send-direction-after-listing.json
@@ -12,7 +12,7 @@
         "replacements": {
           "isAdmin": "Yes",
           "appellantInUk": "No",
-          "legalRepEmail": "ia-law-firm-a@fake.hmcts.net",
+          "legalRepEmail": "RIA-9187-test-case-1@example.com",
           "appellantsRepresentation": "No",
           "listCaseHearingCentre": "taylorHouse",
           "ariaListingReference": "LP/12345/2019",
@@ -29,8 +29,7 @@
               }
             }
           ],
-          "notificationsSent": [],
-          "legalRepresentativeEmailAddress": "RIA-9187-test-case-1@example.com"
+          "notificationsSent": []
         }
       }
     }
@@ -65,8 +64,7 @@
             "id": "9187_LEGAL_REP_NON_STANDARD_DIRECTION",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
-        ],
-        "legalRepresentativeEmailAddress": "RIA-9187-test-case-1@example.com"
+        ]
       }
     },
     "notifications": [

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/utils/AsylumCaseUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/utils/AsylumCaseUtils.java
@@ -398,8 +398,13 @@ public class AsylumCaseUtils {
     }
 
     public static String getLegalRepEmailInternalOrLegalRepJourney(final AsylumCase asylumCase) {
-        return isInternalCase(asylumCase) && hasBeenSubmittedAsLegalRepresentedInternalCase(asylumCase) ? asylumCase.read(LEGAL_REP_EMAIL, String.class).orElseThrow(() -> new IllegalStateException("legalRepEmail is not present"))
-            : asylumCase.read(LEGAL_REPRESENTATIVE_EMAIL_ADDRESS, String.class).orElseThrow(() -> new IllegalStateException("legalRepresentativeEmailAddress is not present"));
+        if (isInternalCase(asylumCase) && hasBeenSubmittedAsLegalRepresentedInternalCase(asylumCase)) {
+            return asylumCase.read(LEGAL_REP_EMAIL, String.class).orElseThrow(() -> new IllegalStateException("legalRepEmail is not present"));
+        } else if (isInternalCase(asylumCase) && !hasBeenSubmittedAsLegalRepresentedInternalCase(asylumCase)) {
+            return StringUtils.EMPTY;
+        } else {
+            return asylumCase.read(LEGAL_REPRESENTATIVE_EMAIL_ADDRESS, String.class).orElseThrow(() -> new IllegalStateException("legalRepresentativeEmailAddress is not present"));
+        }
     }
 
     public static String getLegalRepEmailInternalOrLegalRepJourneyNonMandatory(final AsylumCase asylumCase) {

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/AsylumCaseUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/AsylumCaseUtilsTest.java
@@ -26,7 +26,6 @@ import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumC
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo.NO;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.ccd.field.YesOrNo.YES;
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.getLegalRepEmailInternalOrLegalRepJourney;
-import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.utils.AsylumCaseUtils.getLegalRepEmailInternalOrLegalRepJourneyNonMandatory;
 
 @ExtendWith(MockitoExtension.class)
 public class AsylumCaseUtilsTest {
@@ -59,17 +58,18 @@ public class AsylumCaseUtilsTest {
         lenient().when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(isAdmin));
         if (appellantsRepresentation.equals(NO) && isAdmin.equals(YES)) {
             when(asylumCase.read(LEGAL_REP_EMAIL, String.class)).thenReturn(Optional.of(legalRepEmail));
+            assertEquals(legalRepEmail, getLegalRepEmailInternalOrLegalRepJourney(asylumCase));
+        } else if (appellantsRepresentation.equals(YES) && isAdmin.equals(YES)) {
+            assertTrue(getLegalRepEmailInternalOrLegalRepJourney(asylumCase).isEmpty());
         } else {
             when(asylumCase.read(LEGAL_REPRESENTATIVE_EMAIL_ADDRESS, String.class)).thenReturn(Optional.of(legalRepEmail));
+            assertEquals(legalRepEmail, getLegalRepEmailInternalOrLegalRepJourney(asylumCase));
         }
-        assertEquals(legalRepEmail, getLegalRepEmailInternalOrLegalRepJourney(asylumCase));
-        assertEquals(legalRepEmail, getLegalRepEmailInternalOrLegalRepJourneyNonMandatory(asylumCase));
     }
 
     @ParameterizedTest
     @CsvSource({
         "YES, NO",
-        "YES, YES",
         "NO, NO",
         "NO, YES"
     })
@@ -82,7 +82,6 @@ public class AsylumCaseUtilsTest {
         );
         if (appellantsRepresentation.equals(NO) && isAdmin.equals(YES)) {
             assertEquals("legalRepEmail is not present", thrown.getMessage());
-
         } else {
             assertEquals("legalRepresentativeEmailAddress is not present", thrown.getMessage());
         }


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/RIA-9460

### Change description
When on ICC journey admin choosed that applicant will represent himself, then triggered submit and then editAppealAfterSubmit it throwed an error, because it could not retrieve any of existing LegalRep emails. Now in this particular situation when "It is internal journey and appellant represents himself we return empty string.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
