### PR TITLE
DIAC-1356 FTPA disposed of under rules 31 or 32 - Detained (in Other) notification

### DIFF
--- a/src/functionalTest/resources/scenarios/DIAC-1356-internal-case-disposed-under-rule-31-in-detained-in-other.json
+++ b/src/functionalTest/resources/scenarios/DIAC-1356-internal-case-disposed-under-rule-31-in-detained-in-other.json
@@ -13,7 +13,7 @@
           "isAdmin": "Yes",
           "appellantsRepresentation": "Yes",
           "appellantInDetention": "Yes",
-          "detentionFacility": "Other",
+          "detentionFacility": "other",
           "appellantInUk": "Yes",
           "appellantAddress": {
             "County": "",
@@ -41,7 +41,7 @@
         "isAdmin": "Yes",
         "appellantsRepresentation": "Yes",
         "appellantInDetention": "Yes",
-        "detentionFacility": "Other",
+        "detentionFacility": "other",
         "appellantInUk": "Yes",
         "appellantAddress": {
           "County": "",

--- a/src/functionalTest/resources/scenarios/DIAC-1356-internal-case-disposed-under-rule-31-in-detained-in-other.json
+++ b/src/functionalTest/resources/scenarios/DIAC-1356-internal-case-disposed-under-rule-31-in-detained-in-other.json
@@ -1,0 +1,68 @@
+{
+  "description": "DIAC-1356 internal case disposed under rule 31 detained in other letter",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 1356,
+      "eventId": "decideFtpaApplication",
+      "state": "*",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "isAdmin": "Yes",
+          "appellantsRepresentation": "Yes",
+          "appellantInDetention": "Yes",
+          "detentionFacility": "Other",
+          "appellantInUk": "Yes",
+          "appellantAddress": {
+            "County": "",
+            "Country": "United Kingdom",
+            "PostCode": "NE21JX",
+            "PostTown": "Example Town",
+            "AddressLine1": "5",
+            "AddressLine2": "Example Street"
+          },
+          "ftpaApplicantType": "appellant",
+          "ftpaAppellantSubmitted": "Yes",
+          "ftpaAppellantRjDecisionOutcomeType": "remadeRule31",
+          "ftpaAppellantDecisionRemadeRule32Text": "Rule 31 decision text",
+          "ccdReferenceNumberForDisplay": "1111222233334444"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "appellantsRepresentation": "Yes",
+        "appellantInDetention": "Yes",
+        "detentionFacility": "Other",
+        "appellantInUk": "Yes",
+        "appellantAddress": {
+          "County": "",
+          "Country": "United Kingdom",
+          "PostCode": "NE21JX",
+          "PostTown": "Example Town",
+          "AddressLine1": "5",
+          "AddressLine2": "Example Street"
+        },
+        "ftpaApplicantType": "appellant",
+        "ftpaAppellantSubmitted": "Yes",
+        "ftpaAppellantRjDecisionOutcomeType": "remadeRule31",
+        "ftpaAppellantDecisionRemadeRule32Text": "Rule 31 decision text",
+        "ccdReferenceNumberForDisplay": "1111222233334444",
+        "notificationsSent": [
+          {
+            "id": "1356_INTERNAL_CASE_DISPOSE_UNDER_RULE_31_OR_32_APPELLANT_LETTER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/DIAC-1356-internal-case-disposed-under-rule-32-detained-in-other-letter.json
+++ b/src/functionalTest/resources/scenarios/DIAC-1356-internal-case-disposed-under-rule-32-detained-in-other-letter.json
@@ -13,7 +13,7 @@
           "isAdmin": "Yes",
           "appellantsRepresentation": "Yes",
           "appellantInDetention": "Yes",
-          "detentionFacility": "Other",
+          "detentionFacility": "other",
           "appellantInUk": "Yes",
           "appellantAddress": {
             "County": "",
@@ -41,7 +41,7 @@
         "isAdmin": "Yes",
         "appellantsRepresentation": "Yes",
         "appellantInDetention": "Yes",
-        "detentionFacility": "Other",
+        "detentionFacility": "other",
         "appellantInUk": "Yes",
         "appellantAddress": {
           "County": "",

--- a/src/functionalTest/resources/scenarios/DIAC-1356-internal-case-disposed-under-rule-32-detained-in-other-letter.json
+++ b/src/functionalTest/resources/scenarios/DIAC-1356-internal-case-disposed-under-rule-32-detained-in-other-letter.json
@@ -1,0 +1,68 @@
+{
+  "description": "DIAC-1356 internal case disposed under rule 32 detained in other letter",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 1356,
+      "eventId": "decideFtpaApplication",
+      "state": "*",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "isAdmin": "Yes",
+          "appellantsRepresentation": "Yes",
+          "appellantInDetention": "Yes",
+          "detentionFacility": "Other",
+          "appellantInUk": "Yes",
+          "appellantAddress": {
+            "County": "",
+            "Country": "United Kingdom",
+            "PostCode": "NE21JX",
+            "PostTown": "Example Town",
+            "AddressLine1": "5",
+            "AddressLine2": "Example Street"
+          },
+          "ftpaApplicantType": "appellant",
+          "ftpaAppellantSubmitted": "Yes",
+          "ftpaAppellantRjDecisionOutcomeType": "remadeRule32",
+          "ftpaAppellantDecisionRemadeRule32Text": "Rule 32 decision text",
+          "ccdReferenceNumberForDisplay": "1111222233334444"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "appellantsRepresentation": "Yes",
+        "appellantInDetention": "Yes",
+        "detentionFacility": "Other",
+        "appellantInUk": "Yes",
+        "appellantAddress": {
+          "County": "",
+          "Country": "United Kingdom",
+          "PostCode": "NE21JX",
+          "PostTown": "Example Town",
+          "AddressLine1": "5",
+          "AddressLine2": "Example Street"
+        },
+        "ftpaApplicantType": "appellant",
+        "ftpaAppellantSubmitted": "Yes",
+        "ftpaAppellantRjDecisionOutcomeType": "remadeRule32",
+        "ftpaAppellantDecisionRemadeRule32Text": "Rule 32 decision text",
+        "ccdReferenceNumberForDisplay": "1111222233334444",
+        "notificationsSent": [
+          {
+            "id": "1356_INTERNAL_CASE_DISPOSE_UNDER_RULE_31_OR_32_APPELLANT_LETTER",
+            "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationGeneratorConfiguration.java
@@ -6188,8 +6188,8 @@ public class NotificationGeneratorConfiguration {
         );
     }
 
-    @Bean("internalCaseDisposeUnderRule31Or32AppelantLetterGenerator")
-    public List<NotificationGenerator> internalCaseDisposeUnderRule31Or32AppelantLetterGenerator(
+    @Bean("internalCaseDisposeUnderRule31Or32AppellantLetterGenerator")
+    public List<NotificationGenerator> internalCaseDisposeUnderRule31Or32AppellantLetterGenerator(
         AppellantInternalCaseDisposeUnderRule31Or32Personalisation appellantInternalCaseDisposeUnderRule31Or32Personalisation,
         GovNotifyNotificationSender notificationSender,
         NotificationIdAppender notificationIdAppender

--- a/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasenotificationsapi/infrastructure/config/NotificationHandlerConfiguration.java
@@ -6512,8 +6512,8 @@ public class NotificationHandlerConfiguration {
     }
 
     @Bean
-    public PreSubmitCallbackHandler<AsylumCase> internalCaseDisposeUnderRule31Or32AppelantLetterHandler(
-        @Qualifier("internalCaseDisposeUnderRule31Or32AppelantLetterGenerator")
+    public PreSubmitCallbackHandler<AsylumCase> internalCaseDisposeUnderRule31Or32AppellantLetterHandler(
+        @Qualifier("internalCaseDisposeUnderRule31Or32AppellantLetterGenerator")
         List<NotificationGenerator> notificationGenerators) {
 
         return new NotificationHandler(
@@ -6523,7 +6523,7 @@ public class NotificationHandlerConfiguration {
                 return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                     && callback.getEvent() == Event.DECIDE_FTPA_APPLICATION
                     && isInternalCase(asylumCase)
-                    && !isAppellantInDetention(asylumCase)
+                    && (!isAppellantInDetention(asylumCase) || isDetainedInFacilityType(asylumCase, OTHER))
                     && isFtpaDecisionOutcomeTypeUnderRule31OrRule32(asylumCase);
             },
             notificationGenerators,


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DIAC-1356

FTPA disposed of under rules 31 or 32 - Detained (in Other) notification

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
