### PR TITLE
DIAC-835 Add timestamp to the sentNotifications

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/iacasenotificationsapi/util/MapFieldAssertor.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iacasenotificationsapi/util/MapFieldAssertor.java
@@ -77,6 +77,8 @@ public final class MapFieldAssertor {
 
             if ((expectedValue instanceof String) && (actualValue instanceof String)) {
 
+                String expectedValueString = (String) expectedValue;
+
                 if (isPathContainsNotificationsSentReference(path)) {
                     assertThat(
                             "Expected field matches (" + path + ")",
@@ -85,8 +87,6 @@ public final class MapFieldAssertor {
                     );
                     return;
                 }
-
-                String expectedValueString = (String) expectedValue;
 
                 if (expectedValueString.length() > 3
                     && expectedValueString.startsWith("$/")

--- a/src/functionalTest/java/uk/gov/hmcts/reform/iacasenotificationsapi/util/MapFieldAssertor.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iacasenotificationsapi/util/MapFieldAssertor.java
@@ -77,6 +77,15 @@ public final class MapFieldAssertor {
 
             if ((expectedValue instanceof String) && (actualValue instanceof String)) {
 
+                if (isPathContainsNotificationsSentReference(path)) {
+                    assertThat(
+                            "Expected field matches (" + path + ")",
+                            removeTimestampFromNotificationReference((String) actualValue),
+                            equalTo(expectedValue)
+                    );
+                    return;
+                }
+
                 String expectedValueString = (String) expectedValue;
 
                 if (expectedValueString.length() > 3
@@ -119,4 +128,17 @@ public final class MapFieldAssertor {
             );
         }
     }
+
+    private static boolean isPathContainsNotificationsSentReference(String path) {
+        // Regular expression to match the notificationsSent id format
+        String regex = ".*data\\.notificationsSent\\.\\d+\\.id.*";
+
+        // Check if the input matches the pattern
+        return path.matches(regex);
+    }
+
+    public static String removeTimestampFromNotificationReference(String input) {
+        return input.replaceAll("_(\\d{13})$", "");
+    }
+
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/iacasenotificationsapi/verifiers/NotificationVerifier.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iacasenotificationsapi/verifiers/NotificationVerifier.java
@@ -86,7 +86,7 @@ public class NotificationVerifier implements Verifier {
 
                     Notification notification = notificationClient.getNotificationById(deliveredNotificationId);
 
-                    final String actualReference = notification.getReference().orElse("");
+                    final String actualReference = sanitizeNotificationId(notification.getReference().orElse(""));
                     final String actualRecipient =
                         notification.getEmailAddress().orElse(notification.getPhoneNumber().orElse(""));
                     final String actualSubject = notification.getSubject().orElse("");

--- a/src/functionalTest/java/uk/gov/hmcts/reform/iacasenotificationsapi/verifiers/NotificationVerifier.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iacasenotificationsapi/verifiers/NotificationVerifier.java
@@ -6,7 +6,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.google.common.base.Strings;
+
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -40,8 +43,10 @@ public class NotificationVerifier implements Verifier {
             return;
         }
 
-        List<Map<String, Object>> notificationsSent =
+        List<Map<String, Object>> notificationsSentWithTimestamp =
             MapValueExtractor.extractOrDefault(actualResponse, "data.notificationsSent", Collections.emptyList());
+        List<Map<String, Object>> notificationsSent = new ArrayList<>();
+        sanitizeNotifications(notificationsSentWithTimestamp, notificationsSent);
 
         if (notificationsSent.isEmpty()) {
             assertFalse(
@@ -147,5 +152,19 @@ public class NotificationVerifier implements Verifier {
                     );
                 }
             });
+    }
+
+    private static void sanitizeNotifications(List<Map<String, Object>> notificationsSentWithTimestamp, List<Map<String, Object>> notificationsSent) {
+        for (Map<String, Object> notificationSent : notificationsSentWithTimestamp) {
+            for (Map.Entry<String, Object> entrySet : notificationSent.entrySet()) {
+                String key = entrySet.getKey();
+                int lastIndexOf = key.lastIndexOf("_");
+                Map<String, Object> newEntry = new HashMap<>();
+                newEntry.put(
+                        lastIndexOf != -1 ? entrySet.getKey().substring(0, lastIndexOf - 1) : entrySet.getKey(),
+                        entrySet.getValue());
+                notificationsSent.add(newEntry);
+            }
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/NotificationIdAppender.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/NotificationIdAppender.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.iacasenotificationsapi.domain.service;
 
 import static uk.gov.hmcts.reform.iacasenotificationsapi.domain.entities.AsylumCaseDefinition.NOTIFICATIONS_SENT;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -32,19 +33,19 @@ public class NotificationIdAppender {
 
     public List<IdValue<String>> append(
         List<IdValue<String>> existingNotificationsSent,
-        String notificationReference,
+        String referenceId,
         String notificationId
     ) {
         long numberOfExistingNotificationsOfSameKind =
             existingNotificationsSent
                 .stream()
                 .map(IdValue::getId)
-                .filter(existingNotificationReference -> existingNotificationReference.startsWith(notificationReference))
+                .filter(existingNotificationReference -> existingNotificationReference.startsWith(referenceId))
                 .count();
-
+        long timestamp = Instant.now().toEpochMilli();
         String qualifiedNotificationReference = numberOfExistingNotificationsOfSameKind > 0
             ?
-            (notificationReference + "_" + UUID.randomUUID().toString()) : notificationReference;
+            (referenceId + "_" + UUID.randomUUID().toString() + "_" + timestamp) : referenceId + "_" + timestamp;
 
         final List<IdValue<String>> newNotificationsSent = new ArrayList<>(existingNotificationsSent);
 

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/NotificationIdAppender.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/NotificationIdAppender.java
@@ -33,19 +33,19 @@ public class NotificationIdAppender {
 
     public List<IdValue<String>> append(
         List<IdValue<String>> existingNotificationsSent,
-        String referenceId,
+        String notificationReference,
         String notificationId
     ) {
         long numberOfExistingNotificationsOfSameKind =
             existingNotificationsSent
                 .stream()
                 .map(IdValue::getId)
-                .filter(existingNotificationReference -> existingNotificationReference.startsWith(referenceId))
+                .filter(existingNotificationReference -> existingNotificationReference.startsWith(notificationReference))
                 .count();
         long timestamp = Instant.now().toEpochMilli();
         String qualifiedNotificationReference = numberOfExistingNotificationsOfSameKind > 0
             ?
-            (referenceId + "_" + UUID.randomUUID().toString() + "_" + timestamp) : referenceId + "_" + timestamp;
+            (notificationReference + "_" + UUID.randomUUID().toString() + "_" + timestamp) : notificationReference + "_" + timestamp;
 
         final List<IdValue<String>> newNotificationsSent = new ArrayList<>(existingNotificationsSent);
 

--- a/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/NotificationIdAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasenotificationsapi/domain/service/NotificationIdAppenderTest.java
@@ -27,6 +27,7 @@ public class NotificationIdAppenderTest {
 
     @Test
     public void should_append_first_notification_without_qualifier() {
+        final String timestampRegex = "([0-9]{13})";
 
         List<IdValue<String>> actualNotificationsSent =
             notificationIdAppender.append(
@@ -39,14 +40,17 @@ public class NotificationIdAppenderTest {
         assertEquals(existingNotification1, actualNotificationsSent.get(0));
         assertEquals(existingNotification2, actualNotificationsSent.get(1));
 
-        assertEquals("something", actualNotificationsSent.get(2).getId());
+        assertThat(actualNotificationsSent.get(2).getId()).startsWith("something_");
+        assertThat(actualNotificationsSent.get(2).getId()
+                .substring("something_".length()))
+                .matches(timestampRegex);
         assertEquals("555-666", actualNotificationsSent.get(2).getValue());
     }
 
     @Test
     public void should_append_subsequent_notifications_with_qualifiers() {
 
-        final String uuidRegex = "([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}){1}";
+        final String uuidRegex = "([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}_[0-9]{13})";
 
         List<IdValue<String>> actualNotificationsSent1 =
             notificationIdAppender.append(


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DIAC-835

### Change description
Add timestamp to the sentNotifictaions data to filter downloadable notifications in saveNotificationsData event.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
